### PR TITLE
chore: document OneOf property grouping feature

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,6 +3,9 @@
 
 // terraform-provider-f5xc provides Terraform resources for managing F5 Distributed Cloud services.
 // For documentation, see https://registry.terraform.io/providers/robinmordasiewicz/f5xc/latest/docs
+//
+// Documentation features OneOf property grouping for mutually exclusive arguments,
+// improving clarity by grouping related properties with a single explanatory note.
 
 package main
 


### PR DESCRIPTION
## Summary
Adds documentation comment noting the OneOf property grouping feature in provider documentation, triggering v1.18.1 release with regenerated docs.

## Related Issue
Closes #44

## Problem
PR #41 regenerated all 144 resource docs with OneOf property grouping, but the merge didn't trigger a version release because:
- auto-tag.yml has `paths-ignore: ['docs/**']` (intentional design)
- Only non-docs changes trigger version releases
- Current v1.18.0 does not include the OneOf grouped documentation

## Solution
Add a meaningful documentation comment to main.go noting the OneOf grouping feature. This:
- Triggers auto-tag workflow (main.go is not in paths-ignore)
- Creates v1.18.1 release that includes PR #41's regenerated docs
- Documents the feature in the provider's main package

## Changes Made
Added package-level comment documenting OneOf property grouping feature

## Impact
After merge:
- v1.18.1 will be released automatically
- Terraform Registry will display OneOf grouped documentation
- Users will see mutually exclusive properties grouped with single Note
- Example: https://registry.terraform.io/providers/robinmordasiewicz/f5xc/latest/docs/resources/http_loadbalancer

🤖 Generated with [Claude Code](https://claude.com/claude-code)