### PR TITLE
fix: trigger lint workflow on automated branches

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,8 @@ on:
   push:
     branches:
       - main
+      - openapi-update
+      - auto-generate/**
   pull_request:
     branches:
       - main


### PR DESCRIPTION
## Summary
Add openapi-update and auto-generate/** branches to lint workflow triggers to enable CI checks on PRs created by automation workflows.

## Problem
PRs created by the sync-openapi and generate workflows were unable to pass required status checks because the lint workflow only triggered on main branch pushes and pull_requests.

## Solution
Added branch patterns to the push trigger:
- `openapi-update` - for OpenAPI spec sync PRs
- `auto-generate/**` - for provider generation PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)