### PR TITLE
feat: enable auto-merge for automated workflow PRs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -68,6 +68,7 @@ jobs:
           fi
 
       - name: Create Pull Request for documentation changes
+        id: create-pr
         if: steps.changes.outputs.changed == 'true' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         uses: peter-evans/create-pull-request@v7
         with:
@@ -83,6 +84,14 @@ jobs:
           branch: docs/auto-update
           delete-branch: true
           labels: documentation,automated
+
+      - name: Enable auto-merge on PR
+        if: steps.create-pr.outputs.pull-request-operation == 'created'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr merge ${{ steps.create-pr.outputs.pull-request-number }} \
+            --auto --squash
 
       - name: Fail if docs are out of date on PR
         if: steps.changes.outputs.changed == 'true' && github.event_name == 'pull_request'

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -91,6 +91,7 @@ jobs:
           fi
 
       - name: Create Pull Request
+        id: create-pr
         if: steps.verify-specs.outputs.has_specs == 'true' && steps.git-changes.outputs.has_changes == 'true'
         uses: peter-evans/create-pull-request@v7
         with:
@@ -127,3 +128,11 @@ jobs:
           labels: |
             automated
             api-update
+
+      - name: Enable auto-merge on PR
+        if: steps.create-pr.outputs.pull-request-operation == 'created'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr merge ${{ steps.create-pr.outputs.pull-request-number }} \
+            --auto --squash

--- a/.github/workflows/sync-openapi.yml
+++ b/.github/workflows/sync-openapi.yml
@@ -269,3 +269,11 @@ jobs:
             });
             console.log(`Created PR #${pr.data.number}`);
             return pr.data.number;
+
+      - name: Enable auto-merge on PR
+        if: steps.create_pr.outputs.result != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr merge ${{ steps.create_pr.outputs.result }} \
+            --auto --squash


### PR DESCRIPTION
## Summary
Adds auto-merge functionality to all automated workflows to achieve full automation while maintaining branch protection.

## Related Issue
Closes #50

## Changes Made
- **docs.yml**: Added auto-merge step after PR creation
- **generate.yml**: Added auto-merge step after PR creation
- **sync-openapi.yml**: Added auto-merge step after PR creation

## How It Works
1. Workflow creates PR (respects branch protection)
2. Auto-merge is enabled on the PR via `gh pr merge --auto --squash`
3. PR automatically merges when required status checks pass ("Build and Test", "Lint")
4. Zero manual intervention required

## Branch Protection Compatibility
✅ Maintains required status checks (Build and Test, Lint)
✅ Maintains PR requirement
✅ Works with current protection rules (review count: 0)
✅ Enforces admins rules maintained

## Testing Plan
1. Merge this PR
2. Close existing PR #49 (outdated auto-generated docs PR)
3. Trigger docs workflow via workflow_dispatch or make a change to trigger it
4. Verify PR is created with auto-merge enabled
5. Verify PR merges automatically when checks pass

## Benefits
- 🎯 Zero manual intervention for automated changes
- 🛡️ All branch protections maintained
- ⚡ Faster deployment of automated updates
- 📊 Audit trail preserved via PR history
- 🧹 No orphaned PRs requiring manual cleanup

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)