### PR TITLE
fix: use PAT to enable workflow triggers on auto-generated PRs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -72,7 +72,7 @@ jobs:
         if: steps.changes.outputs.changed == 'true' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         uses: peter-evans/create-pull-request@v7
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.AUTO_MERGE_TOKEN }}
           commit-message: 'docs: auto-generate provider documentation'
           title: 'docs: auto-generate provider documentation'
           body: |

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -95,7 +95,7 @@ jobs:
         if: steps.verify-specs.outputs.has_specs == 'true' && steps.git-changes.outputs.has_changes == 'true'
         uses: peter-evans/create-pull-request@v7
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.AUTO_MERGE_TOKEN }}
           commit-message: |
             chore: regenerate provider from latest API specs
 

--- a/.github/workflows/sync-openapi.yml
+++ b/.github/workflows/sync-openapi.yml
@@ -233,6 +233,7 @@ jobs:
         id: create_pr
         uses: actions/github-script@v7
         with:
+          github-token: ${{ secrets.AUTO_MERGE_TOKEN }}
           script: |
             const prTitle = process.env.PR_TITLE;
             const pr = await github.rest.pulls.create({
@@ -273,7 +274,7 @@ jobs:
       - name: Enable auto-merge on PR
         if: steps.create_pr.outputs.result != ''
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.AUTO_MERGE_TOKEN }}
         run: |
           gh pr merge ${{ steps.create_pr.outputs.result }} \
             --auto --squash


### PR DESCRIPTION
## Summary
Replaces GITHUB_TOKEN with AUTO_MERGE_TOKEN (fine-grained PAT) to enable workflow triggers on auto-generated PRs, achieving full automation.

## Related Issue
Closes #53

## Problem Fixed
PR #52 demonstrated that PRs created with GITHUB_TOKEN don't trigger required status checks due to GitHub security restrictions, blocking auto-merge from completing.

## Solution
Use AUTO_MERGE_TOKEN (fine-grained PAT with repo + workflow scopes) instead of GITHUB_TOKEN for all automated PR creation.

## Changes Made
- **docs.yml**: Line 75 - Use AUTO_MERGE_TOKEN
- **generate.yml**: Line 98 - Use AUTO_MERGE_TOKEN
- **sync-openapi.yml**: Lines 236, 277 - Use AUTO_MERGE_TOKEN

## How It Works Now
1. Workflow generates changes (docs/code)
2. Creates PR using AUTO_MERGE_TOKEN
3. **Workflows trigger** on the PR (Build and Test, Lint)
4. Auto-merge enabled on PR creation
5. **PR automatically merges** when checks pass ✅
6. Zero manual intervention required ✅

## Testing Plan
1. Merge this PR
2. Close PR #52 (outdated test PR)
3. Trigger docs workflow via workflow_dispatch
4. Verify new PR triggers status checks
5. Verify auto-merge completes automatically

## Security Note
- AUTO_MERGE_TOKEN is a fine-grained PAT scoped to this repository only
- Has minimal permissions: Contents (RW), PRs (RW), Workflows (RW)
- Should be rotated after successful testing

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)