### PR TITLE
Improve CI/CD workflows with best practices

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,78 @@
+# Terraform Provider documentation generation workflow
+# Uses hashicorp/terraform-plugin-docs to generate provider documentation
+name: Documentation
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'internal/**'
+      - 'docs/**'
+      - 'examples/**'
+      - 'templates/**'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'internal/**'
+      - 'docs/**'
+      - 'examples/**'
+      - 'templates/**'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  generate-docs:
+    name: Generate Provider Docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+
+      - name: Install tfplugindocs
+        run: |
+          go install github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs@latest
+          echo "$HOME/go/bin" >> $GITHUB_PATH
+
+      - name: Generate documentation
+        run: |
+          tfplugindocs generate
+
+      - name: Check for changes
+        id: changes
+        run: |
+          if [ -n "$(git status --porcelain docs/)" ]; then
+            echo "changed=true" >> $GITHUB_OUTPUT
+          else
+            echo "changed=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Commit and push documentation changes
+        if: steps.changes.outputs.changed == 'true' && github.event_name == 'push'
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          git add docs/
+          git commit -m "docs: auto-generate provider documentation
+
+          🤖 Generated with terraform-plugin-docs"
+          git push
+
+      - name: Fail if docs are out of date on PR
+        if: steps.changes.outputs.changed == 'true' && github.event_name == 'pull_request'
+        run: |
+          echo "::error::Provider documentation is out of date. Please run 'go generate ./...' or 'tfplugindocs generate' locally and commit the changes."
+          git diff docs/
+          exit 1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,58 @@
+# Go linting workflow for Terraform Provider
+# Uses golangci-lint for comprehensive Go code analysis
+name: Lint
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  golangci-lint:
+    name: golangci-lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: latest
+          args: --timeout=5m
+
+  go-test:
+    name: Go Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+
+      - name: Run go mod tidy
+        run: |
+          go mod tidy
+          git diff --exit-code go.mod go.sum
+
+      - name: Run go build
+        run: go build -v ./...
+
+      - name: Run go test
+        run: go test -v -race ./internal/...

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,40 +1,21 @@
+# Terraform Provider release workflow using HashiCorp's reusable workflow
+# See: https://github.com/hashicorp/ghaction-terraform-provider-release
 name: Release
 
 on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
 
 permissions:
   contents: write
 
 jobs:
-  goreleaser:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: 'go.mod'
-          cache: true
-
-      - name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@v6
-        id: import_gpg
-        with:
-          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
-          passphrase: ${{ secrets.PASSPHRASE }}
-
-      - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
-        with:
-          version: latest
-          args: release --clean
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
+  terraform-provider-release:
+    name: 'Terraform Provider Release'
+    uses: hashicorp/ghaction-terraform-provider-release/.github/workflows/community.yml@v4
+    secrets:
+      gpg-private-key: '${{ secrets.GPG_PRIVATE_KEY }}'
+    with:
+      setup-go-version-file: 'go.mod'


### PR DESCRIPTION
## Summary
- Update release workflow to use HashiCorp's official reusable workflow
- Add comprehensive linting workflow with golangci-lint
- Add documentation generation workflow with terraform-plugin-docs

## Changes

### Release Workflow (release.yml)
- Replaced custom GoReleaser workflow with HashiCorp's recommended `hashicorp/ghaction-terraform-provider-release/.github/workflows/community.yml@v4`
- This ensures better registry compatibility and follows HashiCorp's best practices for community providers

### Linting Workflow (lint.yml)
- Added `golangci-lint` for comprehensive Go code analysis
- Added `go test` with race detection for the internal packages
- Added `go mod tidy` check to ensure dependencies are clean
- Runs on push to main and on pull requests

### Documentation Workflow (docs.yml)
- Uses `hashicorp/terraform-plugin-docs` (tfplugindocs) for provider documentation
- Auto-generates documentation on push to main
- Fails PR if documentation is out of date (prompts contributor to regenerate)
- Triggers on changes to internal/, docs/, examples/, or templates/

## Test plan
- [x] Workflow YAML files are valid
- [ ] Release workflow triggers on version tags
- [ ] Lint workflow runs on PR
- [ ] Docs workflow generates documentation

## References
- [HashiCorp Provider Release Action](https://github.com/hashicorp/ghaction-terraform-provider-release)
- [golangci-lint Action](https://github.com/golangci/golangci-lint-action)
- [terraform-plugin-docs](https://github.com/hashicorp/terraform-plugin-docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)