### PR TITLE
fix(ci): exclude automated docs PR from constitution check

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -78,8 +78,8 @@ jobs:
   check-constitution:
     name: Constitution Check
     runs-on: ubuntu-latest
-    # Run on all PRs to enforce rules
-    if: github.event_name == 'pull_request'
+    # Run on all PRs to enforce rules, except automated documentation PRs
+    if: github.event_name == 'pull_request' && github.head_ref != 'docs/auto-update'
     steps:
       - name: Checkout
         uses: actions/checkout@v5


### PR DESCRIPTION
## Summary
Excludes the docs/auto-update branch from constitution Rule 1 checks, allowing automated documentation PRs to merge successfully.

## Related Issue
Closes #42

## Problem
PR #41 (auto-generated documentation with OneOf grouping) is failing the constitution check because it contains generated files (docs/resources/*.md). However, the docs/auto-update branch is specifically used for automated documentation updates and SHOULD contain these generated files.

## Solution
Added condition to constitution check: `github.head_ref != 'docs/auto-update'`

This allows automated documentation PRs to bypass the check while still protecting against manual commits of generated files on other branches.

## Testing
After merge:
- PR #41 constitution check will be skipped
- Other PR checks (Build and Test, Lint) will still run
- Manual PRs on other branches still subject to constitution check

🤖 Generated with [Claude Code](https://claude.com/claude-code)