### PR TITLE
feat: Add system dependencies for MkDocs imaging and PDF export

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -35,6 +35,41 @@ jobs:
           go-version-file: 'go.mod'
           cache: true
 
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            build-essential \
+            ca-certificates \
+            chromium-browser \
+            curl \
+            fonts-dejavu \
+            fonts-droid-fallback \
+            fonts-freefont-ttf \
+            fonts-liberation \
+            fonts-noto \
+            fonts-noto-color-emoji \
+            fonts-wqy-zenhei \
+            git \
+            gobject-introspection \
+            libjpeg-dev \
+            libcairo2 \
+            libcairo2-dev \
+            libfreetype6-dev \
+            libffi-dev \
+            libssl-dev \
+            libx11-dev \
+            libxext-dev \
+            libxrender-dev \
+            libpango1.0-dev \
+            libharfbuzz-dev \
+            libopenjp2-7-dev \
+            openssh-client \
+            tini \
+            xvfb \
+            weasyprint \
+            zlib1g-dev
+
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
@@ -42,6 +77,9 @@ jobs:
 
       - name: Install MkDocs and plugins
         run: |
+          pip install --no-cache-dir \
+            "mkdocs-material[recommended]" \
+            "mkdocs-material[imaging]"
           pip install \
             babel \
             backrefs \


### PR DESCRIPTION
## Summary
- Adds system dependencies via apt-get for image processing and PDF generation
- Includes cairo, pango, harfbuzz, freetype for image manipulation
- Adds weasyprint and chromium for PDF export capabilities
- Installs fonts (noto, dejavu, liberation, emoji) for proper rendering
- Adds `mkdocs-material[recommended]` and `mkdocs-material[imaging]` extras

## Test plan
- [ ] Verify apt-get install completes without errors
- [ ] Confirm pip install succeeds
- [ ] Check MkDocs build passes
- [ ] Verify site deploys correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)