### PR TITLE
feat: Auto-generate API docs from OpenAPI specs

### DIFF
--- a/.github/workflows/sync-openapi.yml
+++ b/.github/workflows/sync-openapi.yml
@@ -112,6 +112,13 @@ jobs:
           go run tools/generate-all-schemas.go --spec-dir=${{ env.SPEC_DIR }}
           echo "✅ Provider code regenerated"
 
+      - name: Regenerate API documentation
+        if: steps.existing_pr.outputs.result == 'false' && steps.spec_changes.outputs.changed == 'true'
+        run: |
+          echo "📚 Regenerating API documentation..."
+          go run tools/generate-api-docs.go --spec-dir=${{ env.SPEC_DIR }}
+          echo "✅ API documentation regenerated"
+
       - name: Run go mod tidy
         if: steps.existing_pr.outputs.result == 'false' && steps.spec_changes.outputs.changed == 'true'
         run: go mod tidy

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,8 +1,1431 @@
+---
+page_title: "API Reference"
+description: "Interactive F5 Distributed Cloud API documentation with Try it out functionality"
+---
+
 # API Reference
 
 Explore the F5 Distributed Cloud API documentation with interactive "Try it out" functionality.
 
-## Namespace API
+!!! tip "Usage"
+    Expand any API section below to view the interactive Swagger UI documentation.
+    Use the "Try it out" button to test API calls directly.
 
-<swagger-ui src="specifications/api/docs-cloud-f5-com.0129.public.ves.io.schema.namespace.ves-swagger.json"/>
+## API Credential
 
+### API Credential
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0007.public.ves.io.schema.api_credential.ves-swagger.json"/>
+
+## API Group
+
+### API Group
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0004.public.ves.io.schema.api_group.ves-swagger.json"/>
+
+## API Group Element
+
+### API Group Element
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0005.public.ves.io.schema.api_group_element.ves-swagger.json"/>
+
+## API Sec
+
+### API Crawler
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0001.public.ves.io.schema.api_sec.api_crawler.ves-swagger.json"/>
+
+### API Discovery
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0003.public.ves.io.schema.api_sec.api_discovery.ves-swagger.json"/>
+
+### API Testing
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0006.public.ves.io.schema.api_sec.api_testing.ves-swagger.json"/>
+
+### Code Base Integration
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0064.public.ves.io.schema.api_sec.code_base_integration.ves-swagger.json"/>
+
+### Rule Suggestion
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0021.public.ves.io.schema.api_sec.rule_suggestion.ves-swagger.json"/>
+
+## Address Allocator
+
+### Address Allocator
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0010.public.ves.io.schema.address_allocator.ves-swagger.json"/>
+
+## Advertise Policy
+
+### Advertise Policy
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0011.public.ves.io.schema.advertise_policy.ves-swagger.json"/>
+
+## Ai Assistant
+
+### Ai Assistant
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0000.public.ves.io.schema.ai_assistant.ves-swagger.json"/>
+
+## Ai Data
+
+### Bfdp
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0024.public.ves.io.schema.ai_data.bfdp.ves-swagger.json"/>
+
+### Bfdp Subscription
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0025.public.ves.io.schema.ai_data.bfdp.subscription.ves-swagger.json"/>
+
+## Alert
+
+### Alert
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0014.public.ves.io.schema.alert.ves-swagger.json"/>
+
+## Alert Policy
+
+### Alert Policy
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0012.public.ves.io.schema.alert_policy.ves-swagger.json"/>
+
+## Alert Receiver
+
+### Alert Receiver
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0013.public.ves.io.schema.alert_receiver.ves-swagger.json"/>
+
+## App Firewall
+
+### App Firewall
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0019.public.ves.io.schema.app_firewall.ves-swagger.json"/>
+
+## App Security
+
+### App Security
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0020.public.ves.io.schema.app_security.ves-swagger.json"/>
+
+## App Setting
+
+### App Setting
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0017.public.ves.io.schema.app_setting.ves-swagger.json"/>
+
+## App Type
+
+### App Type
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0018.public.ves.io.schema.app_type.ves-swagger.json"/>
+
+## Authentication
+
+### Authentication
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0023.public.ves.io.schema.authentication.ves-swagger.json"/>
+
+## BGP
+
+### BGP
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0026.public.ves.io.schema.bgp.ves-swagger.json"/>
+
+## BGP ASN Set
+
+### BGP ASN Set
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0027.public.ves.io.schema.bgp_asn_set.ves-swagger.json"/>
+
+## BGP Routing Policy
+
+### BGP Routing Policy
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0029.public.ves.io.schema.bgp_routing_policy.ves-swagger.json"/>
+
+## Bigcne
+
+### Data Group
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0094.public.ves.io.schema.bigcne.data_group.ves-swagger.json"/>
+
+### Irule
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0080.public.ves.io.schema.bigcne.irule.ves-swagger.json"/>
+
+## Bigip
+
+### Apm
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0030.public.ves.io.schema.bigip.apm.ves-swagger.json"/>
+
+## Bigip Irule
+
+### Bigip Irule
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0031.public.ves.io.schema.bigip_irule.ves-swagger.json"/>
+
+## Billing
+
+### Payment Method
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0178.public.ves.io.schema.billing.payment_method.ves-swagger.json"/>
+
+### Plan Transition
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0181.public.ves.io.schema.billing.plan_transition.ves-swagger.json"/>
+
+## CDN Cache Rule
+
+### CDN Cache Rule
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0043.public.ves.io.schema.cdn_cache_rule.ves-swagger.json"/>
+
+## CRL
+
+### CRL
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0044.public.ves.io.schema.crl.ves-swagger.json"/>
+
+## Certificate
+
+### Certificate
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0048.public.ves.io.schema.certificate.ves-swagger.json"/>
+
+## Certificate Chain
+
+### Certificate Chain
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0049.public.ves.io.schema.certificate_chain.ves-swagger.json"/>
+
+## Certified Hardware
+
+### Certified Hardware
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0050.public.ves.io.schema.certified_hardware.ves-swagger.json"/>
+
+## Cloud Connect
+
+### Cloud Connect
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0058.public.ves.io.schema.cloud_connect.ves-swagger.json"/>
+
+## Cloud Credentials
+
+### Cloud Credentials
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0059.public.ves.io.schema.cloud_credentials.ves-swagger.json"/>
+
+## Cloud Elastic IP
+
+### Cloud Elastic IP
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0060.public.ves.io.schema.cloud_elastic_ip.ves-swagger.json"/>
+
+## Cloud Link
+
+### Cloud Link
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0062.public.ves.io.schema.cloud_link.ves-swagger.json"/>
+
+## Cloud Region
+
+### Cloud Region
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0061.public.ves.io.schema.cloud_region.ves-swagger.json"/>
+
+## Cluster
+
+### Cluster
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0063.public.ves.io.schema.cluster.ves-swagger.json"/>
+
+## Cminstance
+
+### Cminstance
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0047.public.ves.io.schema.cminstance.ves-swagger.json"/>
+
+## Contact
+
+### Contact
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0082.public.ves.io.schema.contact.ves-swagger.json"/>
+
+## Container Registry
+
+### Container Registry
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0083.public.ves.io.schema.container_registry.ves-swagger.json"/>
+
+## Customer Support
+
+### Customer Support
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0084.public.ves.io.schema.customer_support.ves-swagger.json"/>
+
+## DNS Compliance Checks
+
+### DNS Compliance Checks
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0069.public.ves.io.schema.dns_compliance_checks.ves-swagger.json"/>
+
+## DNS Domain
+
+### DNS Domain
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0086.public.ves.io.schema.dns_domain.ves-swagger.json"/>
+
+## DNS LB Health Check
+
+### DNS LB Health Check
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0088.public.ves.io.schema.dns_lb_health_check.ves-swagger.json"/>
+
+## DNS LB Pool
+
+### DNS LB Pool
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0089.public.ves.io.schema.dns_lb_pool.ves-swagger.json"/>
+
+## DNS Load Balancer
+
+### DNS Load Balancer
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0087.public.ves.io.schema.dns_load_balancer.ves-swagger.json"/>
+
+## DNS Zone
+
+### DNS Zone
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0091.public.ves.io.schema.dns_zone.ves-swagger.json"/>
+
+### DNS Zone Subscription
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0106.public.ves.io.schema.dns_zone.subscription.ves-swagger.json"/>
+
+### Rrset
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0105.public.ves.io.schema.dns_zone.rrset.ves-swagger.json"/>
+
+## Data Privacy
+
+### Geo Config
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0119.public.ves.io.schema.data_privacy.geo_config.ves-swagger.json"/>
+
+### Lma Region
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0148.public.ves.io.schema.data_privacy.lma_region.ves-swagger.json"/>
+
+## Data Type
+
+### Data Type
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0096.public.ves.io.schema.data_type.ves-swagger.json"/>
+
+## Dc Cluster Group
+
+### Dc Cluster Group
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0085.public.ves.io.schema.dc_cluster_group.ves-swagger.json"/>
+
+## Discovered Service
+
+### Discovered Service
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0100.public.ves.io.schema.discovered_service.ves-swagger.json"/>
+
+## Discovery
+
+### Discovery
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0101.public.ves.io.schema.discovery.ves-swagger.json"/>
+
+## Endpoint
+
+### Endpoint
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0102.public.ves.io.schema.endpoint.ves-swagger.json"/>
+
+## Enhanced Firewall Policy
+
+### Enhanced Firewall Policy
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0103.public.ves.io.schema.enhanced_firewall_policy.ves-swagger.json"/>
+
+## Fast ACL
+
+### Fast ACL
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0111.public.ves.io.schema.fast_acl.ves-swagger.json"/>
+
+## Fast ACL Rule
+
+### Fast ACL Rule
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0112.public.ves.io.schema.fast_acl_rule.ves-swagger.json"/>
+
+## Filter Set
+
+### Filter Set
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0113.public.ves.io.schema.filter_set.ves-swagger.json"/>
+
+## Fleet
+
+### Fleet
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0114.public.ves.io.schema.fleet.ves-swagger.json"/>
+
+## Flow
+
+### Flow
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0117.public.ves.io.schema.flow.ves-swagger.json"/>
+
+## Flow Anomaly
+
+### Flow Anomaly
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0115.public.ves.io.schema.flow_anomaly.ves-swagger.json"/>
+
+## Forwarding Class
+
+### Forwarding Class
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0118.public.ves.io.schema.forwarding_class.ves-swagger.json"/>
+
+## Geo Location Set
+
+### Geo Location Set
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0120.public.ves.io.schema.geo_location_set.ves-swagger.json"/>
+
+## Gia
+
+### Gia
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0121.public.ves.io.schema.gia.ves-swagger.json"/>
+
+## Global Log Receiver
+
+### Global Log Receiver
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0122.public.ves.io.schema.global_log_receiver.ves-swagger.json"/>
+
+## Graph
+
+### Connectivity
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0081.public.ves.io.schema.graph.connectivity.ves-swagger.json"/>
+
+### L3l4
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0270.public.ves.io.schema.graph.l3l4.ves-swagger.json"/>
+
+### Service
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0207.public.ves.io.schema.graph.service.ves-swagger.json"/>
+
+### Site
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0219.public.ves.io.schema.graph.site.ves-swagger.json"/>
+
+## Healthcheck
+
+### Healthcheck
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0124.public.ves.io.schema.healthcheck.ves-swagger.json"/>
+
+## IP Prefix Set
+
+### IP Prefix Set
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0129.public.ves.io.schema.ip_prefix_set.ves-swagger.json"/>
+
+## Ike1
+
+### Ike1
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0125.public.ves.io.schema.ike1.ves-swagger.json"/>
+
+## Ike2
+
+### Ike2
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0127.public.ves.io.schema.ike2.ves-swagger.json"/>
+
+## Implicit Label
+
+### Implicit Label
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0130.public.ves.io.schema.implicit_label.ves-swagger.json"/>
+
+## Infraprotect
+
+### Infraprotect
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0131.public.ves.io.schema.infraprotect.ves-swagger.json"/>
+
+## Infraprotect ASN
+
+### Infraprotect ASN
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0132.public.ves.io.schema.infraprotect_asn.ves-swagger.json"/>
+
+## Infraprotect ASN Prefix
+
+### Infraprotect ASN Prefix
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0133.public.ves.io.schema.infraprotect_asn_prefix.ves-swagger.json"/>
+
+## Infraprotect Deny List Rule
+
+### Infraprotect Deny List Rule
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0134.public.ves.io.schema.infraprotect_deny_list_rule.ves-swagger.json"/>
+
+## Infraprotect Firewall Rule
+
+### Infraprotect Firewall Rule
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0135.public.ves.io.schema.infraprotect_firewall_rule.ves-swagger.json"/>
+
+## Infraprotect Firewall Rule Group
+
+### Infraprotect Firewall Rule Group
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0136.public.ves.io.schema.infraprotect_firewall_rule_group.ves-swagger.json"/>
+
+## Infraprotect Firewall Ruleset
+
+### Infraprotect Firewall Ruleset
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0137.public.ves.io.schema.infraprotect_firewall_ruleset.ves-swagger.json"/>
+
+## Infraprotect Information
+
+### Infraprotect Information
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0138.public.ves.io.schema.infraprotect_information.ves-swagger.json"/>
+
+## Infraprotect Internet Prefix Advertisement
+
+### Infraprotect Internet Prefix Advertisement
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0139.public.ves.io.schema.infraprotect_internet_prefix_advertisement.ves-swagger.json"/>
+
+## Infraprotect Tunnel
+
+### Infraprotect Tunnel
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0243.public.ves.io.schema.infraprotect_tunnel.ves-swagger.json"/>
+
+## K8s Cluster
+
+### K8s Cluster
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0141.public.ves.io.schema.k8s_cluster.ves-swagger.json"/>
+
+## K8s Cluster Role
+
+### K8s Cluster Role
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0142.public.ves.io.schema.k8s_cluster_role.ves-swagger.json"/>
+
+## K8s Cluster Role Binding
+
+### K8s Cluster Role Binding
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0143.public.ves.io.schema.k8s_cluster_role_binding.ves-swagger.json"/>
+
+## K8s Pod Security Admission
+
+### K8s Pod Security Admission
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0144.public.ves.io.schema.k8s_pod_security_admission.ves-swagger.json"/>
+
+## K8s Pod Security Policy
+
+### K8s Pod Security Policy
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0145.public.ves.io.schema.k8s_pod_security_policy.ves-swagger.json"/>
+
+## Known Label
+
+### Known Label
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0146.public.ves.io.schema.known_label.ves-swagger.json"/>
+
+## Known Label Key
+
+### Known Label Key
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0147.public.ves.io.schema.known_label_key.ves-swagger.json"/>
+
+## Log
+
+### Log
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0151.public.ves.io.schema.log.ves-swagger.json"/>
+
+## Log Receiver
+
+### Log Receiver
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0150.public.ves.io.schema.log_receiver.ves-swagger.json"/>
+
+## Maintenance Status
+
+### Maintenance Status
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0110.public.ves.io.schema.maintenance_status.ves-swagger.json"/>
+
+## Malicious User Mitigation
+
+### Malicious User Mitigation
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0152.public.ves.io.schema.malicious_user_mitigation.ves-swagger.json"/>
+
+## Malware Protection
+
+### Malware Protection Subscription
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0107.public.ves.io.schema.malware_protection.subscription.ves-swagger.json"/>
+
+## Marketplace
+
+### AWS Account
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0176.public.ves.io.schema.marketplace.aws_account.ves-swagger.json"/>
+
+### Xc Saas
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0269.public.ves.io.schema.marketplace.xc_saas.ves-swagger.json"/>
+
+## Module Management
+
+### Module Management
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0158.public.ves.io.schema.module_management.ves-swagger.json"/>
+
+## NAT Policy
+
+### NAT Policy
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0159.public.ves.io.schema.nat_policy.ves-swagger.json"/>
+
+## NFV Service
+
+### NFV Service
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0160.public.ves.io.schema.nfv_service.ves-swagger.json"/>
+
+## Namespace
+
+### Namespace
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0166.public.ves.io.schema.namespace.ves-swagger.json"/>
+
+## Namespace Role
+
+### Namespace Role
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0167.public.ves.io.schema.namespace_role.ves-swagger.json"/>
+
+## Network Connector
+
+### Network Connector
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0169.public.ves.io.schema.network_connector.ves-swagger.json"/>
+
+## Network Firewall
+
+### Network Firewall
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0170.public.ves.io.schema.network_firewall.ves-swagger.json"/>
+
+## Network Interface
+
+### Network Interface
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0171.public.ves.io.schema.network_interface.ves-swagger.json"/>
+
+## Network Policy
+
+### Network Policy
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0172.public.ves.io.schema.network_policy.ves-swagger.json"/>
+
+## Network Policy Rule
+
+### Network Policy Rule
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0173.public.ves.io.schema.network_policy_rule.ves-swagger.json"/>
+
+## Network Policy Set
+
+### Network Policy Set
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0174.public.ves.io.schema.network_policy_set.ves-swagger.json"/>
+
+## Nginx
+
+### Nginx Csg
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0161.public.ves.io.schema.nginx.one.nginx_csg.ves-swagger.json"/>
+
+### Nginx Instance
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0162.public.ves.io.schema.nginx.one.nginx_instance.ves-swagger.json"/>
+
+### Nginx Server
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0163.public.ves.io.schema.nginx.one.nginx_server.ves-swagger.json"/>
+
+### Nginx Service Discovery
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0165.public.ves.io.schema.nginx.one.nginx_service_discovery.ves-swagger.json"/>
+
+### One Subscription
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0164.public.ves.io.schema.nginx.one.subscription.ves-swagger.json"/>
+
+## OIDC Provider
+
+### OIDC Provider
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0200.public.ves.io.schema.oidc_provider.ves-swagger.json"/>
+
+## Observability
+
+### Observability Subscription
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0175.public.ves.io.schema.observability.subscription.ves-swagger.json"/>
+
+### Synthetic Monitor
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0226.public.ves.io.schema.observability.synthetic_monitor.ves-swagger.json"/>
+
+### V1 DNS Monitor
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0090.public.ves.io.schema.observability.synthetic_monitor.v1_dns_monitor.ves-swagger.json"/>
+
+### V1 HTTP Monitor
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0123.public.ves.io.schema.observability.synthetic_monitor.v1_http_monitor.ves-swagger.json"/>
+
+## Operate
+
+### BGP
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0028.public.ves.io.schema.operate.bgp.ves-swagger.json"/>
+
+### CRL
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0045.public.ves.io.schema.operate.crl.ves-swagger.json"/>
+
+### Debug
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0097.public.ves.io.schema.operate.debug.ves-swagger.json"/>
+
+### Dhcp
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0098.public.ves.io.schema.operate.dhcp.ves-swagger.json"/>
+
+### Flow
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0116.public.ves.io.schema.operate.flow.ves-swagger.json"/>
+
+### Lte
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0149.public.ves.io.schema.operate.lte.ves-swagger.json"/>
+
+### Ping
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0179.public.ves.io.schema.operate.ping.ves-swagger.json"/>
+
+### Route
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0198.public.ves.io.schema.operate.route.ves-swagger.json"/>
+
+### Tcpdump
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0232.public.ves.io.schema.operate.tcpdump.ves-swagger.json"/>
+
+### Traceroute
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0241.public.ves.io.schema.operate.traceroute.ves-swagger.json"/>
+
+### USB
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0244.public.ves.io.schema.operate.usb.ves-swagger.json"/>
+
+### Wifi
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0265.public.ves.io.schema.operate.wifi.ves-swagger.json"/>
+
+## Pbac
+
+### Addon Service
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0008.public.ves.io.schema.pbac.addon_service.ves-swagger.json"/>
+
+### Addon Subscription
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0009.public.ves.io.schema.pbac.addon_subscription.ves-swagger.json"/>
+
+### Catalog
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0046.public.ves.io.schema.pbac.catalog.ves-swagger.json"/>
+
+### Navigation Tile
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0168.public.ves.io.schema.pbac.navigation_tile.ves-swagger.json"/>
+
+### Plan
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0180.public.ves.io.schema.pbac.plan.ves-swagger.json"/>
+
+## Policer
+
+### Policer
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0182.public.ves.io.schema.policer.ves-swagger.json"/>
+
+## Protocol Inspection
+
+### Protocol Inspection
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0075.public.ves.io.schema.protocol_inspection.ves-swagger.json"/>
+
+## Protocol Policer
+
+### Protocol Policer
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0185.public.ves.io.schema.protocol_policer.ves-swagger.json"/>
+
+## Public IP
+
+### Public IP
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0187.public.ves.io.schema.public_ip.ves-swagger.json"/>
+
+## Quota
+
+### Quota
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0188.public.ves.io.schema.quota.ves-swagger.json"/>
+
+## RBAC Policy
+
+### RBAC Policy
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0189.public.ves.io.schema.rbac_policy.ves-swagger.json"/>
+
+## Rate Limiter
+
+### Rate Limiter
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0190.public.ves.io.schema.rate_limiter.ves-swagger.json"/>
+
+## Registration
+
+### Registration
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0192.public.ves.io.schema.registration.ves-swagger.json"/>
+
+## Report
+
+### Report
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0193.public.ves.io.schema.report.ves-swagger.json"/>
+
+## Report Config
+
+### Report Config
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0194.public.ves.io.schema.report_config.ves-swagger.json"/>
+
+## Role
+
+### Role
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0195.public.ves.io.schema.role.ves-swagger.json"/>
+
+## Route
+
+### Route
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0197.public.ves.io.schema.route.ves-swagger.json"/>
+
+## SCIM
+
+### SCIM
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0227.public.ves.io.schema.scim.ves-swagger.json"/>
+
+## SRV6 Network Slice
+
+### SRV6 Network Slice
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0199.public.ves.io.schema.srv6_network_slice.ves-swagger.json"/>
+
+## Secret Management
+
+### Secret Management
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0108.public.ves.io.schema.secret_management.ves-swagger.json"/>
+
+## Secret Management Access
+
+### Secret Management Access
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0201.public.ves.io.schema.secret_management_access.ves-swagger.json"/>
+
+## Secret Policy
+
+### Secret Policy
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0202.public.ves.io.schema.secret_policy.ves-swagger.json"/>
+
+## Secret Policy Rule
+
+### Secret Policy Rule
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0203.public.ves.io.schema.secret_policy_rule.ves-swagger.json"/>
+
+## Segment
+
+### Segment
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0204.public.ves.io.schema.segment.ves-swagger.json"/>
+
+## Segment Connection
+
+### Segment Connection
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0205.public.ves.io.schema.segment_connection.ves-swagger.json"/>
+
+## Sensitive Data Policy
+
+### Sensitive Data Policy
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0206.public.ves.io.schema.sensitive_data_policy.ves-swagger.json"/>
+
+## Service Policy
+
+### Service Policy
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0208.public.ves.io.schema.service_policy.ves-swagger.json"/>
+
+## Service Policy Rule
+
+### Service Policy Rule
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0209.public.ves.io.schema.service_policy_rule.ves-swagger.json"/>
+
+## Service Policy Set
+
+### Service Policy Set
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0210.public.ves.io.schema.service_policy_set.ves-swagger.json"/>
+
+## Shape
+
+### Alert Gen Policy
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0033.public.ves.io.schema.shape.brmalerts.alert_gen_policy.ves-swagger.json"/>
+
+### Alert Template
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0034.public.ves.io.schema.shape.brmalerts.alert_template.ves-swagger.json"/>
+
+### Allowed Domain
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0054.public.ves.io.schema.shape.client_side_defense.allowed_domain.ves-swagger.json"/>
+
+### Bot Allowlist Policy
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0040.public.ves.io.schema.shape.bot_defense.bot_allowlist_policy.ves-swagger.json"/>
+
+### Bot Defense Subscription
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0213.public.ves.io.schema.shape.bot_defense.subscription.ves-swagger.json"/>
+
+### Bot Detection Rule
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0036.public.ves.io.schema.shape.bot_defense.threat_intelligence.bot_detection_rule.ves-swagger.json"/>
+
+### Bot Detection Update
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0037.public.ves.io.schema.shape.bot_defense.threat_intelligence.bot_detection_update.ves-swagger.json"/>
+
+### Bot Endpoint Policy
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0038.public.ves.io.schema.shape.bot_defense.bot_endpoint_policy.ves-swagger.json"/>
+
+### Bot Infrastructure
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0039.public.ves.io.schema.shape.bot_defense.bot_infrastructure.ves-swagger.json"/>
+
+### Bot Network Policy
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0041.public.ves.io.schema.shape.bot_defense.bot_network_policy.ves-swagger.json"/>
+
+### Client Side Defense
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0053.public.ves.io.schema.shape.client_side_defense.ves-swagger.json"/>
+
+### Client Side Defense Subscription
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0057.public.ves.io.schema.shape.client_side_defense.subscription.ves-swagger.json"/>
+
+### Data Delivery
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0093.public.ves.io.schema.shape.data_delivery.ves-swagger.json"/>
+
+### Data Delivery Subscription
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0095.public.ves.io.schema.shape.data_delivery.subscription.ves-swagger.json"/>
+
+### Device Id
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0022.public.ves.io.schema.shape.device_id.ves-swagger.json"/>
+
+### Mitigated Domain
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0056.public.ves.io.schema.shape.client_side_defense.mitigated_domain.ves-swagger.json"/>
+
+### Mobile App Shield Subscription
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0154.public.ves.io.schema.shape.mobile_app_shield.subscription.ves-swagger.json"/>
+
+### Mobile Base Config
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0157.public.ves.io.schema.shape.bot_defense.mobile_base_config.ves-swagger.json"/>
+
+### Mobile Integrator Subscription
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0155.public.ves.io.schema.shape.mobile_integrator.subscription.ves-swagger.json"/>
+
+### Mobile Sdk
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0156.public.ves.io.schema.shape.bot_defense.mobile_sdk.ves-swagger.json"/>
+
+### Protected Application
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0184.public.ves.io.schema.shape.bot_defense.protected_application.ves-swagger.json"/>
+
+### Protected Domain
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0055.public.ves.io.schema.shape.client_side_defense.protected_domain.ves-swagger.json"/>
+
+### Receiver
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0092.public.ves.io.schema.shape.data_delivery.receiver.ves-swagger.json"/>
+
+### Recognize
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0214.public.ves.io.schema.shape.recognize.ves-swagger.json"/>
+
+### Reporting
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0212.public.ves.io.schema.shape.bot_defense.reporting.ves-swagger.json"/>
+
+### Safe
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0216.public.ves.io.schema.shape.safe.ves-swagger.json"/>
+
+### Safeap
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0215.public.ves.io.schema.shape.safeap.ves-swagger.json"/>
+
+## Shape Bot Defense Instance
+
+### Shape Bot Defense Instance
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0211.public.ves.io.schema.shape_bot_defense_instance.ves-swagger.json"/>
+
+## Signup
+
+### Signup
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0217.public.ves.io.schema.signup.ves-swagger.json"/>
+
+## Site
+
+### Site
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0218.public.ves.io.schema.site.ves-swagger.json"/>
+
+## Site Mesh Group
+
+### Site Mesh Group
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0220.public.ves.io.schema.site_mesh_group.ves-swagger.json"/>
+
+## Status At Site
+
+### Status At Site
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0221.public.ves.io.schema.status_at_site.ves-swagger.json"/>
+
+## Stored Object
+
+### Stored Object
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0222.public.ves.io.schema.stored_object.ves-swagger.json"/>
+
+## Subnet
+
+### Subnet
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0223.public.ves.io.schema.subnet.ves-swagger.json"/>
+
+## Subscription
+
+### Subscription
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0225.public.ves.io.schema.subscription.ves-swagger.json"/>
+
+## TPM API Key
+
+### TPM API Key
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0228.public.ves.io.schema.tpm_api_key.ves-swagger.json"/>
+
+## TPM Category
+
+### TPM Category
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0229.public.ves.io.schema.tpm_category.ves-swagger.json"/>
+
+## TPM Manager
+
+### TPM Manager
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0230.public.ves.io.schema.tpm_manager.ves-swagger.json"/>
+
+## TPM Provision
+
+### TPM Provision
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0231.public.ves.io.schema.tpm_provision.ves-swagger.json"/>
+
+## Tenant
+
+### Tenant
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0233.public.ves.io.schema.tenant.ves-swagger.json"/>
+
+## Tenant Management
+
+### Allowed Tenant
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0015.public.ves.io.schema.tenant_management.allowed_tenant.ves-swagger.json"/>
+
+### Child Tenant
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0051.public.ves.io.schema.tenant_management.child_tenant.ves-swagger.json"/>
+
+### Child Tenant Manager
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0052.public.ves.io.schema.tenant_management.child_tenant_manager.ves-swagger.json"/>
+
+### Managed Tenant
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0153.public.ves.io.schema.tenant_management.managed_tenant.ves-swagger.json"/>
+
+### Tenant Management
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0235.public.ves.io.schema.tenant_management.ves-swagger.json"/>
+
+### Tenant Profile
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0236.public.ves.io.schema.tenant_management.tenant_profile.ves-swagger.json"/>
+
+## Ticket Management
+
+### Ticket Tracking System
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0238.public.ves.io.schema.ticket_management.ticket_tracking_system.ves-swagger.json"/>
+
+## Token
+
+### Token
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0239.public.ves.io.schema.token.ves-swagger.json"/>
+
+## Topology
+
+### Topology
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0240.public.ves.io.schema.topology.ves-swagger.json"/>
+
+## Trusted Ca List
+
+### Trusted Ca List
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0196.public.ves.io.schema.trusted_ca_list.ves-swagger.json"/>
+
+## Tunnel
+
+### Tunnel
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0242.public.ves.io.schema.tunnel.ves-swagger.json"/>
+
+## USB Policy
+
+### USB Policy
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0245.public.ves.io.schema.usb_policy.ves-swagger.json"/>
+
+## Ui
+
+### Static Component
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0246.public.ves.io.schema.ui.static_component.ves-swagger.json"/>
+
+## Upgrade Status
+
+### Upgrade Status
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0247.public.ves.io.schema.upgrade_status.ves-swagger.json"/>
+
+## Usage
+
+### Invoice
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0140.public.ves.io.schema.usage.invoice.ves-swagger.json"/>
+
+### Plan
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0250.public.ves.io.schema.usage.plan.ves-swagger.json"/>
+
+### Usage
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0249.public.ves.io.schema.usage.ves-swagger.json"/>
+
+### Usage Subscription
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0224.public.ves.io.schema.usage.subscription.ves-swagger.json"/>
+
+## User
+
+### Setting
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0254.public.ves.io.schema.user.setting.ves-swagger.json"/>
+
+### User
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0251.public.ves.io.schema.user.ves-swagger.json"/>
+
+## User Group
+
+### User Group
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0252.public.ves.io.schema.user_group.ves-swagger.json"/>
+
+## User Identification
+
+### User Identification
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0253.public.ves.io.schema.user_identification.ves-swagger.json"/>
+
+## Views
+
+### API Definition
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0002.public.ves.io.schema.views.api_definition.ves-swagger.json"/>
+
+### AWS Tgw Site
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0065.public.ves.io.schema.views.aws_tgw_site.ves-swagger.json"/>
+
+### AWS VPC Site
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0066.public.ves.io.schema.views.aws_vpc_site.ves-swagger.json"/>
+
+### App API Group
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0016.public.ves.io.schema.views.app_api_group.ves-swagger.json"/>
+
+### Azure Vnet Site
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0068.public.ves.io.schema.views.azure_vnet_site.ves-swagger.json"/>
+
+### Bigip Virtual Server
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0032.public.ves.io.schema.views.bigip_virtual_server.ves-swagger.json"/>
+
+### Bot Defense App Infrastructure
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0035.public.ves.io.schema.views.bot_defense_app_infrastructure.ves-swagger.json"/>
+
+### CDN Loadbalancer
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0042.public.ves.io.schema.views.cdn_loadbalancer.ves-swagger.json"/>
+
+### External Connector
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0104.public.ves.io.schema.views.external_connector.ves-swagger.json"/>
+
+### Forward Proxy Policy
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0071.public.ves.io.schema.views.forward_proxy_policy.ves-swagger.json"/>
+
+### GCP VPC Site
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0072.public.ves.io.schema.views.gcp_vpc_site.ves-swagger.json"/>
+
+### HTTP Loadbalancer
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0073.public.ves.io.schema.views.http_loadbalancer.ves-swagger.json"/>
+
+### IKE Phase1 Profile
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0126.public.ves.io.schema.views.ike_phase1_profile.ves-swagger.json"/>
+
+### IKE Phase2 Profile
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0128.public.ves.io.schema.views.ike_phase2_profile.ves-swagger.json"/>
+
+### Network Policy View
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0074.public.ves.io.schema.views.network_policy_view.ves-swagger.json"/>
+
+### Origin Pool
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0177.public.ves.io.schema.views.origin_pool.ves-swagger.json"/>
+
+### Policy Based Routing
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0183.public.ves.io.schema.views.policy_based_routing.ves-swagger.json"/>
+
+### Proxy
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0186.public.ves.io.schema.views.proxy.ves-swagger.json"/>
+
+### Rate Limiter Policy
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0191.public.ves.io.schema.views.rate_limiter_policy.ves-swagger.json"/>
+
+### Securemesh Site
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0076.public.ves.io.schema.views.securemesh_site.ves-swagger.json"/>
+
+### Securemesh Site V2
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0077.public.ves.io.schema.views.securemesh_site_v2.ves-swagger.json"/>
+
+### TCP Loadbalancer
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0078.public.ves.io.schema.views.tcp_loadbalancer.ves-swagger.json"/>
+
+### Tenant Configuration
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0234.public.ves.io.schema.views.tenant_configuration.ves-swagger.json"/>
+
+### Terraform Parameters
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0256.public.ves.io.schema.views.terraform_parameters.ves-swagger.json"/>
+
+### Third Party Application
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0237.public.ves.io.schema.views.third_party_application.ves-swagger.json"/>
+
+### UDP Loadbalancer
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0079.public.ves.io.schema.views.udp_loadbalancer.ves-swagger.json"/>
+
+### View Internal
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0255.public.ves.io.schema.views.view_internal.ves-swagger.json"/>
+
+### Voltstack Site
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0067.public.ves.io.schema.views.voltstack_site.ves-swagger.json"/>
+
+### Workload
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0267.public.ves.io.schema.views.workload.ves-swagger.json"/>
+
+## Virtual Appliance
+
+### Virtual Appliance
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0248.public.ves.io.schema.virtual_appliance.ves-swagger.json"/>
+
+## Virtual Host
+
+### Virtual Host
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0257.public.ves.io.schema.virtual_host.ves-swagger.json"/>
+
+## Virtual K8s
+
+### Virtual K8s
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0258.public.ves.io.schema.virtual_k8s.ves-swagger.json"/>
+
+## Virtual Network
+
+### Virtual Network
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0259.public.ves.io.schema.virtual_network.ves-swagger.json"/>
+
+## Virtual Site
+
+### Virtual Site
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0260.public.ves.io.schema.virtual_site.ves-swagger.json"/>
+
+## Voltshare
+
+### Voltshare
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0109.public.ves.io.schema.voltshare.ves-swagger.json"/>
+
+## Voltshare Admin Policy
+
+### Voltshare Admin Policy
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0261.public.ves.io.schema.voltshare_admin_policy.ves-swagger.json"/>
+
+## WAF
+
+### WAF
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0262.public.ves.io.schema.waf.ves-swagger.json"/>
+
+## WAF Exclusion Policy
+
+### WAF Exclusion Policy
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0263.public.ves.io.schema.waf_exclusion_policy.ves-swagger.json"/>
+
+## WAF Signatures Changelog
+
+### WAF Signatures Changelog
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0264.public.ves.io.schema.waf_signatures_changelog.ves-swagger.json"/>
+
+## Was
+
+### User Token
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0266.public.ves.io.schema.was.user_token.ves-swagger.json"/>
+
+## Workload Flavor
+
+### Workload Flavor
+
+<swagger-ui src="specifications/api/docs-cloud-f5-com.0268.public.ves.io.schema.workload_flavor.ves-swagger.json"/>
+
+
+<!-- Generated automatically from 269 OpenAPI specifications -->

--- a/tools/generate-api-docs.go
+++ b/tools/generate-api-docs.go
@@ -1,0 +1,206 @@
+// generate-api-docs.go generates the docs/api.md file from OpenAPI specifications
+// Usage: go run tools/generate-api-docs.go [--spec-dir=path]
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+type APISpec struct {
+	Category   string
+	Name       string
+	Filename   string
+	SchemaPath string
+}
+
+func main() {
+	specDir := flag.String("spec-dir", "docs/specifications/api", "Directory containing OpenAPI spec files")
+	outputFile := flag.String("output", "docs/api.md", "Output markdown file")
+	flag.Parse()
+
+	specs, err := scanSpecs(*specDir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error scanning specs: %v\n", err)
+		os.Exit(1)
+	}
+
+	if len(specs) == 0 {
+		fmt.Fprintf(os.Stderr, "No OpenAPI specs found in %s\n", *specDir)
+		os.Exit(1)
+	}
+
+	content := generateMarkdown(specs)
+
+	if err := os.WriteFile(*outputFile, []byte(content), 0644); err != nil {
+		fmt.Fprintf(os.Stderr, "Error writing output: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("Generated %s with %d APIs across %d categories\n", *outputFile, len(specs), countCategories(specs))
+}
+
+func scanSpecs(dir string) ([]APISpec, error) {
+	var specs []APISpec
+
+	// Pattern: docs-cloud-f5-com.XXXX.public.ves.io.schema.CATEGORY[.SUBCATEGORY].ves-swagger.json
+	pattern := regexp.MustCompile(`docs-cloud-f5-com\.(\d+)\.public\.ves\.io\.schema\.(.+)\.ves-swagger\.json`)
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
+			continue
+		}
+
+		match := pattern.FindStringSubmatch(entry.Name())
+		if match == nil {
+			continue
+		}
+
+		schemaPath := match[2]
+		parts := strings.Split(schemaPath, ".")
+
+		// Determine category and name
+		category := formatName(parts[0])
+		name := formatName(parts[len(parts)-1])
+
+		// Handle nested paths for better naming
+		if len(parts) > 1 {
+			// Use the last part as name, but include parent for context if it adds value
+			if parts[len(parts)-1] == "subscription" && len(parts) > 1 {
+				name = formatName(parts[len(parts)-2]) + " " + name
+			}
+		}
+
+		specs = append(specs, APISpec{
+			Category:   category,
+			Name:       name,
+			Filename:   entry.Name(),
+			SchemaPath: schemaPath,
+		})
+	}
+
+	// Sort by category, then by name
+	sort.Slice(specs, func(i, j int) bool {
+		if specs[i].Category != specs[j].Category {
+			return specs[i].Category < specs[j].Category
+		}
+		return specs[i].Name < specs[j].Name
+	})
+
+	return specs, nil
+}
+
+func formatName(s string) string {
+	// Replace underscores with spaces and title case
+	s = strings.ReplaceAll(s, "_", " ")
+
+	// Handle common abbreviations
+	abbreviations := map[string]string{
+		"api":   "API",
+		"cdn":   "CDN",
+		"dns":   "DNS",
+		"http":  "HTTP",
+		"https": "HTTPS",
+		"ip":    "IP",
+		"k8s":   "K8s",
+		"lb":    "LB",
+		"nat":   "NAT",
+		"nfv":   "NFV",
+		"oidc":  "OIDC",
+		"tcp":   "TCP",
+		"tls":   "TLS",
+		"udp":   "UDP",
+		"usb":   "USB",
+		"vpc":   "VPC",
+		"vpn":   "VPN",
+		"waf":   "WAF",
+		"bgp":   "BGP",
+		"crl":   "CRL",
+		"ike":   "IKE",
+		"scim":  "SCIM",
+		"tpm":   "TPM",
+		"acl":   "ACL",
+		"asn":   "ASN",
+		"aws":   "AWS",
+		"gcp":   "GCP",
+		"azure": "Azure",
+		"rbac":  "RBAC",
+		"soa":   "SOA",
+		"srv6":  "SRV6",
+	}
+
+	words := strings.Fields(s)
+	for i, word := range words {
+		lower := strings.ToLower(word)
+		if abbr, ok := abbreviations[lower]; ok {
+			words[i] = abbr
+		} else {
+			words[i] = strings.Title(lower)
+		}
+	}
+
+	return strings.Join(words, " ")
+}
+
+func generateMarkdown(specs []APISpec) string {
+	var sb strings.Builder
+
+	sb.WriteString(`---
+page_title: "API Reference"
+description: "Interactive F5 Distributed Cloud API documentation with Try it out functionality"
+---
+
+# API Reference
+
+Explore the F5 Distributed Cloud API documentation with interactive "Try it out" functionality.
+
+!!! tip "Usage"
+    Expand any API section below to view the interactive Swagger UI documentation.
+    Use the "Try it out" button to test API calls directly.
+
+`)
+
+	// Group by category
+	categories := make(map[string][]APISpec)
+	var categoryOrder []string
+
+	for _, spec := range specs {
+		if _, exists := categories[spec.Category]; !exists {
+			categoryOrder = append(categoryOrder, spec.Category)
+		}
+		categories[spec.Category] = append(categories[spec.Category], spec)
+	}
+
+	// Generate content for each category
+	for _, category := range categoryOrder {
+		apis := categories[category]
+		sb.WriteString(fmt.Sprintf("## %s\n\n", category))
+
+		for _, api := range apis {
+			sb.WriteString(fmt.Sprintf("### %s\n\n", api.Name))
+			sb.WriteString(fmt.Sprintf("<swagger-ui src=\"specifications/api/%s\"/>\n\n", api.Filename))
+		}
+	}
+
+	// Add footer with metadata
+	sb.WriteString(fmt.Sprintf("\n<!-- Generated automatically from %d OpenAPI specifications -->\n", len(specs)))
+
+	return sb.String()
+}
+
+func countCategories(specs []APISpec) int {
+	categories := make(map[string]bool)
+	for _, spec := range specs {
+		categories[spec.Category] = true
+	}
+	return len(categories)
+}


### PR DESCRIPTION
## Summary

Add automated API documentation generation that integrates with the existing CI/CD pipeline.

## Changes

- **tools/generate-api-docs.go**: New tool that generates `docs/api.md` from OpenAPI specs
  - Scans all JSON files in `docs/specifications/api/`
  - Groups APIs by category based on schema path
  - Generates markdown with `<swagger-ui>` tags for each API
  - Handles common abbreviations (API, DNS, HTTP, BGP, etc.)

- **sync-openapi.yml**: Added step to regenerate API docs after downloading specs

- **docs/api.md**: Now contains all 269 APIs organized by category

## CI/CD Integration

```
sync-openapi.yml workflow:
  1. Download OpenAPI specs ✓
  2. Regenerate provider code ✓  
  3. Regenerate API docs ← NEW
  4. Build & test ✓
  5. Create PR ✓

pages.yml workflow:
  - Triggers on docs/** changes
  - Auto-deploys when api.md updates
```

## Test plan

- [x] Tool compiles and runs locally
- [x] Generated api.md contains all 269 APIs
- [x] swagger-ui tags render correctly in MkDocs
- [ ] CI/CD workflows pass
- [ ] GitHub Pages renders API documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)