### PR TITLE
feat(ci): add workflow_dispatch trigger to docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,5 +1,6 @@
 # Terraform Provider documentation generation workflow
 # Uses hashicorp/terraform-plugin-docs to generate provider documentation
+# Can be triggered manually via workflow_dispatch for immediate documentation regeneration
 name: Documentation
 
 on:
@@ -21,6 +22,7 @@ on:
       - 'examples/**'
       - 'templates/**'
       - 'tools/**'
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -66,7 +68,7 @@ jobs:
           fi
 
       - name: Create Pull Request for documentation changes
-        if: steps.changes.outputs.changed == 'true' && github.event_name == 'push'
+        if: steps.changes.outputs.changed == 'true' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
Adds `workflow_dispatch` trigger to the Documentation workflow, enabling manual documentation regeneration when automated triggers don't fire.

## Related Issue
Closes #39

## Problem Context
**v1.17.1** in the Terraform Registry contains the OneOf grouping **code** but NOT the **regenerated documentation** because:

1. v1.17.0 (PR #35): Added OneOf grouping code to `tools/transform-docs.go`
   - docs.yml workflow did NOT run (tools/** wasn't in path triggers yet)
   - Documentation files were NOT regenerated

2. v1.17.1 (PR #38): Fixed docs.yml workflow triggers
   - Added tools/** to path triggers
   - But this PR only changed `.github/workflows/docs.yml`
   - docs.yml workflow did NOT run (correctly, since .github/** is not in its triggers)

3. **Result**: Registry shows v1.17.1 with grouping code but old documentation

## Changes Made
- Added `workflow_dispatch:` trigger to docs.yml
- Updated PR creation condition to handle manual workflow runs
- Added comment explaining manual trigger capability

## Benefits
- Immediate documentation regeneration capability
- Testing documentation changes without dummy commits
- Better control over documentation publishing
- Prevents future documentation sync issues

## Testing
After merge:
1. Manually trigger workflow: `gh workflow run docs.yml`
2. Workflow will regenerate all 144 resource docs with OneOf grouping
3. Automated PR will be created with regenerated documentation
4. Merge that PR to publish v1.17.2 with properly grouped documentation

## Next Steps
After this PR merges:
1. Run `gh workflow run docs.yml` to trigger documentation regeneration
2. Review and merge the auto-generated docs PR
3. New version (v1.17.2) will be published with correct OneOf grouping visible in Terraform Registry

🤖 Generated with [Claude Code](https://claude.com/claude-code)