### PR TITLE
fix(docs): remove anchor links and headers for empty nested block sections

### DIFF
--- a/docs/resources/advertise_policy.md
+++ b/docs/resources/advertise_policy.md
@@ -120,23 +120,15 @@ In addition to all arguments above, the following attributes are exported:
 
 ### TLS Parameters
 
-`client_certificate_optional` - (Optional) Empty. This can be used for messages where no values are needed. See [Client Certificate Optional](#tls-parameters-client-certificate-optional) below.
+`client_certificate_optional` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`client_certificate_required` - (Optional) Empty. This can be used for messages where no values are needed. See [Client Certificate Required](#tls-parameters-client-certificate-required) below.
+`client_certificate_required` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `common_params` - (Optional) TLS Parameters. Information of different aspects for TLS authentication related to ciphers, certificates and trust store. See [Common Params](#tls-parameters-common-params) below.
 
-`no_client_certificate` - (Optional) Empty. This can be used for messages where no values are needed. See [No Client Certificate](#tls-parameters-no-client-certificate) below.
+`no_client_certificate` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `xfcc_header_elements` - (Optional) XFCC Header. X-Forwarded-Client-Cert header elements to be set in an mTLS enabled connections. If none are defined, the header will not be added (`List`).
-
-<a id="tls-parameters-client-certificate-optional"></a>
-
-### TLS Parameters Client Certificate Optional
-
-<a id="tls-parameters-client-certificate-required"></a>
-
-### TLS Parameters Client Certificate Required
 
 <a id="tls-parameters-common-params"></a>
 
@@ -158,31 +150,15 @@ In addition to all arguments above, the following attributes are exported:
 
 `certificate_url` - (Optional) Certificate. TLS certificate. Certificate or certificate chain in PEM format including the PEM headers (`String`).
 
-`custom_hash_algorithms` - (Optional) Hash Algorithms. Specifies the hash algorithms to be used. See [Custom Hash Algorithms](#tls-parameters-common-params-tls-certificates-custom-hash-algorithms) below.
+`custom_hash_algorithms` - (Optional) Hash Algorithms. Specifies the hash algorithms to be used (`Block`).
 
 `description` - (Optional) Configuration for description (`String`).
 
-`disable_ocsp_stapling` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable OCSP Stapling](#tls-parameters-common-params-tls-certificates-disable-ocsp-stapling) below.
+`disable_ocsp_stapling` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`private_key` - (Optional) Secret. SecretType is used in an object to indicate a sensitive/confidential field. See [Private Key](#tls-parameters-common-params-tls-certificates-private-key) below.
+`private_key` - (Optional) Secret. SecretType is used in an object to indicate a sensitive/confidential field (`Block`).
 
-`use_system_defaults` - (Optional) Empty. This can be used for messages where no values are needed. See [Use System Defaults](#tls-parameters-common-params-tls-certificates-use-system-defaults) below.
-
-<a id="tls-parameters-common-params-tls-certificates-custom-hash-algorithms"></a>
-
-### TLS Parameters Common Params TLS Certificates Custom Hash Algorithms
-
-<a id="tls-parameters-common-params-tls-certificates-disable-ocsp-stapling"></a>
-
-### TLS Parameters Common Params TLS Certificates Disable OCSP Stapling
-
-<a id="tls-parameters-common-params-tls-certificates-private-key"></a>
-
-### TLS Parameters Common Params TLS Certificates Private Key
-
-<a id="tls-parameters-common-params-tls-certificates-use-system-defaults"></a>
-
-### TLS Parameters Common Params TLS Certificates Use System Defaults
+`use_system_defaults` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="tls-parameters-common-params-validation-params"></a>
 
@@ -190,19 +166,11 @@ In addition to all arguments above, the following attributes are exported:
 
 `skip_hostname_verification` - (Optional) Skip verification of hostname. When True, skip verification of hostname i.e. CN/Subject Alt Name of certificate is not matched to the connecting hostname (`Bool`).
 
-`trusted_ca` - (Optional) Root CA Certificate Reference. Reference to Root CA Certificate. See [Trusted CA](#tls-parameters-common-params-validation-params-trusted-ca) below.
+`trusted_ca` - (Optional) Root CA Certificate Reference. Reference to Root CA Certificate (`Block`).
 
 `trusted_ca_url` - (Optional) Inline Root CA Certificate (legacy). Inline Root CA Certificate (`String`).
 
 `verify_subject_alt_names` - (Optional) List of SANs for matching. List of acceptable Subject Alt Names/CN in the peer's certificate. When skip_hostname_verification is false and verify_subject_alt_names is empty, the hostname of the peer will be used for matching against SAN/CN of peer's certificate (`List`).
-
-<a id="tls-parameters-common-params-validation-params-trusted-ca"></a>
-
-### TLS Parameters Common Params Validation Params Trusted CA
-
-<a id="tls-parameters-no-client-certificate"></a>
-
-### TLS Parameters No Client Certificate
 
 <a id="where"></a>
 
@@ -218,21 +186,13 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Where Site
 
-`disable_internet_vip` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Internet VIP](#where-site-disable-internet-vip) below.
+`disable_internet_vip` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`enable_internet_vip` - (Optional) Empty. This can be used for messages where no values are needed. See [Enable Internet VIP](#where-site-enable-internet-vip) below.
+`enable_internet_vip` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `network_type` - (Optional) Virtual Network Type. Different types of virtual networks understood by the system Virtual-network of type VIRTUAL_NETWORK_SITE_LOCAL provides connectivity to public (outside) network. This is an insecure network and is connected to public internet via NAT Gateways/firwalls Virtual-network of this type is local to every site. Two virtual networks of this type on different sites are neither related nor connected. Constraints: There can be atmost one virtual network of this type in a given site... Possible values include `VIRTUAL_NETWORK_SITE_LOCAL`, `VIRTUAL_NETWORK_SITE_LOCAL_INSIDE`, `VIRTUAL_NETWORK_PER_SITE`, `VIRTUAL_NETWORK_PUBLIC`, `VIRTUAL_NETWORK_GLOBAL`, `VIRTUAL_NETWORK_SITE_SERVICE`, `VIRTUAL_NETWORK_VER_INTERNAL`, `VIRTUAL_NETWORK_SITE_LOCAL_INSIDE_OUTSIDE`, `VIRTUAL_NETWORK_IP_AUTO`, `VIRTUAL_NETWORK_VOLTADN_PRIVATE_NETWORK`, and others. Defaults to `VIRTUAL_NETWORK_SITE_LOCAL` (`String`).
 
 `ref` - (Optional) Reference. A site direct reference. See [Ref](#where-site-ref) below.
-
-<a id="where-site-disable-internet-vip"></a>
-
-### Where Site Disable Internet VIP
-
-<a id="where-site-enable-internet-vip"></a>
-
-### Where Site Enable Internet VIP
 
 <a id="where-site-ref"></a>
 
@@ -272,21 +232,13 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Where Virtual Site
 
-`disable_internet_vip` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Internet VIP](#where-virtual-site-disable-internet-vip) below.
+`disable_internet_vip` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`enable_internet_vip` - (Optional) Empty. This can be used for messages where no values are needed. See [Enable Internet VIP](#where-virtual-site-enable-internet-vip) below.
+`enable_internet_vip` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `network_type` - (Optional) Virtual Network Type. Different types of virtual networks understood by the system Virtual-network of type VIRTUAL_NETWORK_SITE_LOCAL provides connectivity to public (outside) network. This is an insecure network and is connected to public internet via NAT Gateways/firwalls Virtual-network of this type is local to every site. Two virtual networks of this type on different sites are neither related nor connected. Constraints: There can be atmost one virtual network of this type in a given site... Possible values include `VIRTUAL_NETWORK_SITE_LOCAL`, `VIRTUAL_NETWORK_SITE_LOCAL_INSIDE`, `VIRTUAL_NETWORK_PER_SITE`, `VIRTUAL_NETWORK_PUBLIC`, `VIRTUAL_NETWORK_GLOBAL`, `VIRTUAL_NETWORK_SITE_SERVICE`, `VIRTUAL_NETWORK_VER_INTERNAL`, `VIRTUAL_NETWORK_SITE_LOCAL_INSIDE_OUTSIDE`, `VIRTUAL_NETWORK_IP_AUTO`, `VIRTUAL_NETWORK_VOLTADN_PRIVATE_NETWORK`, and others. Defaults to `VIRTUAL_NETWORK_SITE_LOCAL` (`String`).
 
 `ref` - (Optional) Reference. A virtual_site direct reference. See [Ref](#where-virtual-site-ref) below.
-
-<a id="where-virtual-site-disable-internet-vip"></a>
-
-### Where Virtual Site Disable Internet VIP
-
-<a id="where-virtual-site-enable-internet-vip"></a>
-
-### Where Virtual Site Enable Internet VIP
 
 <a id="where-virtual-site-ref"></a>
 

--- a/docs/resources/alert_policy.md
+++ b/docs/resources/alert_policy.md
@@ -90,35 +90,23 @@ In addition to all arguments above, the following attributes are exported:
 
 `custom` - (Optional) Custom Group By. Specify list of custom labels to group/aggregate the alerts. See [Custom](#notification-parameters-custom) below.
 
-`default` - (Optional) Empty. This can be used for messages where no values are needed. See [Default](#notification-parameters-default) below.
+`default` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `group_interval` - (Optional) Notify Interval for a Group. Group Interval is used to specify how long to wait before sending a notification about new alerts that are added to the group for which an initial notification has already been sent. Format: [0-9]\[smhd], where s - seconds, m - minutes, h - hours, d - days If not specified, group_interval defaults to '1m' (`String`).
 
 `group_wait` - (Optional) Wait to Notify. Time value used to specify how long to initially wait for an inhibiting alert to arrive or collect more alerts for the same group. Format: [0-9]\[smhd], where s - seconds, m - minutes, h - hours, d - days If not specified, group_wait defaults to '30s' (`String`).
 
-`individual` - (Optional) Empty. This can be used for messages where no values are needed. See [Individual](#notification-parameters-individual) below.
+`individual` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `repeat_interval` - (Optional) Notify Interval For a Alert. Repeat Interval is used to specify how long to wait before sending a notification again if it has already been sent successfully. Format: [0-9]\[smhd], where s - seconds, m - minutes, h - hours, d - days If not specified, group_interval defaults to '4h' (`String`).
 
-`ves_io_group` - (Optional) Empty. This can be used for messages where no values are needed. See [Ves Io Group](#notification-parameters-ves-io-group) below.
+`ves_io_group` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="notification-parameters-custom"></a>
 
 ### Notification Parameters Custom
 
 `labels` - (Optional) Labels. Name of labels to group/aggregate the alerts (`List`).
-
-<a id="notification-parameters-default"></a>
-
-### Notification Parameters Default
-
-<a id="notification-parameters-individual"></a>
-
-### Notification Parameters Individual
-
-<a id="notification-parameters-ves-io-group"></a>
-
-### Notification Parameters Ves Io Group
 
 <a id="receivers"></a>
 
@@ -142,39 +130,31 @@ In addition to all arguments above, the following attributes are exported:
 
 `alertname_regex` - (Optional) Matching RegEx of Alertname. Regular Expression match for the alertname (`String`).
 
-`any` - (Optional) Empty. This can be used for messages where no values are needed. See [Any](#routes-any) below.
+`any` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `custom` - (Optional) Custom Matcher. A set of matchers an alert has to fulfill to match the route. See [Custom](#routes-custom) below.
 
-`dont_send` - (Optional) Empty. This can be used for messages where no values are needed. See [Dont Send](#routes-dont-send) below.
+`dont_send` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `group` - (Optional) Group Matcher. Select one or more known group names to match the incoming alert. See [Group](#routes-group) below.
 
 `notification_parameters` - (Optional) Notification Parameters. Set of notification parameters to decide how and when the alert notifications should be sent to the receivers. See [Notification Parameters](#routes-notification-parameters) below.
 
-`send` - (Optional) Empty. This can be used for messages where no values are needed. See [Send](#routes-send) below.
+`send` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `severity` - (Optional) Severity Matcher. Select one or more severity levels to match the incoming alert. See [Severity](#routes-severity) below.
-
-<a id="routes-any"></a>
-
-### Routes Any
 
 <a id="routes-custom"></a>
 
 ### Routes Custom
 
-`alertlabel` - (Optional) AlertLabel. AlertLabel to configure the alert policy rule. See [Alertlabel](#routes-custom-alertlabel) below.
+`alertlabel` - (Optional) AlertLabel. AlertLabel to configure the alert policy rule (`Block`).
 
 `alertname` - (Optional) Label Matcher. See [Alertname](#routes-custom-alertname) below.
 
 `group` - (Optional) Label Matcher. See [Group](#routes-custom-group) below.
 
 `severity` - (Optional) Label Matcher. See [Severity](#routes-custom-severity) below.
-
-<a id="routes-custom-alertlabel"></a>
-
-### Routes Custom Alertlabel
 
 <a id="routes-custom-alertname"></a>
 
@@ -200,10 +180,6 @@ In addition to all arguments above, the following attributes are exported:
 
 `regex_match` - (Optional) RegEx Match. Regular expression match value for the label (`String`).
 
-<a id="routes-dont-send"></a>
-
-### Routes Dont Send
-
 <a id="routes-group"></a>
 
 ### Routes Group
@@ -216,39 +192,23 @@ In addition to all arguments above, the following attributes are exported:
 
 `custom` - (Optional) Custom Group By. Specify list of custom labels to group/aggregate the alerts. See [Custom](#routes-notification-parameters-custom) below.
 
-`default` - (Optional) Empty. This can be used for messages where no values are needed. See [Default](#routes-notification-parameters-default) below.
+`default` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `group_interval` - (Optional) Notify Interval for a Group. Group Interval is used to specify how long to wait before sending a notification about new alerts that are added to the group for which an initial notification has already been sent. Format: [0-9]\[smhd], where s - seconds, m - minutes, h - hours, d - days If not specified, group_interval defaults to '1m' (`String`).
 
 `group_wait` - (Optional) Wait to Notify. Time value used to specify how long to initially wait for an inhibiting alert to arrive or collect more alerts for the same group. Format: [0-9]\[smhd], where s - seconds, m - minutes, h - hours, d - days If not specified, group_wait defaults to '30s' (`String`).
 
-`individual` - (Optional) Empty. This can be used for messages where no values are needed. See [Individual](#routes-notification-parameters-individual) below.
+`individual` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `repeat_interval` - (Optional) Notify Interval For a Alert. Repeat Interval is used to specify how long to wait before sending a notification again if it has already been sent successfully. Format: [0-9]\[smhd], where s - seconds, m - minutes, h - hours, d - days If not specified, group_interval defaults to '4h' (`String`).
 
-`ves_io_group` - (Optional) Empty. This can be used for messages where no values are needed. See [Ves Io Group](#routes-notification-parameters-ves-io-group) below.
+`ves_io_group` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="routes-notification-parameters-custom"></a>
 
 ### Routes Notification Parameters Custom
 
 `labels` - (Optional) Labels. Name of labels to group/aggregate the alerts (`List`).
-
-<a id="routes-notification-parameters-default"></a>
-
-### Routes Notification Parameters Default
-
-<a id="routes-notification-parameters-individual"></a>
-
-### Routes Notification Parameters Individual
-
-<a id="routes-notification-parameters-ves-io-group"></a>
-
-### Routes Notification Parameters Ves Io Group
-
-<a id="routes-send"></a>
-
-### Routes Send
 
 <a id="routes-severity"></a>
 

--- a/docs/resources/alert_receiver.md
+++ b/docs/resources/alert_receiver.md
@@ -226,9 +226,9 @@ In addition to all arguments above, the following attributes are exported:
 
 `follow_redirects` - (Optional) Follow Redirects. Configure whether HTTP requests follow HTTP 3xx redirects (`Bool`).
 
-`no_authorization` - (Optional) Empty. This can be used for messages where no values are needed. See [No Authorization](#webhook-http-config-no-authorization) below.
+`no_authorization` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_tls` - (Optional) Empty. This can be used for messages where no values are needed. See [No TLS](#webhook-http-config-no-tls) below.
+`no_tls` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `use_tls` - (Optional) TLS Config. Configures the token request's TLS settings. See [Use TLS](#webhook-http-config-use-tls) below.
 
@@ -236,47 +236,27 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Webhook HTTP Config Auth Token
 
-`token` - (Optional) Secret. SecretType is used in an object to indicate a sensitive/confidential field. See [Token](#webhook-http-config-auth-token-token) below.
-
-<a id="webhook-http-config-auth-token-token"></a>
-
-### Webhook HTTP Config Auth Token Token
+`token` - (Optional) Secret. SecretType is used in an object to indicate a sensitive/confidential field (`Block`).
 
 <a id="webhook-http-config-basic-auth"></a>
 
 ### Webhook HTTP Config Basic Auth
 
-`password` - (Optional) Secret. SecretType is used in an object to indicate a sensitive/confidential field. See [Password](#webhook-http-config-basic-auth-password) below.
+`password` - (Optional) Secret. SecretType is used in an object to indicate a sensitive/confidential field (`Block`).
 
 `user_name` - (Optional) User Name. HTTP Basic Auth User Name (`String`).
-
-<a id="webhook-http-config-basic-auth-password"></a>
-
-### Webhook HTTP Config Basic Auth Password
 
 <a id="webhook-http-config-client-cert-obj"></a>
 
 ### Webhook HTTP Config Client Cert Obj
 
-`use_tls_obj` - (Optional) Certificate Object. Reference to client certificate object. See [Use TLS Obj](#webhook-http-config-client-cert-obj-use-tls-obj) below.
-
-<a id="webhook-http-config-client-cert-obj-use-tls-obj"></a>
-
-### Webhook HTTP Config Client Cert Obj Use TLS Obj
-
-<a id="webhook-http-config-no-authorization"></a>
-
-### Webhook HTTP Config No Authorization
-
-<a id="webhook-http-config-no-tls"></a>
-
-### Webhook HTTP Config No TLS
+`use_tls_obj` - (Optional) Certificate Object. Reference to client certificate object (`Block`).
 
 <a id="webhook-http-config-use-tls"></a>
 
 ### Webhook HTTP Config Use TLS
 
-`disable_sni` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Sni](#webhook-http-config-use-tls-disable-sni) below.
+`disable_sni` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `max_version` - (Optional) TLS Protocol. TlsProtocol is enumeration of supported TLS versions F5 Distributed Cloud will choose the optimal TLS version. Possible values are `TLS_AUTO`, `TLSv1_0`, `TLSv1_1`, `TLSv1_2`, `TLSv1_3`. Defaults to `TLS_AUTO` (`String`).
 
@@ -284,21 +264,9 @@ In addition to all arguments above, the following attributes are exported:
 
 `sni` - (Optional) SNI Value. SNI value to be used (`String`).
 
-`use_server_verification` - (Optional) TLS Validation Context for Servers. Upstream TLS Validation Context. See [Use Server Verification](#webhook-http-config-use-tls-use-server-verification) below.
+`use_server_verification` - (Optional) TLS Validation Context for Servers. Upstream TLS Validation Context (`Block`).
 
-`volterra_trusted_ca` - (Optional) Empty. This can be used for messages where no values are needed. See [Volterra Trusted CA](#webhook-http-config-use-tls-volterra-trusted-ca) below.
-
-<a id="webhook-http-config-use-tls-disable-sni"></a>
-
-### Webhook HTTP Config Use TLS Disable Sni
-
-<a id="webhook-http-config-use-tls-use-server-verification"></a>
-
-### Webhook HTTP Config Use TLS Use Server Verification
-
-<a id="webhook-http-config-use-tls-volterra-trusted-ca"></a>
-
-### Webhook HTTP Config Use TLS Volterra Trusted CA
+`volterra_trusted_ca` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="webhook-url"></a>
 

--- a/docs/resources/api_crawler.md
+++ b/docs/resources/api_crawler.md
@@ -94,17 +94,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Domains Simple Login Password
 
-`blindfold_secret_info` - (Optional) Blindfold Secret. BlindfoldSecretInfoType specifies information about the Secret managed by F5XC Secret Management. See [Blindfold Secret Info](#domains-simple-login-password-blindfold-secret-info) below.
+`blindfold_secret_info` - (Optional) Blindfold Secret. BlindfoldSecretInfoType specifies information about the Secret managed by F5XC Secret Management (`Block`).
 
-`clear_secret_info` - (Optional) In-Clear Secret. ClearSecretInfoType specifies information about the Secret that is not encrypted. See [Clear Secret Info](#domains-simple-login-password-clear-secret-info) below.
-
-<a id="domains-simple-login-password-blindfold-secret-info"></a>
-
-### Domains Simple Login Password Blindfold Secret Info
-
-<a id="domains-simple-login-password-clear-secret-info"></a>
-
-### Domains Simple Login Password Clear Secret Info
+`clear_secret_info` - (Optional) In-Clear Secret. ClearSecretInfoType specifies information about the Secret that is not encrypted (`Block`).
 
 <a id="timeouts"></a>
 

--- a/docs/resources/api_definition.md
+++ b/docs/resources/api_definition.md
@@ -61,9 +61,9 @@ resource "f5xc_api_definition" "example" {
 
 > **Note:** One of the arguments from this list "mixed_schema_origin, strict_schema_origin" must be set.
 
-`mixed_schema_origin` - (Optional) Empty. This can be used for messages where no values are needed. See [Mixed Schema Origin](#mixed-schema-origin) below for details.
+`mixed_schema_origin` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`strict_schema_origin` - (Optional) Empty. This can be used for messages where no values are needed. See [Strict Schema Origin](#strict-schema-origin) below for details.
+`strict_schema_origin` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `non_api_endpoints` - (Optional) API Discovery Exclusion List. List of Non-API Endpoints. See [Non API Endpoints](#non-api-endpoints) below for details.
 
@@ -95,10 +95,6 @@ In addition to all arguments above, the following attributes are exported:
 
 `path` - (Optional) Path. An endpoint path, as specified in OpenAPI, including parameters. The path should comply with RFC 3986 and may have parameters according to OpenAPI specification (`String`).
 
-<a id="mixed-schema-origin"></a>
-
-### Mixed Schema Origin
-
 <a id="non-api-endpoints"></a>
 
 ### Non API Endpoints
@@ -106,10 +102,6 @@ In addition to all arguments above, the following attributes are exported:
 `method` - (Optional) HTTP Method. Specifies the HTTP method used to access a resource. Any HTTP Method. Possible values include `ANY`, `GET`, `HEAD`, `POST`, `PUT`, `DELETE`, `CONNECT`, `OPTIONS`, `TRACE`, `PATCH`, and others. Defaults to `ANY` (`String`).
 
 `path` - (Optional) Path. An endpoint path, as specified in OpenAPI, including parameters. The path should comply with RFC 3986 and may have parameters according to OpenAPI specification (`String`).
-
-<a id="strict-schema-origin"></a>
-
-### Strict Schema Origin
 
 <a id="timeouts"></a>
 

--- a/docs/resources/api_testing.md
+++ b/docs/resources/api_testing.md
@@ -68,11 +68,11 @@ resource "f5xc_api_testing" "example" {
 
 > **Note:** One of the arguments from this list "every_day, every_month, every_week" must be set.
 
-`every_day` - (Optional) Empty. This can be used for messages where no values are needed. See [Every Day](#every-day) below for details.
+`every_day` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`every_month` - (Optional) Empty. This can be used for messages where no values are needed. See [Every Month](#every-month) below for details.
+`every_month` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`every_week` - (Optional) Empty. This can be used for messages where no values are needed. See [Every Week](#every-week) below for details.
+`every_week` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `timeouts` - (Optional) See [Timeouts](#timeouts) below for details.
 
@@ -98,7 +98,7 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Domains Credentials
 
-`admin` - (Optional) Empty. This can be used for messages where no values are needed. See [Admin](#domains-credentials-admin) below.
+`admin` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `api_key` - (Optional) API Key. See [API Key](#domains-credentials-api-key) below.
 
@@ -110,11 +110,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `login_endpoint` - (Optional) Login Endpoint. See [Login Endpoint](#domains-credentials-login-endpoint) below.
 
-`standard` - (Optional) Empty. This can be used for messages where no values are needed. See [Standard](#domains-credentials-standard) below.
-
-<a id="domains-credentials-admin"></a>
-
-### Domains Credentials Admin
+`standard` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="domains-credentials-api-key"></a>
 
@@ -122,65 +118,33 @@ In addition to all arguments above, the following attributes are exported:
 
 `key` - (Optional) Key (`String`).
 
-`value` - (Optional) Secret. SecretType is used in an object to indicate a sensitive/confidential field. See [Value](#domains-credentials-api-key-value) below.
-
-<a id="domains-credentials-api-key-value"></a>
-
-### Domains Credentials API Key Value
+`value` - (Optional) Secret. SecretType is used in an object to indicate a sensitive/confidential field (`Block`).
 
 <a id="domains-credentials-basic-auth"></a>
 
 ### Domains Credentials Basic Auth
 
-`password` - (Optional) Secret. SecretType is used in an object to indicate a sensitive/confidential field. See [Password](#domains-credentials-basic-auth-password) below.
+`password` - (Optional) Secret. SecretType is used in an object to indicate a sensitive/confidential field (`Block`).
 
 `user` - (Optional) User (`String`).
-
-<a id="domains-credentials-basic-auth-password"></a>
-
-### Domains Credentials Basic Auth Password
 
 <a id="domains-credentials-bearer-token"></a>
 
 ### Domains Credentials Bearer Token
 
-`token` - (Optional) Secret. SecretType is used in an object to indicate a sensitive/confidential field. See [Token](#domains-credentials-bearer-token-token) below.
-
-<a id="domains-credentials-bearer-token-token"></a>
-
-### Domains Credentials Bearer Token Token
+`token` - (Optional) Secret. SecretType is used in an object to indicate a sensitive/confidential field (`Block`).
 
 <a id="domains-credentials-login-endpoint"></a>
 
 ### Domains Credentials Login Endpoint
 
-`json_payload` - (Optional) Secret. SecretType is used in an object to indicate a sensitive/confidential field. See [JSON Payload](#domains-credentials-login-endpoint-json-payload) below.
+`json_payload` - (Optional) Secret. SecretType is used in an object to indicate a sensitive/confidential field (`Block`).
 
 `method` - (Optional) HTTP Method. Specifies the HTTP method used to access a resource. Any HTTP Method. Possible values include `ANY`, `GET`, `HEAD`, `POST`, `PUT`, `DELETE`, `CONNECT`, `OPTIONS`, `TRACE`, `PATCH`, and others. Defaults to `ANY` (`String`).
 
 `path` - (Optional) Path (`String`).
 
 `token_response_key` - (Optional) Token Response Key (`String`).
-
-<a id="domains-credentials-login-endpoint-json-payload"></a>
-
-### Domains Credentials Login Endpoint JSON Payload
-
-<a id="domains-credentials-standard"></a>
-
-### Domains Credentials Standard
-
-<a id="every-day"></a>
-
-### Every Day
-
-<a id="every-month"></a>
-
-### Every Month
-
-<a id="every-week"></a>
-
-### Every Week
 
 <a id="timeouts"></a>
 

--- a/docs/resources/apm.md
+++ b/docs/resources/apm.md
@@ -104,153 +104,73 @@ In addition to all arguments above, the following attributes are exported:
 
 `ssh_key` - (Optional) Public SSH key. Public SSH key for accessing the BIG-IP nodes (`String`).
 
-`tags` - (Optional) AWS Tags. AWS Tags is a label consisting of a user-defined key and value. It helps to manage, identify, organize, search for, and filter resources in AWS console. See [Tags](#aws-site-type-choice-apm-aws-site-tags) below.
+`tags` - (Optional) AWS Tags. AWS Tags is a label consisting of a user-defined key and value. It helps to manage, identify, organize, search for, and filter resources in AWS console (`Block`).
 
 <a id="aws-site-type-choice-apm-aws-site-admin-password"></a>
 
 ### AWS Site Type Choice Apm AWS Site Admin Password
 
-`blindfold_secret_info` - (Optional) Blindfold Secret. BlindfoldSecretInfoType specifies information about the Secret managed by F5XC Secret Management. See [Blindfold Secret Info](#aws-site-type-choice-apm-aws-site-admin-password-blindfold-secret-info) below.
+`blindfold_secret_info` - (Optional) Blindfold Secret. BlindfoldSecretInfoType specifies information about the Secret managed by F5XC Secret Management (`Block`).
 
-`clear_secret_info` - (Optional) In-Clear Secret. ClearSecretInfoType specifies information about the Secret that is not encrypted. See [Clear Secret Info](#aws-site-type-choice-apm-aws-site-admin-password-clear-secret-info) below.
-
-<a id="aws-site-type-choice-apm-aws-site-admin-password-blindfold-secret-info"></a>
-
-### AWS Site Type Choice Apm AWS Site Admin Password Blindfold Secret Info
-
-<a id="aws-site-type-choice-apm-aws-site-admin-password-clear-secret-info"></a>
-
-### AWS Site Type Choice Apm AWS Site Admin Password Clear Secret Info
+`clear_secret_info` - (Optional) In-Clear Secret. ClearSecretInfoType specifies information about the Secret that is not encrypted (`Block`).
 
 <a id="aws-site-type-choice-apm-aws-site-aws-tgw-site"></a>
 
 ### AWS Site Type Choice Apm AWS Site AWS Tgw Site
 
-`aws_tgw_site` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [AWS Tgw Site](#aws-site-type-choice-apm-aws-site-aws-tgw-site-aws-tgw-site) below.
-
-<a id="aws-site-type-choice-apm-aws-site-aws-tgw-site-aws-tgw-site"></a>
-
-### AWS Site Type Choice Apm AWS Site AWS Tgw Site AWS Tgw Site
+`aws_tgw_site` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name (`Block`).
 
 <a id="aws-site-type-choice-apm-aws-site-endpoint-service"></a>
 
 ### AWS Site Type Choice Apm AWS Site Endpoint Service
 
-`advertise_on_slo_ip` - (Optional) Empty. This can be used for messages where no values are needed. See [Advertise On Slo IP](#aws-site-type-choice-apm-aws-site-endpoint-service-advertise-on-slo-ip) below.
+`advertise_on_slo_ip` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`advertise_on_slo_ip_external` - (Optional) Empty. This can be used for messages where no values are needed. See [Advertise On Slo IP External](#aws-site-type-choice-apm-aws-site-endpoint-service-advertise-on-slo-ip-external) below.
+`advertise_on_slo_ip_external` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`automatic_vip` - (Optional) Empty. This can be used for messages where no values are needed. See [Automatic VIP](#aws-site-type-choice-apm-aws-site-endpoint-service-automatic-vip) below.
+`automatic_vip` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `configured_vip` - (Optional) Configured VIP. Enter IP address for the default VIP (`String`).
 
-`custom_tcp_ports` - (Optional) Port Range List. List of port ranges. See [Custom TCP Ports](#aws-site-type-choice-apm-aws-site-endpoint-service-custom-tcp-ports) below.
+`custom_tcp_ports` - (Optional) Port Range List. List of port ranges (`Block`).
 
-`custom_udp_ports` - (Optional) Port Range List. List of port ranges. See [Custom UDP Ports](#aws-site-type-choice-apm-aws-site-endpoint-service-custom-udp-ports) below.
+`custom_udp_ports` - (Optional) Port Range List. List of port ranges (`Block`).
 
-`default_tcp_ports` - (Optional) Empty. This can be used for messages where no values are needed. See [Default TCP Ports](#aws-site-type-choice-apm-aws-site-endpoint-service-default-tcp-ports) below.
+`default_tcp_ports` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`disable_advertise_on_slo_ip` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Advertise On Slo IP](#aws-site-type-choice-apm-aws-site-endpoint-service-disable-advertise-on-slo-ip) below.
+`disable_advertise_on_slo_ip` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`http_port` - (Optional) Empty. This can be used for messages where no values are needed. See [HTTP Port](#aws-site-type-choice-apm-aws-site-endpoint-service-http-port) below.
+`http_port` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`https_port` - (Optional) Empty. This can be used for messages where no values are needed. See [HTTPS Port](#aws-site-type-choice-apm-aws-site-endpoint-service-https-port) below.
+`https_port` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_tcp_ports` - (Optional) Empty. This can be used for messages where no values are needed. See [No TCP Ports](#aws-site-type-choice-apm-aws-site-endpoint-service-no-tcp-ports) below.
+`no_tcp_ports` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_udp_ports` - (Optional) Empty. This can be used for messages where no values are needed. See [No UDP Ports](#aws-site-type-choice-apm-aws-site-endpoint-service-no-udp-ports) below.
-
-<a id="aws-site-type-choice-apm-aws-site-endpoint-service-advertise-on-slo-ip"></a>
-
-### AWS Site Type Choice Apm AWS Site Endpoint Service Advertise On Slo IP
-
-<a id="aws-site-type-choice-apm-aws-site-endpoint-service-advertise-on-slo-ip-external"></a>
-
-### AWS Site Type Choice Apm AWS Site Endpoint Service Advertise On Slo IP External
-
-<a id="aws-site-type-choice-apm-aws-site-endpoint-service-automatic-vip"></a>
-
-### AWS Site Type Choice Apm AWS Site Endpoint Service Automatic VIP
-
-<a id="aws-site-type-choice-apm-aws-site-endpoint-service-custom-tcp-ports"></a>
-
-### AWS Site Type Choice Apm AWS Site Endpoint Service Custom TCP Ports
-
-<a id="aws-site-type-choice-apm-aws-site-endpoint-service-custom-udp-ports"></a>
-
-### AWS Site Type Choice Apm AWS Site Endpoint Service Custom UDP Ports
-
-<a id="aws-site-type-choice-apm-aws-site-endpoint-service-default-tcp-ports"></a>
-
-### AWS Site Type Choice Apm AWS Site Endpoint Service Default TCP Ports
-
-<a id="aws-site-type-choice-apm-aws-site-endpoint-service-disable-advertise-on-slo-ip"></a>
-
-### AWS Site Type Choice Apm AWS Site Endpoint Service Disable Advertise On Slo IP
-
-<a id="aws-site-type-choice-apm-aws-site-endpoint-service-http-port"></a>
-
-### AWS Site Type Choice Apm AWS Site Endpoint Service HTTP Port
-
-<a id="aws-site-type-choice-apm-aws-site-endpoint-service-https-port"></a>
-
-### AWS Site Type Choice Apm AWS Site Endpoint Service HTTPS Port
-
-<a id="aws-site-type-choice-apm-aws-site-endpoint-service-no-tcp-ports"></a>
-
-### AWS Site Type Choice Apm AWS Site Endpoint Service No TCP Ports
-
-<a id="aws-site-type-choice-apm-aws-site-endpoint-service-no-udp-ports"></a>
-
-### AWS Site Type Choice Apm AWS Site Endpoint Service No UDP Ports
+`no_udp_ports` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="aws-site-type-choice-apm-aws-site-nodes"></a>
 
 ### AWS Site Type Choice Apm AWS Site Nodes
 
-`automatic_prefix` - (Optional) Empty. This can be used for messages where no values are needed. See [Automatic Prefix](#aws-site-type-choice-apm-aws-site-nodes-automatic-prefix) below.
+`automatic_prefix` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `aws_az_name` - (Optional) AWS AZ Name. The AWS Availability Zone must be consistent with the AWS Region chosen. Please select an AZ in the same Region as your TGW Site (`String`).
 
-`mgmt_subnet` - (Optional) AWS Subnet. Parameters for AWS subnet. See [Mgmt Subnet](#aws-site-type-choice-apm-aws-site-nodes-mgmt-subnet) below.
+`mgmt_subnet` - (Optional) AWS Subnet. Parameters for AWS subnet (`Block`).
 
 `node_name` - (Optional) Node Name. Node Name will be used to assign as hostname to the service (`String`).
 
-`reserved_mgmt_subnet` - (Optional) Empty. This can be used for messages where no values are needed. See [Reserved Mgmt Subnet](#aws-site-type-choice-apm-aws-site-nodes-reserved-mgmt-subnet) below.
+`reserved_mgmt_subnet` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `tunnel_prefix` - (Optional) Tunnel IP Prefix. Enter IP prefix for the tunnel, it has to be /30 (`String`).
-
-<a id="aws-site-type-choice-apm-aws-site-nodes-automatic-prefix"></a>
-
-### AWS Site Type Choice Apm AWS Site Nodes Automatic Prefix
-
-<a id="aws-site-type-choice-apm-aws-site-nodes-mgmt-subnet"></a>
-
-### AWS Site Type Choice Apm AWS Site Nodes Mgmt Subnet
-
-<a id="aws-site-type-choice-apm-aws-site-nodes-reserved-mgmt-subnet"></a>
-
-### AWS Site Type Choice Apm AWS Site Nodes Reserved Mgmt Subnet
-
-<a id="aws-site-type-choice-apm-aws-site-tags"></a>
-
-### AWS Site Type Choice Apm AWS Site Tags
 
 <a id="aws-site-type-choice-market-place-image"></a>
 
 ### AWS Site Type Choice Market Place Image
 
-`best_plus_pay_g200_mbps` - (Optional) Empty. This can be used for messages where no values are needed. See [Best Plus Pay G200 Mbps](#aws-site-type-choice-market-place-image-best-plus-pay-g200-mbps) below.
+`best_plus_pay_g200_mbps` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`best_plus_payg_1gbps` - (Optional) Empty. This can be used for messages where no values are needed. See [Best Plus Payg 1gbps](#aws-site-type-choice-market-place-image-best-plus-payg-1gbps) below.
-
-<a id="aws-site-type-choice-market-place-image-best-plus-pay-g200-mbps"></a>
-
-### AWS Site Type Choice Market Place Image Best Plus Pay G200 Mbps
-
-<a id="aws-site-type-choice-market-place-image-best-plus-payg-1gbps"></a>
-
-### AWS Site Type Choice Market Place Image Best Plus Payg 1gbps
+`best_plus_payg_1gbps` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="baremetal-site-type-choice"></a>
 
@@ -280,17 +200,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Baremetal Site Type Choice F5 Bare Metal Site Admin Password
 
-`blindfold_secret_info` - (Optional) Blindfold Secret. BlindfoldSecretInfoType specifies information about the Secret managed by F5XC Secret Management. See [Blindfold Secret Info](#baremetal-site-type-choice-f5-bare-metal-site-admin-password-blindfold-secret-info) below.
+`blindfold_secret_info` - (Optional) Blindfold Secret. BlindfoldSecretInfoType specifies information about the Secret managed by F5XC Secret Management (`Block`).
 
-`clear_secret_info` - (Optional) In-Clear Secret. ClearSecretInfoType specifies information about the Secret that is not encrypted. See [Clear Secret Info](#baremetal-site-type-choice-f5-bare-metal-site-admin-password-clear-secret-info) below.
-
-<a id="baremetal-site-type-choice-f5-bare-metal-site-admin-password-blindfold-secret-info"></a>
-
-### Baremetal Site Type Choice F5 Bare Metal Site Admin Password Blindfold Secret Info
-
-<a id="baremetal-site-type-choice-f5-bare-metal-site-admin-password-clear-secret-info"></a>
-
-### Baremetal Site Type Choice F5 Bare Metal Site Admin Password Clear Secret Info
+`clear_secret_info` - (Optional) In-Clear Secret. ClearSecretInfoType specifies information about the Secret that is not encrypted (`Block`).
 
 <a id="baremetal-site-type-choice-f5-bare-metal-site-bare-metal-site"></a>
 
@@ -310,15 +222,11 @@ In addition to all arguments above, the following attributes are exported:
 
 `license_server_ip` - (Optional) License Server IP. IP Address from the TCP Load Balancer which is configured to communicate with License Server (`String`).
 
-`password` - (Optional) Secret. SecretType is used in an object to indicate a sensitive/confidential field. See [Password](#baremetal-site-type-choice-f5-bare-metal-site-bigiq-instance-password) below.
+`password` - (Optional) Secret. SecretType is used in an object to indicate a sensitive/confidential field (`Block`).
 
 `sku_name` - (Optional) Offering Name. License offering name aka SKU name (`String`).
 
 `username` - (Optional) User Name. User Name used to access BIG-IQ to activate the license (`String`).
-
-<a id="baremetal-site-type-choice-f5-bare-metal-site-bigiq-instance-password"></a>
-
-### Baremetal Site Type Choice F5 Bare Metal Site Bigiq Instance Password
 
 <a id="baremetal-site-type-choice-f5-bare-metal-site-nodes"></a>
 
@@ -328,19 +236,11 @@ In addition to all arguments above, the following attributes are exported:
 
 `bm_virtual_cpu_count` - (Optional) Bare Metal ServiceNode Virtual CPU Count. Enum to define number of virtual CPU's to be assigned to the node - BM_4_VCPU: 4 virtual CPUs - BM_8_VCPU: 8 virtual CPUs. Possible values are `BM_4_VCPU`, `BM_8_VCPU`. Defaults to `BM_4_VCPU` (`String`).
 
-`external_interface` - (Optional) Interface. x-required BIG-IP interface details. See [External Interface](#baremetal-site-type-choice-f5-bare-metal-site-nodes-external-interface) below.
+`external_interface` - (Optional) Interface. x-required BIG-IP interface details (`Block`).
 
-`internal_interface` - (Optional) Interface. x-required BIG-IP interface details. See [Internal Interface](#baremetal-site-type-choice-f5-bare-metal-site-nodes-internal-interface) below.
+`internal_interface` - (Optional) Interface. x-required BIG-IP interface details (`Block`).
 
 `node_name` - (Optional) Node Name. Node Name will be used to assign as hostname to the service (`String`).
-
-<a id="baremetal-site-type-choice-f5-bare-metal-site-nodes-external-interface"></a>
-
-### Baremetal Site Type Choice F5 Bare Metal Site Nodes External Interface
-
-<a id="baremetal-site-type-choice-f5-bare-metal-site-nodes-internal-interface"></a>
-
-### Baremetal Site Type Choice F5 Bare Metal Site Nodes Internal Interface
 
 <a id="https-management"></a>
 
@@ -348,7 +248,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `advertise_on_internet` - (Optional) Advertise Public. This defines a way to advertise a load balancer on public. If optional public_ip is provided, it will only be advertised on RE sites where that public_ip is available. See [Advertise On Internet](#https-management-advertise-on-internet) below.
 
-`advertise_on_internet_default_vip` - (Optional) Empty. This can be used for messages where no values are needed. See [Advertise On Internet Default VIP](#https-management-advertise-on-internet-default-vip) below.
+`advertise_on_internet_default_vip` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `advertise_on_sli_vip` - (Optional) Inline TLS Parameters. Inline TLS parameters. See [Advertise On Sli VIP](#https-management-advertise-on-sli-vip) below.
 
@@ -358,7 +258,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `advertise_on_slo_vip` - (Optional) Inline TLS Parameters. Inline TLS parameters. See [Advertise On Slo VIP](#https-management-advertise-on-slo-vip) below.
 
-`default_https_port` - (Optional) Empty. This can be used for messages where no values are needed. See [Default HTTPS Port](#https-management-default-https-port) below.
+`default_https_port` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `domain_suffix` - (Optional) Domain Suffix. Domain suffix will be used along with node name to form URL to access node management (`String`).
 
@@ -380,15 +280,11 @@ In addition to all arguments above, the following attributes are exported:
 
 `tenant` - (Optional) Tenant. When a configuration object(e.g. virtual_host) refers to another(e.g route) then tenant will hold the referred object's(e.g. route's) tenant (`String`).
 
-<a id="https-management-advertise-on-internet-default-vip"></a>
-
-### HTTPS Management Advertise On Internet Default VIP
-
 <a id="https-management-advertise-on-sli-vip"></a>
 
 ### HTTPS Management Advertise On Sli VIP
 
-`no_mtls` - (Optional) Empty. This can be used for messages where no values are needed. See [No mTLS](#https-management-advertise-on-sli-vip-no-mtls) below.
+`no_mtls` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `tls_certificates` - (Optional) TLS Certificates. Users can add one or more certificates that share the same set of domains. for example, domain.com and *.domain.com - but use different signature algorithms. See [TLS Certificates](#https-management-advertise-on-sli-vip-tls-certificates) below.
 
@@ -396,69 +292,33 @@ In addition to all arguments above, the following attributes are exported:
 
 `use_mtls` - (Optional) Clients TLS validation context. Validation context for downstream client TLS connections. See [Use mTLS](#https-management-advertise-on-sli-vip-use-mtls) below.
 
-<a id="https-management-advertise-on-sli-vip-no-mtls"></a>
-
-### HTTPS Management Advertise On Sli VIP No mTLS
-
 <a id="https-management-advertise-on-sli-vip-tls-certificates"></a>
 
 ### HTTPS Management Advertise On Sli VIP TLS Certificates
 
 `certificate_url` - (Optional) Certificate. TLS certificate. Certificate or certificate chain in PEM format including the PEM headers (`String`).
 
-`custom_hash_algorithms` - (Optional) Hash Algorithms. Specifies the hash algorithms to be used. See [Custom Hash Algorithms](#https-management-advertise-on-sli-vip-tls-certificates-custom-hash-algorithms) below.
+`custom_hash_algorithms` - (Optional) Hash Algorithms. Specifies the hash algorithms to be used (`Block`).
 
 `description` - (Optional) Configuration for description (`String`).
 
-`disable_ocsp_stapling` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable OCSP Stapling](#https-management-advertise-on-sli-vip-tls-certificates-disable-ocsp-stapling) below.
+`disable_ocsp_stapling` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`private_key` - (Optional) Secret. SecretType is used in an object to indicate a sensitive/confidential field. See [Private Key](#https-management-advertise-on-sli-vip-tls-certificates-private-key) below.
+`private_key` - (Optional) Secret. SecretType is used in an object to indicate a sensitive/confidential field (`Block`).
 
-`use_system_defaults` - (Optional) Empty. This can be used for messages where no values are needed. See [Use System Defaults](#https-management-advertise-on-sli-vip-tls-certificates-use-system-defaults) below.
-
-<a id="https-management-advertise-on-sli-vip-tls-certificates-custom-hash-algorithms"></a>
-
-### HTTPS Management Advertise On Sli VIP TLS Certificates Custom Hash Algorithms
-
-<a id="https-management-advertise-on-sli-vip-tls-certificates-disable-ocsp-stapling"></a>
-
-### HTTPS Management Advertise On Sli VIP TLS Certificates Disable OCSP Stapling
-
-<a id="https-management-advertise-on-sli-vip-tls-certificates-private-key"></a>
-
-### HTTPS Management Advertise On Sli VIP TLS Certificates Private Key
-
-<a id="https-management-advertise-on-sli-vip-tls-certificates-use-system-defaults"></a>
-
-### HTTPS Management Advertise On Sli VIP TLS Certificates Use System Defaults
+`use_system_defaults` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="https-management-advertise-on-sli-vip-tls-config"></a>
 
 ### HTTPS Management Advertise On Sli VIP TLS Config
 
-`custom_security` - (Optional) Custom Ciphers. This defines TLS protocol config including min/max versions and allowed ciphers. See [Custom Security](#https-management-advertise-on-sli-vip-tls-config-custom-security) below.
+`custom_security` - (Optional) Custom Ciphers. This defines TLS protocol config including min/max versions and allowed ciphers (`Block`).
 
-`default_security` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Security](#https-management-advertise-on-sli-vip-tls-config-default-security) below.
+`default_security` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`low_security` - (Optional) Empty. This can be used for messages where no values are needed. See [Low Security](#https-management-advertise-on-sli-vip-tls-config-low-security) below.
+`low_security` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`medium_security` - (Optional) Empty. This can be used for messages where no values are needed. See [Medium Security](#https-management-advertise-on-sli-vip-tls-config-medium-security) below.
-
-<a id="https-management-advertise-on-sli-vip-tls-config-custom-security"></a>
-
-### HTTPS Management Advertise On Sli VIP TLS Config Custom Security
-
-<a id="https-management-advertise-on-sli-vip-tls-config-default-security"></a>
-
-### HTTPS Management Advertise On Sli VIP TLS Config Default Security
-
-<a id="https-management-advertise-on-sli-vip-tls-config-low-security"></a>
-
-### HTTPS Management Advertise On Sli VIP TLS Config Low Security
-
-<a id="https-management-advertise-on-sli-vip-tls-config-medium-security"></a>
-
-### HTTPS Management Advertise On Sli VIP TLS Config Medium Security
+`medium_security` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="https-management-advertise-on-sli-vip-use-mtls"></a>
 
@@ -466,43 +326,23 @@ In addition to all arguments above, the following attributes are exported:
 
 `client_certificate_optional` - (Optional) Client Certificate Optional. Client certificate is optional. If the client has provided a certificate, the load balancer will verify it. If certification verification fails, the connection will be terminated. If the client does not provide a certificate, the connection will be accepted (`Bool`).
 
-`crl` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [CRL](#https-management-advertise-on-sli-vip-use-mtls-crl) below.
+`crl` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name (`Block`).
 
-`no_crl` - (Optional) Empty. This can be used for messages where no values are needed. See [No CRL](#https-management-advertise-on-sli-vip-use-mtls-no-crl) below.
+`no_crl` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`trusted_ca` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Trusted CA](#https-management-advertise-on-sli-vip-use-mtls-trusted-ca) below.
+`trusted_ca` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name (`Block`).
 
 `trusted_ca_url` - (Optional) Inline Root CA Certificate (legacy). Upload a Root CA Certificate specifically for this Load Balancer (`String`).
 
-`xfcc_disabled` - (Optional) Empty. This can be used for messages where no values are needed. See [Xfcc Disabled](#https-management-advertise-on-sli-vip-use-mtls-xfcc-disabled) below.
+`xfcc_disabled` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`xfcc_options` - (Optional) XFCC Header Elements. X-Forwarded-Client-Cert header elements to be added to requests. See [Xfcc Options](#https-management-advertise-on-sli-vip-use-mtls-xfcc-options) below.
-
-<a id="https-management-advertise-on-sli-vip-use-mtls-crl"></a>
-
-### HTTPS Management Advertise On Sli VIP Use mTLS CRL
-
-<a id="https-management-advertise-on-sli-vip-use-mtls-no-crl"></a>
-
-### HTTPS Management Advertise On Sli VIP Use mTLS No CRL
-
-<a id="https-management-advertise-on-sli-vip-use-mtls-trusted-ca"></a>
-
-### HTTPS Management Advertise On Sli VIP Use mTLS Trusted CA
-
-<a id="https-management-advertise-on-sli-vip-use-mtls-xfcc-disabled"></a>
-
-### HTTPS Management Advertise On Sli VIP Use mTLS Xfcc Disabled
-
-<a id="https-management-advertise-on-sli-vip-use-mtls-xfcc-options"></a>
-
-### HTTPS Management Advertise On Sli VIP Use mTLS Xfcc Options
+`xfcc_options` - (Optional) XFCC Header Elements. X-Forwarded-Client-Cert header elements to be added to requests (`Block`).
 
 <a id="https-management-advertise-on-slo-internet-vip"></a>
 
 ### HTTPS Management Advertise On Slo Internet VIP
 
-`no_mtls` - (Optional) Empty. This can be used for messages where no values are needed. See [No mTLS](#https-management-advertise-on-slo-internet-vip-no-mtls) below.
+`no_mtls` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `tls_certificates` - (Optional) TLS Certificates. Users can add one or more certificates that share the same set of domains. for example, domain.com and *.domain.com - but use different signature algorithms. See [TLS Certificates](#https-management-advertise-on-slo-internet-vip-tls-certificates) below.
 
@@ -510,69 +350,33 @@ In addition to all arguments above, the following attributes are exported:
 
 `use_mtls` - (Optional) Clients TLS validation context. Validation context for downstream client TLS connections. See [Use mTLS](#https-management-advertise-on-slo-internet-vip-use-mtls) below.
 
-<a id="https-management-advertise-on-slo-internet-vip-no-mtls"></a>
-
-### HTTPS Management Advertise On Slo Internet VIP No mTLS
-
 <a id="https-management-advertise-on-slo-internet-vip-tls-certificates"></a>
 
 ### HTTPS Management Advertise On Slo Internet VIP TLS Certificates
 
 `certificate_url` - (Optional) Certificate. TLS certificate. Certificate or certificate chain in PEM format including the PEM headers (`String`).
 
-`custom_hash_algorithms` - (Optional) Hash Algorithms. Specifies the hash algorithms to be used. See [Custom Hash Algorithms](#https-management-advertise-on-slo-internet-vip-tls-certificates-custom-hash-algorithms) below.
+`custom_hash_algorithms` - (Optional) Hash Algorithms. Specifies the hash algorithms to be used (`Block`).
 
 `description` - (Optional) Configuration for description (`String`).
 
-`disable_ocsp_stapling` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable OCSP Stapling](#https-management-advertise-on-slo-internet-vip-tls-certificates-disable-ocsp-stapling) below.
+`disable_ocsp_stapling` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`private_key` - (Optional) Secret. SecretType is used in an object to indicate a sensitive/confidential field. See [Private Key](#https-management-advertise-on-slo-internet-vip-tls-certificates-private-key) below.
+`private_key` - (Optional) Secret. SecretType is used in an object to indicate a sensitive/confidential field (`Block`).
 
-`use_system_defaults` - (Optional) Empty. This can be used for messages where no values are needed. See [Use System Defaults](#https-management-advertise-on-slo-internet-vip-tls-certificates-use-system-defaults) below.
-
-<a id="https-management-advertise-on-slo-internet-vip-tls-certificates-custom-hash-algorithms"></a>
-
-### HTTPS Management Advertise On Slo Internet VIP TLS Certificates Custom Hash Algorithms
-
-<a id="https-management-advertise-on-slo-internet-vip-tls-certificates-disable-ocsp-stapling"></a>
-
-### HTTPS Management Advertise On Slo Internet VIP TLS Certificates Disable OCSP Stapling
-
-<a id="https-management-advertise-on-slo-internet-vip-tls-certificates-private-key"></a>
-
-### HTTPS Management Advertise On Slo Internet VIP TLS Certificates Private Key
-
-<a id="https-management-advertise-on-slo-internet-vip-tls-certificates-use-system-defaults"></a>
-
-### HTTPS Management Advertise On Slo Internet VIP TLS Certificates Use System Defaults
+`use_system_defaults` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="https-management-advertise-on-slo-internet-vip-tls-config"></a>
 
 ### HTTPS Management Advertise On Slo Internet VIP TLS Config
 
-`custom_security` - (Optional) Custom Ciphers. This defines TLS protocol config including min/max versions and allowed ciphers. See [Custom Security](#https-management-advertise-on-slo-internet-vip-tls-config-custom-security) below.
+`custom_security` - (Optional) Custom Ciphers. This defines TLS protocol config including min/max versions and allowed ciphers (`Block`).
 
-`default_security` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Security](#https-management-advertise-on-slo-internet-vip-tls-config-default-security) below.
+`default_security` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`low_security` - (Optional) Empty. This can be used for messages where no values are needed. See [Low Security](#https-management-advertise-on-slo-internet-vip-tls-config-low-security) below.
+`low_security` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`medium_security` - (Optional) Empty. This can be used for messages where no values are needed. See [Medium Security](#https-management-advertise-on-slo-internet-vip-tls-config-medium-security) below.
-
-<a id="https-management-advertise-on-slo-internet-vip-tls-config-custom-security"></a>
-
-### HTTPS Management Advertise On Slo Internet VIP TLS Config Custom Security
-
-<a id="https-management-advertise-on-slo-internet-vip-tls-config-default-security"></a>
-
-### HTTPS Management Advertise On Slo Internet VIP TLS Config Default Security
-
-<a id="https-management-advertise-on-slo-internet-vip-tls-config-low-security"></a>
-
-### HTTPS Management Advertise On Slo Internet VIP TLS Config Low Security
-
-<a id="https-management-advertise-on-slo-internet-vip-tls-config-medium-security"></a>
-
-### HTTPS Management Advertise On Slo Internet VIP TLS Config Medium Security
+`medium_security` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="https-management-advertise-on-slo-internet-vip-use-mtls"></a>
 
@@ -580,43 +384,23 @@ In addition to all arguments above, the following attributes are exported:
 
 `client_certificate_optional` - (Optional) Client Certificate Optional. Client certificate is optional. If the client has provided a certificate, the load balancer will verify it. If certification verification fails, the connection will be terminated. If the client does not provide a certificate, the connection will be accepted (`Bool`).
 
-`crl` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [CRL](#https-management-advertise-on-slo-internet-vip-use-mtls-crl) below.
+`crl` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name (`Block`).
 
-`no_crl` - (Optional) Empty. This can be used for messages where no values are needed. See [No CRL](#https-management-advertise-on-slo-internet-vip-use-mtls-no-crl) below.
+`no_crl` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`trusted_ca` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Trusted CA](#https-management-advertise-on-slo-internet-vip-use-mtls-trusted-ca) below.
+`trusted_ca` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name (`Block`).
 
 `trusted_ca_url` - (Optional) Inline Root CA Certificate (legacy). Upload a Root CA Certificate specifically for this Load Balancer (`String`).
 
-`xfcc_disabled` - (Optional) Empty. This can be used for messages where no values are needed. See [Xfcc Disabled](#https-management-advertise-on-slo-internet-vip-use-mtls-xfcc-disabled) below.
+`xfcc_disabled` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`xfcc_options` - (Optional) XFCC Header Elements. X-Forwarded-Client-Cert header elements to be added to requests. See [Xfcc Options](#https-management-advertise-on-slo-internet-vip-use-mtls-xfcc-options) below.
-
-<a id="https-management-advertise-on-slo-internet-vip-use-mtls-crl"></a>
-
-### HTTPS Management Advertise On Slo Internet VIP Use mTLS CRL
-
-<a id="https-management-advertise-on-slo-internet-vip-use-mtls-no-crl"></a>
-
-### HTTPS Management Advertise On Slo Internet VIP Use mTLS No CRL
-
-<a id="https-management-advertise-on-slo-internet-vip-use-mtls-trusted-ca"></a>
-
-### HTTPS Management Advertise On Slo Internet VIP Use mTLS Trusted CA
-
-<a id="https-management-advertise-on-slo-internet-vip-use-mtls-xfcc-disabled"></a>
-
-### HTTPS Management Advertise On Slo Internet VIP Use mTLS Xfcc Disabled
-
-<a id="https-management-advertise-on-slo-internet-vip-use-mtls-xfcc-options"></a>
-
-### HTTPS Management Advertise On Slo Internet VIP Use mTLS Xfcc Options
+`xfcc_options` - (Optional) XFCC Header Elements. X-Forwarded-Client-Cert header elements to be added to requests (`Block`).
 
 <a id="https-management-advertise-on-slo-sli"></a>
 
 ### HTTPS Management Advertise On Slo Sli
 
-`no_mtls` - (Optional) Empty. This can be used for messages where no values are needed. See [No mTLS](#https-management-advertise-on-slo-sli-no-mtls) below.
+`no_mtls` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `tls_certificates` - (Optional) TLS Certificates. Users can add one or more certificates that share the same set of domains. for example, domain.com and *.domain.com - but use different signature algorithms. See [TLS Certificates](#https-management-advertise-on-slo-sli-tls-certificates) below.
 
@@ -624,69 +408,33 @@ In addition to all arguments above, the following attributes are exported:
 
 `use_mtls` - (Optional) Clients TLS validation context. Validation context for downstream client TLS connections. See [Use mTLS](#https-management-advertise-on-slo-sli-use-mtls) below.
 
-<a id="https-management-advertise-on-slo-sli-no-mtls"></a>
-
-### HTTPS Management Advertise On Slo Sli No mTLS
-
 <a id="https-management-advertise-on-slo-sli-tls-certificates"></a>
 
 ### HTTPS Management Advertise On Slo Sli TLS Certificates
 
 `certificate_url` - (Optional) Certificate. TLS certificate. Certificate or certificate chain in PEM format including the PEM headers (`String`).
 
-`custom_hash_algorithms` - (Optional) Hash Algorithms. Specifies the hash algorithms to be used. See [Custom Hash Algorithms](#https-management-advertise-on-slo-sli-tls-certificates-custom-hash-algorithms) below.
+`custom_hash_algorithms` - (Optional) Hash Algorithms. Specifies the hash algorithms to be used (`Block`).
 
 `description` - (Optional) Configuration for description (`String`).
 
-`disable_ocsp_stapling` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable OCSP Stapling](#https-management-advertise-on-slo-sli-tls-certificates-disable-ocsp-stapling) below.
+`disable_ocsp_stapling` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`private_key` - (Optional) Secret. SecretType is used in an object to indicate a sensitive/confidential field. See [Private Key](#https-management-advertise-on-slo-sli-tls-certificates-private-key) below.
+`private_key` - (Optional) Secret. SecretType is used in an object to indicate a sensitive/confidential field (`Block`).
 
-`use_system_defaults` - (Optional) Empty. This can be used for messages where no values are needed. See [Use System Defaults](#https-management-advertise-on-slo-sli-tls-certificates-use-system-defaults) below.
-
-<a id="https-management-advertise-on-slo-sli-tls-certificates-custom-hash-algorithms"></a>
-
-### HTTPS Management Advertise On Slo Sli TLS Certificates Custom Hash Algorithms
-
-<a id="https-management-advertise-on-slo-sli-tls-certificates-disable-ocsp-stapling"></a>
-
-### HTTPS Management Advertise On Slo Sli TLS Certificates Disable OCSP Stapling
-
-<a id="https-management-advertise-on-slo-sli-tls-certificates-private-key"></a>
-
-### HTTPS Management Advertise On Slo Sli TLS Certificates Private Key
-
-<a id="https-management-advertise-on-slo-sli-tls-certificates-use-system-defaults"></a>
-
-### HTTPS Management Advertise On Slo Sli TLS Certificates Use System Defaults
+`use_system_defaults` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="https-management-advertise-on-slo-sli-tls-config"></a>
 
 ### HTTPS Management Advertise On Slo Sli TLS Config
 
-`custom_security` - (Optional) Custom Ciphers. This defines TLS protocol config including min/max versions and allowed ciphers. See [Custom Security](#https-management-advertise-on-slo-sli-tls-config-custom-security) below.
+`custom_security` - (Optional) Custom Ciphers. This defines TLS protocol config including min/max versions and allowed ciphers (`Block`).
 
-`default_security` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Security](#https-management-advertise-on-slo-sli-tls-config-default-security) below.
+`default_security` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`low_security` - (Optional) Empty. This can be used for messages where no values are needed. See [Low Security](#https-management-advertise-on-slo-sli-tls-config-low-security) below.
+`low_security` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`medium_security` - (Optional) Empty. This can be used for messages where no values are needed. See [Medium Security](#https-management-advertise-on-slo-sli-tls-config-medium-security) below.
-
-<a id="https-management-advertise-on-slo-sli-tls-config-custom-security"></a>
-
-### HTTPS Management Advertise On Slo Sli TLS Config Custom Security
-
-<a id="https-management-advertise-on-slo-sli-tls-config-default-security"></a>
-
-### HTTPS Management Advertise On Slo Sli TLS Config Default Security
-
-<a id="https-management-advertise-on-slo-sli-tls-config-low-security"></a>
-
-### HTTPS Management Advertise On Slo Sli TLS Config Low Security
-
-<a id="https-management-advertise-on-slo-sli-tls-config-medium-security"></a>
-
-### HTTPS Management Advertise On Slo Sli TLS Config Medium Security
+`medium_security` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="https-management-advertise-on-slo-sli-use-mtls"></a>
 
@@ -694,43 +442,23 @@ In addition to all arguments above, the following attributes are exported:
 
 `client_certificate_optional` - (Optional) Client Certificate Optional. Client certificate is optional. If the client has provided a certificate, the load balancer will verify it. If certification verification fails, the connection will be terminated. If the client does not provide a certificate, the connection will be accepted (`Bool`).
 
-`crl` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [CRL](#https-management-advertise-on-slo-sli-use-mtls-crl) below.
+`crl` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name (`Block`).
 
-`no_crl` - (Optional) Empty. This can be used for messages where no values are needed. See [No CRL](#https-management-advertise-on-slo-sli-use-mtls-no-crl) below.
+`no_crl` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`trusted_ca` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Trusted CA](#https-management-advertise-on-slo-sli-use-mtls-trusted-ca) below.
+`trusted_ca` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name (`Block`).
 
 `trusted_ca_url` - (Optional) Inline Root CA Certificate (legacy). Upload a Root CA Certificate specifically for this Load Balancer (`String`).
 
-`xfcc_disabled` - (Optional) Empty. This can be used for messages where no values are needed. See [Xfcc Disabled](#https-management-advertise-on-slo-sli-use-mtls-xfcc-disabled) below.
+`xfcc_disabled` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`xfcc_options` - (Optional) XFCC Header Elements. X-Forwarded-Client-Cert header elements to be added to requests. See [Xfcc Options](#https-management-advertise-on-slo-sli-use-mtls-xfcc-options) below.
-
-<a id="https-management-advertise-on-slo-sli-use-mtls-crl"></a>
-
-### HTTPS Management Advertise On Slo Sli Use mTLS CRL
-
-<a id="https-management-advertise-on-slo-sli-use-mtls-no-crl"></a>
-
-### HTTPS Management Advertise On Slo Sli Use mTLS No CRL
-
-<a id="https-management-advertise-on-slo-sli-use-mtls-trusted-ca"></a>
-
-### HTTPS Management Advertise On Slo Sli Use mTLS Trusted CA
-
-<a id="https-management-advertise-on-slo-sli-use-mtls-xfcc-disabled"></a>
-
-### HTTPS Management Advertise On Slo Sli Use mTLS Xfcc Disabled
-
-<a id="https-management-advertise-on-slo-sli-use-mtls-xfcc-options"></a>
-
-### HTTPS Management Advertise On Slo Sli Use mTLS Xfcc Options
+`xfcc_options` - (Optional) XFCC Header Elements. X-Forwarded-Client-Cert header elements to be added to requests (`Block`).
 
 <a id="https-management-advertise-on-slo-vip"></a>
 
 ### HTTPS Management Advertise On Slo VIP
 
-`no_mtls` - (Optional) Empty. This can be used for messages where no values are needed. See [No mTLS](#https-management-advertise-on-slo-vip-no-mtls) below.
+`no_mtls` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `tls_certificates` - (Optional) TLS Certificates. Users can add one or more certificates that share the same set of domains. for example, domain.com and *.domain.com - but use different signature algorithms. See [TLS Certificates](#https-management-advertise-on-slo-vip-tls-certificates) below.
 
@@ -738,69 +466,33 @@ In addition to all arguments above, the following attributes are exported:
 
 `use_mtls` - (Optional) Clients TLS validation context. Validation context for downstream client TLS connections. See [Use mTLS](#https-management-advertise-on-slo-vip-use-mtls) below.
 
-<a id="https-management-advertise-on-slo-vip-no-mtls"></a>
-
-### HTTPS Management Advertise On Slo VIP No mTLS
-
 <a id="https-management-advertise-on-slo-vip-tls-certificates"></a>
 
 ### HTTPS Management Advertise On Slo VIP TLS Certificates
 
 `certificate_url` - (Optional) Certificate. TLS certificate. Certificate or certificate chain in PEM format including the PEM headers (`String`).
 
-`custom_hash_algorithms` - (Optional) Hash Algorithms. Specifies the hash algorithms to be used. See [Custom Hash Algorithms](#https-management-advertise-on-slo-vip-tls-certificates-custom-hash-algorithms) below.
+`custom_hash_algorithms` - (Optional) Hash Algorithms. Specifies the hash algorithms to be used (`Block`).
 
 `description` - (Optional) Configuration for description (`String`).
 
-`disable_ocsp_stapling` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable OCSP Stapling](#https-management-advertise-on-slo-vip-tls-certificates-disable-ocsp-stapling) below.
+`disable_ocsp_stapling` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`private_key` - (Optional) Secret. SecretType is used in an object to indicate a sensitive/confidential field. See [Private Key](#https-management-advertise-on-slo-vip-tls-certificates-private-key) below.
+`private_key` - (Optional) Secret. SecretType is used in an object to indicate a sensitive/confidential field (`Block`).
 
-`use_system_defaults` - (Optional) Empty. This can be used for messages where no values are needed. See [Use System Defaults](#https-management-advertise-on-slo-vip-tls-certificates-use-system-defaults) below.
-
-<a id="https-management-advertise-on-slo-vip-tls-certificates-custom-hash-algorithms"></a>
-
-### HTTPS Management Advertise On Slo VIP TLS Certificates Custom Hash Algorithms
-
-<a id="https-management-advertise-on-slo-vip-tls-certificates-disable-ocsp-stapling"></a>
-
-### HTTPS Management Advertise On Slo VIP TLS Certificates Disable OCSP Stapling
-
-<a id="https-management-advertise-on-slo-vip-tls-certificates-private-key"></a>
-
-### HTTPS Management Advertise On Slo VIP TLS Certificates Private Key
-
-<a id="https-management-advertise-on-slo-vip-tls-certificates-use-system-defaults"></a>
-
-### HTTPS Management Advertise On Slo VIP TLS Certificates Use System Defaults
+`use_system_defaults` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="https-management-advertise-on-slo-vip-tls-config"></a>
 
 ### HTTPS Management Advertise On Slo VIP TLS Config
 
-`custom_security` - (Optional) Custom Ciphers. This defines TLS protocol config including min/max versions and allowed ciphers. See [Custom Security](#https-management-advertise-on-slo-vip-tls-config-custom-security) below.
+`custom_security` - (Optional) Custom Ciphers. This defines TLS protocol config including min/max versions and allowed ciphers (`Block`).
 
-`default_security` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Security](#https-management-advertise-on-slo-vip-tls-config-default-security) below.
+`default_security` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`low_security` - (Optional) Empty. This can be used for messages where no values are needed. See [Low Security](#https-management-advertise-on-slo-vip-tls-config-low-security) below.
+`low_security` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`medium_security` - (Optional) Empty. This can be used for messages where no values are needed. See [Medium Security](#https-management-advertise-on-slo-vip-tls-config-medium-security) below.
-
-<a id="https-management-advertise-on-slo-vip-tls-config-custom-security"></a>
-
-### HTTPS Management Advertise On Slo VIP TLS Config Custom Security
-
-<a id="https-management-advertise-on-slo-vip-tls-config-default-security"></a>
-
-### HTTPS Management Advertise On Slo VIP TLS Config Default Security
-
-<a id="https-management-advertise-on-slo-vip-tls-config-low-security"></a>
-
-### HTTPS Management Advertise On Slo VIP TLS Config Low Security
-
-<a id="https-management-advertise-on-slo-vip-tls-config-medium-security"></a>
-
-### HTTPS Management Advertise On Slo VIP TLS Config Medium Security
+`medium_security` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="https-management-advertise-on-slo-vip-use-mtls"></a>
 
@@ -808,41 +500,17 @@ In addition to all arguments above, the following attributes are exported:
 
 `client_certificate_optional` - (Optional) Client Certificate Optional. Client certificate is optional. If the client has provided a certificate, the load balancer will verify it. If certification verification fails, the connection will be terminated. If the client does not provide a certificate, the connection will be accepted (`Bool`).
 
-`crl` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [CRL](#https-management-advertise-on-slo-vip-use-mtls-crl) below.
+`crl` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name (`Block`).
 
-`no_crl` - (Optional) Empty. This can be used for messages where no values are needed. See [No CRL](#https-management-advertise-on-slo-vip-use-mtls-no-crl) below.
+`no_crl` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`trusted_ca` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Trusted CA](#https-management-advertise-on-slo-vip-use-mtls-trusted-ca) below.
+`trusted_ca` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name (`Block`).
 
 `trusted_ca_url` - (Optional) Inline Root CA Certificate (legacy). Upload a Root CA Certificate specifically for this Load Balancer (`String`).
 
-`xfcc_disabled` - (Optional) Empty. This can be used for messages where no values are needed. See [Xfcc Disabled](#https-management-advertise-on-slo-vip-use-mtls-xfcc-disabled) below.
+`xfcc_disabled` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`xfcc_options` - (Optional) XFCC Header Elements. X-Forwarded-Client-Cert header elements to be added to requests. See [Xfcc Options](#https-management-advertise-on-slo-vip-use-mtls-xfcc-options) below.
-
-<a id="https-management-advertise-on-slo-vip-use-mtls-crl"></a>
-
-### HTTPS Management Advertise On Slo VIP Use mTLS CRL
-
-<a id="https-management-advertise-on-slo-vip-use-mtls-no-crl"></a>
-
-### HTTPS Management Advertise On Slo VIP Use mTLS No CRL
-
-<a id="https-management-advertise-on-slo-vip-use-mtls-trusted-ca"></a>
-
-### HTTPS Management Advertise On Slo VIP Use mTLS Trusted CA
-
-<a id="https-management-advertise-on-slo-vip-use-mtls-xfcc-disabled"></a>
-
-### HTTPS Management Advertise On Slo VIP Use mTLS Xfcc Disabled
-
-<a id="https-management-advertise-on-slo-vip-use-mtls-xfcc-options"></a>
-
-### HTTPS Management Advertise On Slo VIP Use mTLS Xfcc Options
-
-<a id="https-management-default-https-port"></a>
-
-### HTTPS Management Default HTTPS Port
+`xfcc_options` - (Optional) XFCC Header Elements. X-Forwarded-Client-Cert header elements to be added to requests (`Block`).
 
 <a id="timeouts"></a>
 

--- a/docs/resources/app_firewall.md
+++ b/docs/resources/app_firewall.md
@@ -68,27 +68,27 @@ resource "f5xc_app_firewall" "example" {
 
 `ai_risk_based_blocking` - (Optional) Risk-Based Blocking (Powered by AI) - Preview. All Attack Types, including high, medium, and low accuracy signatures, automatic Attack Signature tuning, Threat Campaigns, and all Violations will be enabled. AI and ML algorithms will assess request risk, and only high-risk requests will be blocked by default. This feature is in preview mode. See [Ai Risk Based Blocking](#ai-risk-based-blocking) below for details.
 
-`default_detection_settings` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Detection Settings](#default-detection-settings) below for details.
+`default_detection_settings` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `detection_settings` - (Optional) Configuration for WAF attack detection sensitivity and signature coverage. Controls which attack signatures are enabled and how they detect potential threats. See [Detection Settings](#detection-settings) below for details.
 
 > **Note:** One of the arguments from this list "allow_all_response_codes, allowed_response_codes" must be set.
 
-`allow_all_response_codes` - (Optional) Empty. This can be used for messages where no values are needed. See [Allow All Response Codes](#allow-all-response-codes) below for details.
+`allow_all_response_codes` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `allowed_response_codes` - (Optional) Allowed Response Codes. List of HTTP response status codes that are allowed. See [Allowed Response Codes](#allowed-response-codes) below for details.
 
 > **Note:** One of the arguments from this list "blocking, monitoring" must be set.
 
-`blocking` - (Optional) Empty. This can be used for messages where no values are needed. See [Blocking](#blocking) below for details.
+`blocking` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`monitoring` - (Optional) Empty. This can be used for messages where no values are needed. See [Monitoring](#monitoring) below for details.
+`monitoring` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 > **Note:** One of the arguments from this list "blocking_page, use_default_blocking_page" must be set.
 
 `blocking_page` - (Optional) Custom Blocking Response Page. Custom blocking response page body. See [Blocking Page](#blocking-page) below for details.
 
-`use_default_blocking_page` - (Optional) Empty. This can be used for messages where no values are needed. See [Use Default Blocking Page](#use-default-blocking-page) below for details.
+`use_default_blocking_page` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `bot_protection_setting` - (Optional) Configuration for protecting against automated bot traffic. Enables detection and mitigation of malicious bots while allowing legitimate automation. See [Bot Protection Setting](#bot-protection-setting) below for details.
 
@@ -96,11 +96,11 @@ resource "f5xc_app_firewall" "example" {
 
 `custom_anonymization` - (Optional) Anonymization Configuration. Anonymization settings which is a list of HTTP headers, parameters and cookies. See [Custom Anonymization](#custom-anonymization) below for details.
 
-`default_anonymization` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Anonymization](#default-anonymization) below for details.
+`default_anonymization` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`disable_anonymization` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Anonymization](#disable-anonymization) below for details.
+`disable_anonymization` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`default_bot_setting` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Bot Setting](#default-bot-setting) below for details.
+`default_bot_setting` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `timeouts` - (Optional) See [Timeouts](#timeouts) below for details.
 
@@ -122,19 +122,11 @@ In addition to all arguments above, the following attributes are exported:
 
 `medium_risk_action` - (Optional) Risk Based Blocking Action. Action to be performed on the request Log and block Log only. Possible values are `AI_BLOCK`, `AI_REPORT`. Defaults to `AI_BLOCK` (`String`).
 
-<a id="allow-all-response-codes"></a>
-
-### Allow All Response Codes
-
 <a id="allowed-response-codes"></a>
 
 ### Allowed Response Codes
 
 `response_code` - (Optional) Response Code. List of HTTP response status codes that are allowed (`List`).
-
-<a id="blocking"></a>
-
-### Blocking
 
 <a id="blocking-page"></a>
 
@@ -188,37 +180,25 @@ In addition to all arguments above, the following attributes are exported:
 
 `query_param_name` - (Optional) Query Parameter Name. Masks the query parameter value. The setting does not mask the query parameter name (`String`).
 
-<a id="default-anonymization"></a>
-
-### Default Anonymization
-
-<a id="default-bot-setting"></a>
-
-### Default Bot Setting
-
-<a id="default-detection-settings"></a>
-
-### Default Detection Settings
-
 <a id="detection-settings"></a>
 
 ### Detection Settings
 
 `bot_protection_setting` - (Optional) Configuration for protecting against automated bot traffic. Enables detection and mitigation of malicious bots while allowing legitimate automation. See [Bot Protection Setting](#detection-settings-bot-protection-setting) below.
 
-`default_bot_setting` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Bot Setting](#detection-settings-default-bot-setting) below.
+`default_bot_setting` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`default_violation_settings` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Violation Settings](#detection-settings-default-violation-settings) below.
+`default_violation_settings` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`disable_staging` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Staging](#detection-settings-disable-staging) below.
+`disable_staging` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`disable_suppression` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Suppression](#detection-settings-disable-suppression) below.
+`disable_suppression` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`disable_threat_campaigns` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Threat Campaigns](#detection-settings-disable-threat-campaigns) below.
+`disable_threat_campaigns` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`enable_suppression` - (Optional) Empty. This can be used for messages where no values are needed. See [Enable Suppression](#detection-settings-enable-suppression) below.
+`enable_suppression` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`enable_threat_campaigns` - (Optional) Empty. This can be used for messages where no values are needed. See [Enable Threat Campaigns](#detection-settings-enable-threat-campaigns) below.
+`enable_threat_campaigns` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `signature_selection_setting` - (Optional) Attack Signatures. Attack Signatures are patterns that identify attacks on a web application and its components. See [Signature Selection Setting](#detection-settings-signature-selection-setting) below.
 
@@ -238,69 +218,25 @@ In addition to all arguments above, the following attributes are exported:
 
 `suspicious_bot_action` - (Optional) Bot Action. Action to be performed on the request Log and block Log only Disable detection. Possible values are `BLOCK`, `REPORT`, `IGNORE`. Defaults to `BLOCK` (`String`).
 
-<a id="detection-settings-default-bot-setting"></a>
-
-### Detection Settings Default Bot Setting
-
-<a id="detection-settings-default-violation-settings"></a>
-
-### Detection Settings Default Violation Settings
-
-<a id="detection-settings-disable-staging"></a>
-
-### Detection Settings Disable Staging
-
-<a id="detection-settings-disable-suppression"></a>
-
-### Detection Settings Disable Suppression
-
-<a id="detection-settings-disable-threat-campaigns"></a>
-
-### Detection Settings Disable Threat Campaigns
-
-<a id="detection-settings-enable-suppression"></a>
-
-### Detection Settings Enable Suppression
-
-<a id="detection-settings-enable-threat-campaigns"></a>
-
-### Detection Settings Enable Threat Campaigns
-
 <a id="detection-settings-signature-selection-setting"></a>
 
 ### Detection Settings Signature Selection Setting
 
 `attack_type_settings` - (Optional) Attack Type Settings. Specifies attack-type settings to be used by WAF. See [Attack Type Settings](#detection-settings-signature-selection-setting-attack-type-settings) below.
 
-`default_attack_type_settings` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Attack Type Settings](#detection-settings-signature-selection-setting-default-attack-type-settings) below.
+`default_attack_type_settings` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`high_medium_accuracy_signatures` - (Optional) Empty. This can be used for messages where no values are needed. See [High Medium Accuracy Signatures](#detection-settings-signature-selection-setting-high-medium-accuracy-signatures) below.
+`high_medium_accuracy_signatures` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`high_medium_low_accuracy_signatures` - (Optional) Empty. This can be used for messages where no values are needed. See [High Medium Low Accuracy Signatures](#detection-settings-signature-selection-setting-high-medium-low-accuracy-signatures) below.
+`high_medium_low_accuracy_signatures` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`only_high_accuracy_signatures` - (Optional) Empty. This can be used for messages where no values are needed. See [Only High Accuracy Signatures](#detection-settings-signature-selection-setting-only-high-accuracy-signatures) below.
+`only_high_accuracy_signatures` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="detection-settings-signature-selection-setting-attack-type-settings"></a>
 
 ### Detection Settings Signature Selection Setting Attack Type Settings
 
 `disabled_attack_types` - (Optional) Disabled Attack Types. List of Attack Types that will be ignored and not trigger a detection (`List`).
-
-<a id="detection-settings-signature-selection-setting-default-attack-type-settings"></a>
-
-### Detection Settings Signature Selection Setting Default Attack Type Settings
-
-<a id="detection-settings-signature-selection-setting-high-medium-accuracy-signatures"></a>
-
-### Detection Settings Signature Selection Setting High Medium Accuracy Signatures
-
-<a id="detection-settings-signature-selection-setting-high-medium-low-accuracy-signatures"></a>
-
-### Detection Settings Signature Selection Setting High Medium Low Accuracy Signatures
-
-<a id="detection-settings-signature-selection-setting-only-high-accuracy-signatures"></a>
-
-### Detection Settings Signature Selection Setting Only High Accuracy Signatures
 
 <a id="detection-settings-stage-new-and-updated-signatures"></a>
 
@@ -320,14 +256,6 @@ In addition to all arguments above, the following attributes are exported:
 
 `disabled_violation_types` - (Optional) Disabled Violations. List of violations to be excluded (`List`).
 
-<a id="disable-anonymization"></a>
-
-### Disable Anonymization
-
-<a id="monitoring"></a>
-
-### Monitoring
-
 <a id="timeouts"></a>
 
 ### Timeouts
@@ -339,10 +267,6 @@ In addition to all arguments above, the following attributes are exported:
 `read` - (Optional) A string that can be [parsed as a duration](`HTTPS://pkg.go.dev/time#ParseDuration`) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Read operations occur during any refresh or planning operation when refresh is enabled (`String`).
 
 `update` - (Optional) A string that can be [parsed as a duration](`HTTPS://pkg.go.dev/time#ParseDuration`) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours) (`String`).
-
-<a id="use-default-blocking-page"></a>
-
-### Use Default Blocking Page
 
 ## Import
 

--- a/docs/resources/app_setting.md
+++ b/docs/resources/app_setting.md
@@ -104,17 +104,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ### App Type Settings Business Logic Markup Setting
 
-`disable` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable](#app-type-settings-business-logic-markup-setting-disable) below.
+`disable` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`enable` - (Optional) Empty. This can be used for messages where no values are needed. See [Enable](#app-type-settings-business-logic-markup-setting-enable) below.
-
-<a id="app-type-settings-business-logic-markup-setting-disable"></a>
-
-### App Type Settings Business Logic Markup Setting Disable
-
-<a id="app-type-settings-business-logic-markup-setting-enable"></a>
-
-### App Type Settings Business Logic Markup Setting Enable
+`enable` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="app-type-settings-timeseries-analyses-setting"></a>
 
@@ -134,133 +126,53 @@ In addition to all arguments above, the following attributes are exported:
 
 ### App Type Settings User Behavior Analysis Setting
 
-`disable_detection` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Detection](#app-type-settings-user-behavior-analysis-setting-disable-detection) below.
+`disable_detection` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`disable_learning` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Learning](#app-type-settings-user-behavior-analysis-setting-disable-learning) below.
+`disable_learning` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `enable_detection` - (Optional) Malicious User Detection Settings. Various factors about user activity are monitored and analysed to determine malicious users. These settings allow tuning those factors used by the system to detect malicious users. See [Enable Detection](#app-type-settings-user-behavior-analysis-setting-enable-detection) below.
 
-`enable_learning` - (Optional) Empty. This can be used for messages where no values are needed. See [Enable Learning](#app-type-settings-user-behavior-analysis-setting-enable-learning) below.
-
-<a id="app-type-settings-user-behavior-analysis-setting-disable-detection"></a>
-
-### App Type Settings User Behavior Analysis Setting Disable Detection
-
-<a id="app-type-settings-user-behavior-analysis-setting-disable-learning"></a>
-
-### App Type Settings User Behavior Analysis Setting Disable Learning
+`enable_learning` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="app-type-settings-user-behavior-analysis-setting-enable-detection"></a>
 
 ### App Type Settings User Behavior Analysis Setting Enable Detection
 
-`bola_detection_automatic` - (Optional) Empty. This can be used for messages where no values are needed. See [Bola Detection Automatic](#app-type-settings-user-behavior-analysis-setting-enable-detection-bola-detection-automatic) below.
+`bola_detection_automatic` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `cooling_off_period` - (Optional) Cooling off period. Malicious user detection assigns a threat level to each user based on their activity. Once a threat level is assigned, the system continues tracking activity from this user and if no further malicious activity is seen, it gradually reduces the threat assesment to lower levels. This field specifies the time period, in minutes, used by the system to decay a user's threat level from a high to medium or medium to low or low to none (`Number`).
 
-`exclude_bola_detection` - (Optional) Empty. This can be used for messages where no values are needed. See [Exclude Bola Detection](#app-type-settings-user-behavior-analysis-setting-enable-detection-exclude-bola-detection) below.
+`exclude_bola_detection` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`exclude_bot_defense_activity` - (Optional) Empty. This can be used for messages where no values are needed. See [Exclude Bot Defense Activity](#app-type-settings-user-behavior-analysis-setting-enable-detection-exclude-bot-defense-activity) below.
+`exclude_bot_defense_activity` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`exclude_failed_login_activity` - (Optional) Empty. This can be used for messages where no values are needed. See [Exclude Failed Login Activity](#app-type-settings-user-behavior-analysis-setting-enable-detection-exclude-failed-login-activity) below.
+`exclude_failed_login_activity` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`exclude_forbidden_activity` - (Optional) Empty. This can be used for messages where no values are needed. See [Exclude Forbidden Activity](#app-type-settings-user-behavior-analysis-setting-enable-detection-exclude-forbidden-activity) below.
+`exclude_forbidden_activity` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`exclude_ip_reputation` - (Optional) Empty. This can be used for messages where no values are needed. See [Exclude IP Reputation](#app-type-settings-user-behavior-analysis-setting-enable-detection-exclude-ip-reputation) below.
+`exclude_ip_reputation` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`exclude_non_existent_url_activity` - (Optional) Empty. This can be used for messages where no values are needed. See [Exclude Non Existent URL Activity](#app-type-settings-user-behavior-analysis-setting-enable-detection-exclude-non-existent-url-activity) below.
+`exclude_non_existent_url_activity` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`exclude_rate_limit` - (Optional) Empty. This can be used for messages where no values are needed. See [Exclude Rate Limit](#app-type-settings-user-behavior-analysis-setting-enable-detection-exclude-rate-limit) below.
+`exclude_rate_limit` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`exclude_waf_activity` - (Optional) Empty. This can be used for messages where no values are needed. See [Exclude WAF Activity](#app-type-settings-user-behavior-analysis-setting-enable-detection-exclude-waf-activity) below.
+`exclude_waf_activity` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`include_bot_defense_activity` - (Optional) Empty. This can be used for messages where no values are needed. See [Include Bot Defense Activity](#app-type-settings-user-behavior-analysis-setting-enable-detection-include-bot-defense-activity) below.
+`include_bot_defense_activity` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`include_failed_login_activity` - (Optional) Failed Login Activity Setting. When enabled, the system monitors persistent failed login attempts from a user. A failed login is detected if a request results in a response code of 401. These settings specify how to use failed login activity to determine suspicious behavior. See [Include Failed Login Activity](#app-type-settings-user-behavior-analysis-setting-enable-detection-include-failed-login-activity) below.
+`include_failed_login_activity` - (Optional) Failed Login Activity Setting. When enabled, the system monitors persistent failed login attempts from a user. A failed login is detected if a request results in a response code of 401. These settings specify how to use failed login activity to determine suspicious behavior (`Block`).
 
-`include_forbidden_activity` - (Optional) Forbidden Activity Setting. When L7 policy rules are set up to disallow certain types of requests, the system monitors persistent attempts from a user to send requests which result in policy denies. These settings specify how to use disallowed request activity from a user to determine suspicious behavior. See [Include Forbidden Activity](#app-type-settings-user-behavior-analysis-setting-enable-detection-include-forbidden-activity) below.
+`include_forbidden_activity` - (Optional) Forbidden Activity Setting. When L7 policy rules are set up to disallow certain types of requests, the system monitors persistent attempts from a user to send requests which result in policy denies. These settings specify how to use disallowed request activity from a user to determine suspicious behavior (`Block`).
 
-`include_ip_reputation` - (Optional) Empty. This can be used for messages where no values are needed. See [Include IP Reputation](#app-type-settings-user-behavior-analysis-setting-enable-detection-include-ip-reputation) below.
+`include_ip_reputation` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`include_non_existent_url_activity_automatic` - (Optional) Non-existent URL Automatic Activity Settings. See [Include Non Existent URL Activity Automatic](#app-type-settings-user-behavior-analysis-setting-enable-detection-include-non-existent-url-activity-automatic) below.
+`include_non_existent_url_activity_automatic` - (Optional) Non-existent URL Automatic Activity Settings (`Block`).
 
-`include_non_existent_url_activity_custom` - (Optional) Non-existent URL Custom Activity Setting. See [Include Non Existent URL Activity Custom](#app-type-settings-user-behavior-analysis-setting-enable-detection-include-non-existent-url-activity-custom) below.
+`include_non_existent_url_activity_custom` - (Optional) Non-existent URL Custom Activity Setting (`Block`).
 
-`include_rate_limit` - (Optional) Empty. This can be used for messages where no values are needed. See [Include Rate Limit](#app-type-settings-user-behavior-analysis-setting-enable-detection-include-rate-limit) below.
+`include_rate_limit` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`include_waf_activity` - (Optional) Empty. This can be used for messages where no values are needed. See [Include WAF Activity](#app-type-settings-user-behavior-analysis-setting-enable-detection-include-waf-activity) below.
-
-<a id="app-type-settings-user-behavior-analysis-setting-enable-detection-bola-detection-automatic"></a>
-
-### App Type Settings User Behavior Analysis Setting Enable Detection Bola Detection Automatic
-
-<a id="app-type-settings-user-behavior-analysis-setting-enable-detection-exclude-bola-detection"></a>
-
-### App Type Settings User Behavior Analysis Setting Enable Detection Exclude Bola Detection
-
-<a id="app-type-settings-user-behavior-analysis-setting-enable-detection-exclude-bot-defense-activity"></a>
-
-### App Type Settings User Behavior Analysis Setting Enable Detection Exclude Bot Defense Activity
-
-<a id="app-type-settings-user-behavior-analysis-setting-enable-detection-exclude-failed-login-activity"></a>
-
-### App Type Settings User Behavior Analysis Setting Enable Detection Exclude Failed Login Activity
-
-<a id="app-type-settings-user-behavior-analysis-setting-enable-detection-exclude-forbidden-activity"></a>
-
-### App Type Settings User Behavior Analysis Setting Enable Detection Exclude Forbidden Activity
-
-<a id="app-type-settings-user-behavior-analysis-setting-enable-detection-exclude-ip-reputation"></a>
-
-### App Type Settings User Behavior Analysis Setting Enable Detection Exclude IP Reputation
-
-<a id="app-type-settings-user-behavior-analysis-setting-enable-detection-exclude-non-existent-url-activity"></a>
-
-### App Type Settings User Behavior Analysis Setting Enable Detection Exclude Non Existent URL Activity
-
-<a id="app-type-settings-user-behavior-analysis-setting-enable-detection-exclude-rate-limit"></a>
-
-### App Type Settings User Behavior Analysis Setting Enable Detection Exclude Rate Limit
-
-<a id="app-type-settings-user-behavior-analysis-setting-enable-detection-exclude-waf-activity"></a>
-
-### App Type Settings User Behavior Analysis Setting Enable Detection Exclude WAF Activity
-
-<a id="app-type-settings-user-behavior-analysis-setting-enable-detection-include-bot-defense-activity"></a>
-
-### App Type Settings User Behavior Analysis Setting Enable Detection Include Bot Defense Activity
-
-<a id="app-type-settings-user-behavior-analysis-setting-enable-detection-include-failed-login-activity"></a>
-
-### App Type Settings User Behavior Analysis Setting Enable Detection Include Failed Login Activity
-
-<a id="app-type-settings-user-behavior-analysis-setting-enable-detection-include-forbidden-activity"></a>
-
-### App Type Settings User Behavior Analysis Setting Enable Detection Include Forbidden Activity
-
-<a id="app-type-settings-user-behavior-analysis-setting-enable-detection-include-ip-reputation"></a>
-
-### App Type Settings User Behavior Analysis Setting Enable Detection Include IP Reputation
-
-<a id="app-type-settings-user-behavior-analysis-setting-enable-detection-include-non-existent-url-activity-automatic"></a>
-
-### App Type Settings User Behavior Analysis Setting Enable Detection Include Non Existent URL Activity Automatic
-
-<a id="app-type-settings-user-behavior-analysis-setting-enable-detection-include-non-existent-url-activity-custom"></a>
-
-### App Type Settings User Behavior Analysis Setting Enable Detection Include Non Existent URL Activity Custom
-
-<a id="app-type-settings-user-behavior-analysis-setting-enable-detection-include-rate-limit"></a>
-
-### App Type Settings User Behavior Analysis Setting Enable Detection Include Rate Limit
-
-<a id="app-type-settings-user-behavior-analysis-setting-enable-detection-include-waf-activity"></a>
-
-### App Type Settings User Behavior Analysis Setting Enable Detection Include WAF Activity
-
-<a id="app-type-settings-user-behavior-analysis-setting-enable-learning"></a>
-
-### App Type Settings User Behavior Analysis Setting Enable Learning
+`include_waf_activity` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="timeouts"></a>
 

--- a/docs/resources/app_type.md
+++ b/docs/resources/app_type.md
@@ -80,25 +80,17 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Business Logic Markup Setting
 
-`disable` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable](#business-logic-markup-setting-disable) below.
+`disable` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `discovered_api_settings` - (Optional) Discovered API Settings. x-example: '2' Configure Discovered API Settings. See [Discovered API Settings](#business-logic-markup-setting-discovered-api-settings) below.
 
-`enable` - (Optional) Empty. This can be used for messages where no values are needed. See [Enable](#business-logic-markup-setting-enable) below.
-
-<a id="business-logic-markup-setting-disable"></a>
-
-### Business Logic Markup Setting Disable
+`enable` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="business-logic-markup-setting-discovered-api-settings"></a>
 
 ### Business Logic Markup Setting Discovered API Settings
 
 `purge_duration_for_inactive_discovered_apis` - (Optional) Purge Duration for Inactive Discovered APIs from Traffic. Inactive discovered API will be deleted after configured duration (`Number`).
-
-<a id="business-logic-markup-setting-enable"></a>
-
-### Business Logic Markup Setting Enable
 
 <a id="features"></a>
 

--- a/docs/resources/authentication.md
+++ b/docs/resources/authentication.md
@@ -86,7 +86,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `cookie_refresh_interval` - (Optional) Cookie Refresh Interval. Specifies in seconds refresh interval for session cookie. This is used to keep the active user active and reduce RE-login. When an incoming cookie's session expiry is still valid, and time to expire falls behind this interval, RE-issue a cookie with new expiry and with the same original session expiry. Default refresh interval is 3000 seconds (`Number`).
 
-`kms_key_hmac` - (Optional) KMS Key Reference. Reference to KMS Key Object. See [Kms Key HMAC](#cookie-params-kms-key-hmac) below.
+`kms_key_hmac` - (Optional) KMS Key Reference. Reference to KMS Key Object (`Block`).
 
 `session_expiry` - (Optional) Session Expiry duration. specifies in seconds max lifetime of an authenticated session after which the user will be forced to login again. Default session expiry is 86400 seconds(24 hours) (`Number`).
 
@@ -106,37 +106,17 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Cookie Params Auth HMAC Prim Key
 
-`blindfold_secret_info` - (Optional) Blindfold Secret. BlindfoldSecretInfoType specifies information about the Secret managed by F5XC Secret Management. See [Blindfold Secret Info](#cookie-params-auth-hmac-prim-key-blindfold-secret-info) below.
+`blindfold_secret_info` - (Optional) Blindfold Secret. BlindfoldSecretInfoType specifies information about the Secret managed by F5XC Secret Management (`Block`).
 
-`clear_secret_info` - (Optional) In-Clear Secret. ClearSecretInfoType specifies information about the Secret that is not encrypted. See [Clear Secret Info](#cookie-params-auth-hmac-prim-key-clear-secret-info) below.
-
-<a id="cookie-params-auth-hmac-prim-key-blindfold-secret-info"></a>
-
-### Cookie Params Auth HMAC Prim Key Blindfold Secret Info
-
-<a id="cookie-params-auth-hmac-prim-key-clear-secret-info"></a>
-
-### Cookie Params Auth HMAC Prim Key Clear Secret Info
+`clear_secret_info` - (Optional) In-Clear Secret. ClearSecretInfoType specifies information about the Secret that is not encrypted (`Block`).
 
 <a id="cookie-params-auth-hmac-sec-key"></a>
 
 ### Cookie Params Auth HMAC Sec Key
 
-`blindfold_secret_info` - (Optional) Blindfold Secret. BlindfoldSecretInfoType specifies information about the Secret managed by F5XC Secret Management. See [Blindfold Secret Info](#cookie-params-auth-hmac-sec-key-blindfold-secret-info) below.
+`blindfold_secret_info` - (Optional) Blindfold Secret. BlindfoldSecretInfoType specifies information about the Secret managed by F5XC Secret Management (`Block`).
 
-`clear_secret_info` - (Optional) In-Clear Secret. ClearSecretInfoType specifies information about the Secret that is not encrypted. See [Clear Secret Info](#cookie-params-auth-hmac-sec-key-clear-secret-info) below.
-
-<a id="cookie-params-auth-hmac-sec-key-blindfold-secret-info"></a>
-
-### Cookie Params Auth HMAC Sec Key Blindfold Secret Info
-
-<a id="cookie-params-auth-hmac-sec-key-clear-secret-info"></a>
-
-### Cookie Params Auth HMAC Sec Key Clear Secret Info
-
-<a id="cookie-params-kms-key-hmac"></a>
-
-### Cookie Params Kms Key HMAC
+`clear_secret_info` - (Optional) In-Clear Secret. ClearSecretInfoType specifies information about the Secret that is not encrypted (`Block`).
 
 <a id="oidc-auth"></a>
 

--- a/docs/resources/aws_tgw_site.md
+++ b/docs/resources/aws_tgw_site.md
@@ -105,11 +105,11 @@ resource "f5xc_aws_tgw_site" "example" {
 
 > **Note:** One of the arguments from this list "block_all_services, blocked_services, default_blocked_services" must be set.
 
-`block_all_services` - (Optional) Empty. This can be used for messages where no values are needed. See [Block All Services](#block-all-services) below for details.
+`block_all_services` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `blocked_services` - (Optional) Disable Node Local Services. Disable node local services on this site. Note: The chosen services will get disabled on all nodes in the site. See [Blocked Services](#blocked-services) below for details.
 
-`default_blocked_services` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Blocked Services](#default-blocked-services) below for details.
+`default_blocked_services` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `coordinates` - (Optional) Site Coordinates. Coordinates of the site which provides the site physical location. See [Coordinates](#coordinates) below for details.
 
@@ -117,7 +117,7 @@ resource "f5xc_aws_tgw_site" "example" {
 
 > **Note:** One of the arguments from this list "direct_connect_disabled, direct_connect_enabled, private_connectivity" must be set.
 
-`direct_connect_disabled` - (Optional) Empty. This can be used for messages where no values are needed. See [Direct Connect Disabled](#direct-connect-disabled) below for details.
+`direct_connect_disabled` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `direct_connect_enabled` - (Optional) Direct Connect Configuration. Direct Connect Configuration. See [Direct Connect Enabled](#direct-connect-enabled) below for details.
 
@@ -129,7 +129,7 @@ resource "f5xc_aws_tgw_site" "example" {
 
 `log_receiver` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Log Receiver](#log-receiver) below for details.
 
-`logs_streaming_disabled` - (Optional) Empty. This can be used for messages where no values are needed. See [Logs Streaming Disabled](#logs-streaming-disabled) below for details.
+`logs_streaming_disabled` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `offline_survivability_mode` - (Optional) Offline Survivability Mode. Offline Survivability allows the Site to continue functioning normally without traffic loss during periods of connectivity loss to the Regional Edge (RE) or the Global Controller (GC). When this feature is enabled, a site can continue to function as is with existing configuration for upto 7 days, even when the site is offline. The certificates needed to keep the services running on this site are signed using a local CA. Secrets would also be cached locally to handl. See [Offline Survivability Mode](#offline-survivability-mode) below for details.
 
@@ -139,7 +139,7 @@ resource "f5xc_aws_tgw_site" "example" {
 
 `sw` - (Optional) F5XC Software Version. Select the F5XC Software Version for the site. By default, latest available F5XC Software Version will be used. Refer to release notes to find required released SW versions. See [Sw](#sw) below for details.
 
-`tags` - (Optional) AWS Tags. AWS Tags is a label consisting of a user-defined key and value. It helps to manage, identify, organize, search for, and filter resources in AWS console. See [Tags](#tags) below for details.
+`tags` - (Optional) AWS Tags. AWS Tags is a label consisting of a user-defined key and value. It helps to manage, identify, organize, search for, and filter resources in AWS console (`Block`).
 
 `tgw_security` - (Optional) TGW Security Configuration. Security Configuration for transit gateway. See [Tgw Security](#tgw-security) below for details.
 
@@ -171,15 +171,15 @@ In addition to all arguments above, the following attributes are exported:
 
 `custom_security_group` - (Optional) Security Group IDS. Enter pre created security groups for slo(Site Local Outside) and sli(Site Local Inside) interface. Supported only for sites deployed on existing VPC. See [Custom Security Group](#aws-parameters-custom-security-group) below.
 
-`disable_internet_vip` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Internet VIP](#aws-parameters-disable-internet-vip) below.
+`disable_internet_vip` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `disk_size` - (Optional) Node Disk Size. Node disk size for all node in the F5XC site. Unit is GiB (`Number`).
 
-`enable_internet_vip` - (Optional) Empty. This can be used for messages where no values are needed. See [Enable Internet VIP](#aws-parameters-enable-internet-vip) below.
+`enable_internet_vip` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `existing_tgw` - (Optional) Existing TGW Type. Information needed for existing TGW. See [Existing Tgw](#aws-parameters-existing-tgw) below.
 
-`f5xc_security_group` - (Optional) Empty. This can be used for messages where no values are needed. See [F5xc Security Group](#aws-parameters-f5xc-security-group) below.
+`f5xc_security_group` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `instance_type` - (Optional) AWS Instance Type for Node. Instance size based on the performance (`String`).
 
@@ -187,11 +187,11 @@ In addition to all arguments above, the following attributes are exported:
 
 `new_vpc` - (Optional) AWS VPC Parameters. Parameters to create new AWS VPC. See [New Vpc](#aws-parameters-new-vpc) below.
 
-`no_worker_nodes` - (Optional) Empty. This can be used for messages where no values are needed. See [No Worker Nodes](#aws-parameters-no-worker-nodes) below.
+`no_worker_nodes` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `nodes_per_az` - (Optional) Desired Worker Nodes Per AZ. Desired Worker Nodes Per AZ. Max limit is up to 21 (`Number`).
 
-`reserved_tgw_cidr` - (Optional) Empty. This can be used for messages where no values are needed. See [Reserved Tgw CIDR](#aws-parameters-reserved-tgw-cidr) below.
+`reserved_tgw_cidr` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `ssh_key` - (Optional) Public SSH key. Public SSH key for accessing nodes of the site (`String`).
 
@@ -247,7 +247,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `outside_subnet` - (Optional) AWS Subnet. Parameters for AWS subnet. See [Outside Subnet](#aws-parameters-az-nodes-outside-subnet) below.
 
-`reserved_inside_subnet` - (Optional) Empty. This can be used for messages where no values are needed. See [Reserved Inside Subnet](#aws-parameters-az-nodes-reserved-inside-subnet) below.
+`reserved_inside_subnet` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `workload_subnet` - (Optional) AWS Subnet. Parameters for AWS subnet. See [Workload Subnet](#aws-parameters-az-nodes-workload-subnet) below.
 
@@ -257,11 +257,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `existing_subnet_id` - (Optional) Existing Subnet ID. Information about existing subnet ID (`String`).
 
-`subnet_param` - (Optional) New Cloud Subnet Parameters. Parameters for creating a new cloud subnet. See [Subnet Param](#aws-parameters-az-nodes-inside-subnet-subnet-param) below.
-
-<a id="aws-parameters-az-nodes-inside-subnet-subnet-param"></a>
-
-### AWS Parameters Az Nodes Inside Subnet Subnet Param
+`subnet_param` - (Optional) New Cloud Subnet Parameters. Parameters for creating a new cloud subnet (`Block`).
 
 <a id="aws-parameters-az-nodes-outside-subnet"></a>
 
@@ -269,15 +265,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `existing_subnet_id` - (Optional) Existing Subnet ID. Information about existing subnet ID (`String`).
 
-`subnet_param` - (Optional) New Cloud Subnet Parameters. Parameters for creating a new cloud subnet. See [Subnet Param](#aws-parameters-az-nodes-outside-subnet-subnet-param) below.
-
-<a id="aws-parameters-az-nodes-outside-subnet-subnet-param"></a>
-
-### AWS Parameters Az Nodes Outside Subnet Subnet Param
-
-<a id="aws-parameters-az-nodes-reserved-inside-subnet"></a>
-
-### AWS Parameters Az Nodes Reserved Inside Subnet
+`subnet_param` - (Optional) New Cloud Subnet Parameters. Parameters for creating a new cloud subnet (`Block`).
 
 <a id="aws-parameters-az-nodes-workload-subnet"></a>
 
@@ -285,11 +273,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `existing_subnet_id` - (Optional) Existing Subnet ID. Information about existing subnet ID (`String`).
 
-`subnet_param` - (Optional) New Cloud Subnet Parameters. Parameters for creating a new cloud subnet. See [Subnet Param](#aws-parameters-az-nodes-workload-subnet-subnet-param) below.
-
-<a id="aws-parameters-az-nodes-workload-subnet-subnet-param"></a>
-
-### AWS Parameters Az Nodes Workload Subnet Subnet Param
+`subnet_param` - (Optional) New Cloud Subnet Parameters. Parameters for creating a new cloud subnet (`Block`).
 
 <a id="aws-parameters-custom-security-group"></a>
 
@@ -298,14 +282,6 @@ In addition to all arguments above, the following attributes are exported:
 `inside_security_group_id` - (Optional) Inside Security Group ID. Security Group ID to be attached to SLI(Site Local Inside) Interface (`String`).
 
 `outside_security_group_id` - (Optional) Outside Security Group ID. Security Group ID to be attached to SLO(Site Local Outside) Interface (`String`).
-
-<a id="aws-parameters-disable-internet-vip"></a>
-
-### AWS Parameters Disable Internet VIP
-
-<a id="aws-parameters-enable-internet-vip"></a>
-
-### AWS Parameters Enable Internet VIP
 
 <a id="aws-parameters-existing-tgw"></a>
 
@@ -317,21 +293,13 @@ In addition to all arguments above, the following attributes are exported:
 
 `volterra_site_asn` - (Optional) Enter F5XC Site ASN. F5XC Site ASN (`Number`).
 
-<a id="aws-parameters-f5xc-security-group"></a>
-
-### AWS Parameters F5xc Security Group
-
 <a id="aws-parameters-new-tgw"></a>
 
 ### AWS Parameters New Tgw
 
-`system_generated` - (Optional) Empty. This can be used for messages where no values are needed. See [System Generated](#aws-parameters-new-tgw-system-generated) below.
+`system_generated` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `user_assigned` - (Optional) TGW Assigned ASN Type. Information needed when ASNs are assigned by the user. See [User Assigned](#aws-parameters-new-tgw-user-assigned) below.
-
-<a id="aws-parameters-new-tgw-system-generated"></a>
-
-### AWS Parameters New Tgw System Generated
 
 <a id="aws-parameters-new-tgw-user-assigned"></a>
 
@@ -345,33 +313,17 @@ In addition to all arguments above, the following attributes are exported:
 
 ### AWS Parameters New Vpc
 
-`autogenerate` - (Optional) Empty. This can be used for messages where no values are needed. See [Autogenerate](#aws-parameters-new-vpc-autogenerate) below.
+`autogenerate` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `name_tag` - (Optional) Choose VPC Name. Specify the VPC Name (`String`).
 
 `primary_ipv4` - (Optional) Primary IPv4 CIDR block. IPv4 CIDR block for this VPC. It has to be private address space. The Primary IPv4 block cannot be modified. All subnets prefixes in this VPC must be part of this CIDR block (`String`).
-
-<a id="aws-parameters-new-vpc-autogenerate"></a>
-
-### AWS Parameters New Vpc Autogenerate
-
-<a id="aws-parameters-no-worker-nodes"></a>
-
-### AWS Parameters No Worker Nodes
-
-<a id="aws-parameters-reserved-tgw-cidr"></a>
-
-### AWS Parameters Reserved Tgw CIDR
 
 <a id="aws-parameters-tgw-cidr"></a>
 
 ### AWS Parameters Tgw CIDR
 
 `ipv4` - (Optional) IPv4 Subnet. IPv4 subnet prefix for this subnet (`String`).
-
-<a id="block-all-services"></a>
-
-### Block All Services
 
 <a id="blocked-services"></a>
 
@@ -383,25 +335,13 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Blocked Services Blocked Sevice
 
-`dns` - (Optional) Empty. This can be used for messages where no values are needed. See [DNS](#blocked-services-blocked-sevice-dns) below.
+`dns` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `network_type` - (Optional) Virtual Network Type. Different types of virtual networks understood by the system Virtual-network of type VIRTUAL_NETWORK_SITE_LOCAL provides connectivity to public (outside) network. This is an insecure network and is connected to public internet via NAT Gateways/firwalls Virtual-network of this type is local to every site. Two virtual networks of this type on different sites are neither related nor connected. Constraints: There can be atmost one virtual network of this type in a given site... Possible values include `VIRTUAL_NETWORK_SITE_LOCAL`, `VIRTUAL_NETWORK_SITE_LOCAL_INSIDE`, `VIRTUAL_NETWORK_PER_SITE`, `VIRTUAL_NETWORK_PUBLIC`, `VIRTUAL_NETWORK_GLOBAL`, `VIRTUAL_NETWORK_SITE_SERVICE`, `VIRTUAL_NETWORK_VER_INTERNAL`, `VIRTUAL_NETWORK_SITE_LOCAL_INSIDE_OUTSIDE`, `VIRTUAL_NETWORK_IP_AUTO`, `VIRTUAL_NETWORK_VOLTADN_PRIVATE_NETWORK`, and others. Defaults to `VIRTUAL_NETWORK_SITE_LOCAL` (`String`).
 
-`ssh` - (Optional) Empty. This can be used for messages where no values are needed. See [SSH](#blocked-services-blocked-sevice-ssh) below.
+`ssh` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`web_user_interface` - (Optional) Empty. This can be used for messages where no values are needed. See [Web User Interface](#blocked-services-blocked-sevice-web-user-interface) below.
-
-<a id="blocked-services-blocked-sevice-dns"></a>
-
-### Blocked Services Blocked Sevice DNS
-
-<a id="blocked-services-blocked-sevice-ssh"></a>
-
-### Blocked Services Blocked Sevice SSH
-
-<a id="blocked-services-blocked-sevice-web-user-interface"></a>
-
-### Blocked Services Blocked Sevice Web User Interface
+`web_user_interface` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="coordinates"></a>
 
@@ -419,29 +359,17 @@ In addition to all arguments above, the following attributes are exported:
 
 `outside_nameserver` - (Optional) DNS Server for Outside Network. Optional DNS server IP to be used for name resolution in outside network (`String`).
 
-<a id="default-blocked-services"></a>
-
-### Default Blocked Services
-
-<a id="direct-connect-disabled"></a>
-
-### Direct Connect Disabled
-
 <a id="direct-connect-enabled"></a>
 
 ### Direct Connect Enabled
 
-`auto_asn` - (Optional) Empty. This can be used for messages where no values are needed. See [Auto Asn](#direct-connect-enabled-auto-asn) below.
+`auto_asn` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `custom_asn` - (Optional) Custom ASN. Custom Autonomous System Number (`Number`).
 
 `hosted_vifs` - (Optional) AWS Direct Connect Hosted VIF Config. x-example: 'value' AWS Direct Connect Hosted VIF Configuration. See [Hosted Vifs](#direct-connect-enabled-hosted-vifs) below.
 
-`standard_vifs` - (Optional) Empty. This can be used for messages where no values are needed. See [Standard Vifs](#direct-connect-enabled-standard-vifs) below.
-
-<a id="direct-connect-enabled-auto-asn"></a>
-
-### Direct Connect Enabled Auto Asn
+`standard_vifs` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="direct-connect-enabled-hosted-vifs"></a>
 
@@ -449,7 +377,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `site_registration_over_direct_connect` - (Optional) CloudLink ADN Network Config. See [Site Registration Over Direct Connect](#direct-connect-enabled-hosted-vifs-site-registration-over-direct-connect) below.
 
-`site_registration_over_internet` - (Optional) Empty. This can be used for messages where no values are needed. See [Site Registration Over Internet](#direct-connect-enabled-hosted-vifs-site-registration-over-internet) below.
+`site_registration_over_internet` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `vif_list` - (Optional) List of Hosted VIF Config. List of Hosted VIF Config. See [Vif List](#direct-connect-enabled-hosted-vifs-vif-list) below.
 
@@ -459,59 +387,35 @@ In addition to all arguments above, the following attributes are exported:
 
 `cloudlink_network_name` - (Optional) Private ADN Network. Establish private connectivity with the F5 Distributed Cloud Global Network using a Private ADN network. To provision a Private ADN network, please contact F5 Distributed Cloud support (`String`).
 
-<a id="direct-connect-enabled-hosted-vifs-site-registration-over-internet"></a>
-
-### Direct Connect Enabled Hosted Vifs Site Registration Over Internet
-
 <a id="direct-connect-enabled-hosted-vifs-vif-list"></a>
 
 ### Direct Connect Enabled Hosted Vifs Vif List
 
 `other_region` - (Optional) Other Region. Other Region (`String`).
 
-`same_as_site_region` - (Optional) Empty. This can be used for messages where no values are needed. See [Same As Site Region](#direct-connect-enabled-hosted-vifs-vif-list-same-as-site-region) below.
+`same_as_site_region` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `vif_id` - (Optional) VIF ID. AWS Direct Connect VIF ID that needs to be connected to the site (`String`).
-
-<a id="direct-connect-enabled-hosted-vifs-vif-list-same-as-site-region"></a>
-
-### Direct Connect Enabled Hosted Vifs Vif List Same As Site Region
-
-<a id="direct-connect-enabled-standard-vifs"></a>
-
-### Direct Connect Enabled Standard Vifs
 
 <a id="kubernetes-upgrade-drain"></a>
 
 ### Kubernetes Upgrade Drain
 
-`disable_upgrade_drain` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Upgrade Drain](#kubernetes-upgrade-drain-disable-upgrade-drain) below.
+`disable_upgrade_drain` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `enable_upgrade_drain` - (Optional) Enable Node by Node Upgrade. Specify batch upgrade settings for worker nodes within a site. See [Enable Upgrade Drain](#kubernetes-upgrade-drain-enable-upgrade-drain) below.
-
-<a id="kubernetes-upgrade-drain-disable-upgrade-drain"></a>
-
-### Kubernetes Upgrade Drain Disable Upgrade Drain
 
 <a id="kubernetes-upgrade-drain-enable-upgrade-drain"></a>
 
 ### Kubernetes Upgrade Drain Enable Upgrade Drain
 
-`disable_vega_upgrade_mode` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Vega Upgrade Mode](#kubernetes-upgrade-drain-enable-upgrade-drain-disable-vega-upgrade-mode) below.
+`disable_vega_upgrade_mode` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `drain_max_unavailable_node_count` - (Optional) Node Batch Size Count (`Number`).
 
 `drain_node_timeout` - (Optional) Upgrade Wait Time. Seconds to wait before initiating upgrade on the next set of nodes. Setting it to 0 will wait indefinitely for all services on nodes to be upgraded gracefully before proceeding to the next set of nodes. (Warning: It may block upgrade if services on a node cannot be gracefully upgraded. It is recommended to use the default value) (`Number`).
 
-`enable_vega_upgrade_mode` - (Optional) Empty. This can be used for messages where no values are needed. See [Enable Vega Upgrade Mode](#kubernetes-upgrade-drain-enable-upgrade-drain-enable-vega-upgrade-mode) below.
-
-<a id="kubernetes-upgrade-drain-enable-upgrade-drain-disable-vega-upgrade-mode"></a>
-
-### Kubernetes Upgrade Drain Enable Upgrade Drain Disable Vega Upgrade Mode
-
-<a id="kubernetes-upgrade-drain-enable-upgrade-drain-enable-vega-upgrade-mode"></a>
-
-### Kubernetes Upgrade Drain Enable Upgrade Drain Enable Vega Upgrade Mode
+`enable_vega_upgrade_mode` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="log-receiver"></a>
 
@@ -523,37 +427,21 @@ In addition to all arguments above, the following attributes are exported:
 
 `tenant` - (Optional) Tenant. When a configuration object(e.g. virtual_host) refers to another(e.g route) then tenant will hold the referred object's(e.g. route's) tenant (`String`).
 
-<a id="logs-streaming-disabled"></a>
-
-### Logs Streaming Disabled
-
 <a id="offline-survivability-mode"></a>
 
 ### Offline Survivability Mode
 
-`enable_offline_survivability_mode` - (Optional) Empty. This can be used for messages where no values are needed. See [Enable Offline Survivability Mode](#offline-survivability-mode-enable-offline-survivability-mode) below.
+`enable_offline_survivability_mode` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_offline_survivability_mode` - (Optional) Empty. This can be used for messages where no values are needed. See [No Offline Survivability Mode](#offline-survivability-mode-no-offline-survivability-mode) below.
-
-<a id="offline-survivability-mode-enable-offline-survivability-mode"></a>
-
-### Offline Survivability Mode Enable Offline Survivability Mode
-
-<a id="offline-survivability-mode-no-offline-survivability-mode"></a>
-
-### Offline Survivability Mode No Offline Survivability Mode
+`no_offline_survivability_mode` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="os"></a>
 
 ### OS
 
-`default_os_version` - (Optional) Empty. This can be used for messages where no values are needed. See [Default OS Version](#os-default-os-version) below.
+`default_os_version` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `operating_system_version` - (Optional) Operating System Version. Specify a OS version to be used e.g. 9.2024.6 (`String`).
-
-<a id="os-default-os-version"></a>
-
-### OS Default OS Version
 
 <a id="performance-enhancement-mode"></a>
 
@@ -561,27 +449,15 @@ In addition to all arguments above, the following attributes are exported:
 
 `perf_mode_l3_enhanced` - (Optional) L3 Mode Enhanced Performance. x-required L3 enhanced performance mode options. See [Perf Mode L3 Enhanced](#performance-enhancement-mode-perf-mode-l3-enhanced) below.
 
-`perf_mode_l7_enhanced` - (Optional) Empty. This can be used for messages where no values are needed. See [Perf Mode L7 Enhanced](#performance-enhancement-mode-perf-mode-l7-enhanced) below.
+`perf_mode_l7_enhanced` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="performance-enhancement-mode-perf-mode-l3-enhanced"></a>
 
 ### Performance Enhancement Mode Perf Mode L3 Enhanced
 
-`jumbo` - (Optional) Empty. This can be used for messages where no values are needed. See [Jumbo](#performance-enhancement-mode-perf-mode-l3-enhanced-jumbo) below.
+`jumbo` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_jumbo` - (Optional) Empty. This can be used for messages where no values are needed. See [No Jumbo](#performance-enhancement-mode-perf-mode-l3-enhanced-no-jumbo) below.
-
-<a id="performance-enhancement-mode-perf-mode-l3-enhanced-jumbo"></a>
-
-### Performance Enhancement Mode Perf Mode L3 Enhanced Jumbo
-
-<a id="performance-enhancement-mode-perf-mode-l3-enhanced-no-jumbo"></a>
-
-### Performance Enhancement Mode Perf Mode L3 Enhanced No Jumbo
-
-<a id="performance-enhancement-mode-perf-mode-l7-enhanced"></a>
-
-### Performance Enhancement Mode Perf Mode L7 Enhanced
+`no_jumbo` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="private-connectivity"></a>
 
@@ -589,9 +465,9 @@ In addition to all arguments above, the following attributes are exported:
 
 `cloud_link` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Cloud Link](#private-connectivity-cloud-link) below.
 
-`inside` - (Optional) Empty. This can be used for messages where no values are needed. See [Inside](#private-connectivity-inside) below.
+`inside` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`outside` - (Optional) Empty. This can be used for messages where no values are needed. See [Outside](#private-connectivity-outside) below.
+`outside` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="private-connectivity-cloud-link"></a>
 
@@ -603,29 +479,13 @@ In addition to all arguments above, the following attributes are exported:
 
 `tenant` - (Optional) Tenant. When a configuration object(e.g. virtual_host) refers to another(e.g route) then tenant will hold the referred object's(e.g. route's) tenant (`String`).
 
-<a id="private-connectivity-inside"></a>
-
-### Private Connectivity Inside
-
-<a id="private-connectivity-outside"></a>
-
-### Private Connectivity Outside
-
 <a id="sw"></a>
 
 ### Sw
 
-`default_sw_version` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Sw Version](#sw-default-sw-version) below.
+`default_sw_version` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `volterra_software_version` - (Optional) F5XC Software Version. Specify a F5XC Software Version to be used e.g. crt-20210329-1002 (`String`).
-
-<a id="sw-default-sw-version"></a>
-
-### Sw Default Sw Version
-
-<a id="tags"></a>
-
-### Tags
 
 <a id="tgw-security"></a>
 
@@ -639,15 +499,15 @@ In addition to all arguments above, the following attributes are exported:
 
 `active_network_policies` - (Optional) Active Firewall Policies Type. List of firewall policy views. See [Active Network Policies](#tgw-security-active-network-policies) below.
 
-`east_west_service_policy_allow_all` - (Optional) Empty. This can be used for messages where no values are needed. See [East West Service Policy Allow All](#tgw-security-east-west-service-policy-allow-all) below.
+`east_west_service_policy_allow_all` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`forward_proxy_allow_all` - (Optional) Empty. This can be used for messages where no values are needed. See [Forward Proxy Allow All](#tgw-security-forward-proxy-allow-all) below.
+`forward_proxy_allow_all` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_east_west_policy` - (Optional) Empty. This can be used for messages where no values are needed. See [No East West Policy](#tgw-security-no-east-west-policy) below.
+`no_east_west_policy` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_forward_proxy` - (Optional) Empty. This can be used for messages where no values are needed. See [No Forward Proxy](#tgw-security-no-forward-proxy) below.
+`no_forward_proxy` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_network_policy` - (Optional) Empty. This can be used for messages where no values are needed. See [No Network Policy](#tgw-security-no-network-policy) below.
+`no_network_policy` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="tgw-security-active-east-west-service-policies"></a>
 
@@ -713,26 +573,6 @@ In addition to all arguments above, the following attributes are exported:
 
 `tenant` - (Optional) Tenant. When a configuration object(e.g. virtual_host) refers to another(e.g route) then tenant will hold the referred object's(e.g. route's) tenant (`String`).
 
-<a id="tgw-security-east-west-service-policy-allow-all"></a>
-
-### Tgw Security East West Service Policy Allow All
-
-<a id="tgw-security-forward-proxy-allow-all"></a>
-
-### Tgw Security Forward Proxy Allow All
-
-<a id="tgw-security-no-east-west-policy"></a>
-
-### Tgw Security No East West Policy
-
-<a id="tgw-security-no-forward-proxy"></a>
-
-### Tgw Security No Forward Proxy
-
-<a id="tgw-security-no-network-policy"></a>
-
-### Tgw Security No Network Policy
-
 <a id="timeouts"></a>
 
 ### Timeouts
@@ -761,19 +601,19 @@ In addition to all arguments above, the following attributes are exported:
 
 `inside_static_routes` - (Optional) Static Route List Type. List of static routes. See [Inside Static Routes](#vn-config-inside-static-routes) below.
 
-`no_dc_cluster_group` - (Optional) Empty. This can be used for messages where no values are needed. See [No Dc Cluster Group](#vn-config-no-dc-cluster-group) below.
+`no_dc_cluster_group` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_global_network` - (Optional) Empty. This can be used for messages where no values are needed. See [No Global Network](#vn-config-no-global-network) below.
+`no_global_network` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_inside_static_routes` - (Optional) Empty. This can be used for messages where no values are needed. See [No Inside Static Routes](#vn-config-no-inside-static-routes) below.
+`no_inside_static_routes` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_outside_static_routes` - (Optional) Empty. This can be used for messages where no values are needed. See [No Outside Static Routes](#vn-config-no-outside-static-routes) below.
+`no_outside_static_routes` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `outside_static_routes` - (Optional) Static Route List Type. List of static routes. See [Outside Static Routes](#vn-config-outside-static-routes) below.
 
-`sm_connection_public_ip` - (Optional) Empty. This can be used for messages where no values are needed. See [Sm Connection Public IP](#vn-config-sm-connection-public-ip) below.
+`sm_connection_public_ip` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`sm_connection_pvt_ip` - (Optional) Empty. This can be used for messages where no values are needed. See [Sm Connection Pvt IP](#vn-config-sm-connection-pvt-ip) below.
+`sm_connection_pvt_ip` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="vn-config-allowed-vip-port"></a>
 
@@ -781,13 +621,13 @@ In addition to all arguments above, the following attributes are exported:
 
 `custom_ports` - (Optional) Custom Ports. List of Custom port. See [Custom Ports](#vn-config-allowed-vip-port-custom-ports) below.
 
-`disable_allowed_vip_port` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Allowed VIP Port](#vn-config-allowed-vip-port-disable-allowed-vip-port) below.
+`disable_allowed_vip_port` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`use_http_https_port` - (Optional) Empty. This can be used for messages where no values are needed. See [Use HTTP HTTPS Port](#vn-config-allowed-vip-port-use-http-https-port) below.
+`use_http_https_port` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`use_http_port` - (Optional) Empty. This can be used for messages where no values are needed. See [Use HTTP Port](#vn-config-allowed-vip-port-use-http-port) below.
+`use_http_port` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`use_https_port` - (Optional) Empty. This can be used for messages where no values are needed. See [Use HTTPS Port](#vn-config-allowed-vip-port-use-https-port) below.
+`use_https_port` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="vn-config-allowed-vip-port-custom-ports"></a>
 
@@ -795,57 +635,25 @@ In addition to all arguments above, the following attributes are exported:
 
 `port_ranges` - (Optional) Port Ranges. Port Ranges (`String`).
 
-<a id="vn-config-allowed-vip-port-disable-allowed-vip-port"></a>
-
-### Vn Config Allowed VIP Port Disable Allowed VIP Port
-
-<a id="vn-config-allowed-vip-port-use-http-https-port"></a>
-
-### Vn Config Allowed VIP Port Use HTTP HTTPS Port
-
-<a id="vn-config-allowed-vip-port-use-http-port"></a>
-
-### Vn Config Allowed VIP Port Use HTTP Port
-
-<a id="vn-config-allowed-vip-port-use-https-port"></a>
-
-### Vn Config Allowed VIP Port Use HTTPS Port
-
 <a id="vn-config-allowed-vip-port-sli"></a>
 
 ### Vn Config Allowed VIP Port Sli
 
 `custom_ports` - (Optional) Custom Ports. List of Custom port. See [Custom Ports](#vn-config-allowed-vip-port-sli-custom-ports) below.
 
-`disable_allowed_vip_port` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Allowed VIP Port](#vn-config-allowed-vip-port-sli-disable-allowed-vip-port) below.
+`disable_allowed_vip_port` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`use_http_https_port` - (Optional) Empty. This can be used for messages where no values are needed. See [Use HTTP HTTPS Port](#vn-config-allowed-vip-port-sli-use-http-https-port) below.
+`use_http_https_port` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`use_http_port` - (Optional) Empty. This can be used for messages where no values are needed. See [Use HTTP Port](#vn-config-allowed-vip-port-sli-use-http-port) below.
+`use_http_port` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`use_https_port` - (Optional) Empty. This can be used for messages where no values are needed. See [Use HTTPS Port](#vn-config-allowed-vip-port-sli-use-https-port) below.
+`use_https_port` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="vn-config-allowed-vip-port-sli-custom-ports"></a>
 
 ### Vn Config Allowed VIP Port Sli Custom Ports
 
 `port_ranges` - (Optional) Port Ranges. Port Ranges (`String`).
-
-<a id="vn-config-allowed-vip-port-sli-disable-allowed-vip-port"></a>
-
-### Vn Config Allowed VIP Port Sli Disable Allowed VIP Port
-
-<a id="vn-config-allowed-vip-port-sli-use-http-https-port"></a>
-
-### Vn Config Allowed VIP Port Sli Use HTTP HTTPS Port
-
-<a id="vn-config-allowed-vip-port-sli-use-http-port"></a>
-
-### Vn Config Allowed VIP Port Sli Use HTTP Port
-
-<a id="vn-config-allowed-vip-port-sli-use-https-port"></a>
-
-### Vn Config Allowed VIP Port Sli Use HTTPS Port
 
 <a id="vn-config-dc-cluster-group-inside-vn"></a>
 
@@ -877,17 +685,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Vn Config Global Network List Global Network Connections
 
-`sli_to_global_dr` - (Optional) Global Network. Global network reference for direct connection. See [Sli To Global DR](#vn-config-global-network-list-global-network-connections-sli-to-global-dr) below.
+`sli_to_global_dr` - (Optional) Global Network. Global network reference for direct connection (`Block`).
 
-`slo_to_global_dr` - (Optional) Global Network. Global network reference for direct connection. See [Slo To Global DR](#vn-config-global-network-list-global-network-connections-slo-to-global-dr) below.
-
-<a id="vn-config-global-network-list-global-network-connections-sli-to-global-dr"></a>
-
-### Vn Config Global Network List Global Network Connections Sli To Global DR
-
-<a id="vn-config-global-network-list-global-network-connections-slo-to-global-dr"></a>
-
-### Vn Config Global Network List Global Network Connections Slo To Global DR
+`slo_to_global_dr` - (Optional) Global Network. Global network reference for direct connection (`Block`).
 
 <a id="vn-config-inside-static-routes"></a>
 
@@ -899,29 +699,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Vn Config Inside Static Routes Static Route List
 
-`custom_static_route` - (Optional) Static Route. Defines a static route, configuring a list of prefixes and a next-hop to be used for them. See [Custom Static Route](#vn-config-inside-static-routes-static-route-list-custom-static-route) below.
+`custom_static_route` - (Optional) Static Route. Defines a static route, configuring a list of prefixes and a next-hop to be used for them (`Block`).
 
 `simple_static_route` - (Optional) Simple Static Route. Use simple static route for prefix pointing to single interface in the network (`String`).
-
-<a id="vn-config-inside-static-routes-static-route-list-custom-static-route"></a>
-
-### Vn Config Inside Static Routes Static Route List Custom Static Route
-
-<a id="vn-config-no-dc-cluster-group"></a>
-
-### Vn Config No Dc Cluster Group
-
-<a id="vn-config-no-global-network"></a>
-
-### Vn Config No Global Network
-
-<a id="vn-config-no-inside-static-routes"></a>
-
-### Vn Config No Inside Static Routes
-
-<a id="vn-config-no-outside-static-routes"></a>
-
-### Vn Config No Outside Static Routes
 
 <a id="vn-config-outside-static-routes"></a>
 
@@ -933,21 +713,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Vn Config Outside Static Routes Static Route List
 
-`custom_static_route` - (Optional) Static Route. Defines a static route, configuring a list of prefixes and a next-hop to be used for them. See [Custom Static Route](#vn-config-outside-static-routes-static-route-list-custom-static-route) below.
+`custom_static_route` - (Optional) Static Route. Defines a static route, configuring a list of prefixes and a next-hop to be used for them (`Block`).
 
 `simple_static_route` - (Optional) Simple Static Route. Use simple static route for prefix pointing to single interface in the network (`String`).
-
-<a id="vn-config-outside-static-routes-static-route-list-custom-static-route"></a>
-
-### Vn Config Outside Static Routes Static Route List Custom Static Route
-
-<a id="vn-config-sm-connection-public-ip"></a>
-
-### Vn Config Sm Connection Public IP
-
-<a id="vn-config-sm-connection-pvt-ip"></a>
-
-### Vn Config Sm Connection Pvt IP
 
 <a id="vpc-attachments"></a>
 
@@ -959,13 +727,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Vpc Attachments Vpc List
 
-`labels` - (Optional) Labels. Add labels for the VPC attachment. These labels can then be used in policies such as enhanced firewall. See [Labels](#vpc-attachments-vpc-list-labels) below.
+`labels` - (Optional) Labels. Add labels for the VPC attachment. These labels can then be used in policies such as enhanced firewall (`Block`).
 
 `vpc_id` - (Optional) VPC ID. Information about existing VPC (`String`).
-
-<a id="vpc-attachments-vpc-list-labels"></a>
-
-### Vpc Attachments Vpc List Labels
 
 ## Import
 

--- a/docs/resources/aws_vpc_site.md
+++ b/docs/resources/aws_vpc_site.md
@@ -99,11 +99,11 @@ resource "f5xc_aws_vpc_site" "example" {
 
 > **Note:** One of the arguments from this list "block_all_services, blocked_services, default_blocked_services" must be set.
 
-`block_all_services` - (Optional) Empty. This can be used for messages where no values are needed. See [Block All Services](#block-all-services) below for details.
+`block_all_services` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `blocked_services` - (Optional) Disable Node Local Services. Disable node local services on this site. Note: The chosen services will get disabled on all nodes in the site. See [Blocked Services](#blocked-services) below for details.
 
-`default_blocked_services` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Blocked Services](#default-blocked-services) below for details.
+`default_blocked_services` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `coordinates` - (Optional) Site Coordinates. Coordinates of the site which provides the site physical location. See [Coordinates](#coordinates) below for details.
 
@@ -113,11 +113,11 @@ resource "f5xc_aws_vpc_site" "example" {
 
 `custom_security_group` - (Optional) Security Group IDS. Enter pre created security groups for slo(Site Local Outside) and sli(Site Local Inside) interface. Supported only for sites deployed on existing VPC. See [Custom Security Group](#custom-security-group) below for details.
 
-`f5xc_security_group` - (Optional) Empty. This can be used for messages where no values are needed. See [F5xc Security Group](#f5xc-security-group) below for details.
+`f5xc_security_group` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 > **Note:** One of the arguments from this list "direct_connect_disabled, direct_connect_enabled, private_connectivity" must be set.
 
-`direct_connect_disabled` - (Optional) Empty. This can be used for messages where no values are needed. See [Direct Connect Disabled](#direct-connect-disabled) below for details.
+`direct_connect_disabled` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `direct_connect_enabled` - (Optional) Direct Connect Configuration. Direct Connect Configuration. See [Direct Connect Enabled](#direct-connect-enabled) below for details.
 
@@ -125,15 +125,15 @@ resource "f5xc_aws_vpc_site" "example" {
 
 > **Note:** One of the arguments from this list "disable_internet_vip, enable_internet_vip" must be set.
 
-`disable_internet_vip` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Internet VIP](#disable-internet-vip) below for details.
+`disable_internet_vip` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`enable_internet_vip` - (Optional) Empty. This can be used for messages where no values are needed. See [Enable Internet VIP](#enable-internet-vip) below for details.
+`enable_internet_vip` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `disk_size` - (Optional) Cloud Disk Size. Disk size to be used for this instance in GiB. 80 is 80 GiB (`Number`).
 
 > **Note:** One of the arguments from this list "egress_gateway_default, egress_nat_gw, egress_virtual_private_gateway" must be set.
 
-`egress_gateway_default` - (Optional) Empty. This can be used for messages where no values are needed. See [Egress Gateway Default](#egress-gateway-default) below for details.
+`egress_gateway_default` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `egress_nat_gw` - (Optional) AWS NAT Gateway choice. With this option, egress site traffic will be routed through an Network Address Translation(NAT) Gateway. See [Egress NAT Gw](#egress-nat-gw) below for details.
 
@@ -141,9 +141,9 @@ resource "f5xc_aws_vpc_site" "example" {
 
 > **Note:** One of the arguments from this list "f5_orchestrated_routing, manual_routing" must be set.
 
-`f5_orchestrated_routing` - (Optional) Empty. This can be used for messages where no values are needed. See [F5 Orchestrated Routing](#f5-orchestrated-routing) below for details.
+`f5_orchestrated_routing` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`manual_routing` - (Optional) Empty. This can be used for messages where no values are needed. See [Manual Routing](#manual-routing) below for details.
+`manual_routing` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 > **Note:** One of the arguments from this list "ingress_egress_gw, ingress_gw, voltstack_cluster" must be set.
 
@@ -161,11 +161,11 @@ resource "f5xc_aws_vpc_site" "example" {
 
 `log_receiver` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Log Receiver](#log-receiver) below for details.
 
-`logs_streaming_disabled` - (Optional) Empty. This can be used for messages where no values are needed. See [Logs Streaming Disabled](#logs-streaming-disabled) below for details.
+`logs_streaming_disabled` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 > **Note:** One of the arguments from this list "no_worker_nodes, nodes_per_az, total_nodes" must be set.
 
-`no_worker_nodes` - (Optional) Empty. This can be used for messages where no values are needed. See [No Worker Nodes](#no-worker-nodes) below for details.
+`no_worker_nodes` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `nodes_per_az` - (Optional) Desired Worker Nodes Per AZ. Desired Worker Nodes Per AZ. Max limit is up to 21 (`Number`).
 
@@ -179,7 +179,7 @@ resource "f5xc_aws_vpc_site" "example" {
 
 `sw` - (Optional) F5XC Software Version. Select the F5XC Software Version for the site. By default, latest available F5XC Software Version will be used. Refer to release notes to find required released SW versions. See [Sw](#sw) below for details.
 
-`tags` - (Optional) AWS Tags. AWS Tags is a label consisting of a user-defined key and value. It helps to manage, identify, organize, search for, and filter resources in AWS console. See [Tags](#tags) below for details.
+`tags` - (Optional) AWS Tags. AWS Tags is a label consisting of a user-defined key and value. It helps to manage, identify, organize, search for, and filter resources in AWS console (`Block`).
 
 `timeouts` - (Optional) See [Timeouts](#timeouts) below for details.
 
@@ -229,10 +229,6 @@ In addition to all arguments above, the following attributes are exported:
 
 `tenant` - (Optional) Tenant. When a configuration object(e.g. virtual_host) refers to another(e.g route) then tenant will hold the referred object's(e.g. route's) tenant (`String`).
 
-<a id="block-all-services"></a>
-
-### Block All Services
-
 <a id="blocked-services"></a>
 
 ### Blocked Services
@@ -243,25 +239,13 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Blocked Services Blocked Sevice
 
-`dns` - (Optional) Empty. This can be used for messages where no values are needed. See [DNS](#blocked-services-blocked-sevice-dns) below.
+`dns` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `network_type` - (Optional) Virtual Network Type. Different types of virtual networks understood by the system Virtual-network of type VIRTUAL_NETWORK_SITE_LOCAL provides connectivity to public (outside) network. This is an insecure network and is connected to public internet via NAT Gateways/firwalls Virtual-network of this type is local to every site. Two virtual networks of this type on different sites are neither related nor connected. Constraints: There can be atmost one virtual network of this type in a given site... Possible values include `VIRTUAL_NETWORK_SITE_LOCAL`, `VIRTUAL_NETWORK_SITE_LOCAL_INSIDE`, `VIRTUAL_NETWORK_PER_SITE`, `VIRTUAL_NETWORK_PUBLIC`, `VIRTUAL_NETWORK_GLOBAL`, `VIRTUAL_NETWORK_SITE_SERVICE`, `VIRTUAL_NETWORK_VER_INTERNAL`, `VIRTUAL_NETWORK_SITE_LOCAL_INSIDE_OUTSIDE`, `VIRTUAL_NETWORK_IP_AUTO`, `VIRTUAL_NETWORK_VOLTADN_PRIVATE_NETWORK`, and others. Defaults to `VIRTUAL_NETWORK_SITE_LOCAL` (`String`).
 
-`ssh` - (Optional) Empty. This can be used for messages where no values are needed. See [SSH](#blocked-services-blocked-sevice-ssh) below.
+`ssh` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`web_user_interface` - (Optional) Empty. This can be used for messages where no values are needed. See [Web User Interface](#blocked-services-blocked-sevice-web-user-interface) below.
-
-<a id="blocked-services-blocked-sevice-dns"></a>
-
-### Blocked Services Blocked Sevice DNS
-
-<a id="blocked-services-blocked-sevice-ssh"></a>
-
-### Blocked Services Blocked Sevice SSH
-
-<a id="blocked-services-blocked-sevice-web-user-interface"></a>
-
-### Blocked Services Blocked Sevice Web User Interface
+`web_user_interface` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="coordinates"></a>
 
@@ -287,29 +271,17 @@ In addition to all arguments above, the following attributes are exported:
 
 `outside_security_group_id` - (Optional) Outside Security Group ID. Security Group ID to be attached to SLO(Site Local Outside) Interface (`String`).
 
-<a id="default-blocked-services"></a>
-
-### Default Blocked Services
-
-<a id="direct-connect-disabled"></a>
-
-### Direct Connect Disabled
-
 <a id="direct-connect-enabled"></a>
 
 ### Direct Connect Enabled
 
-`auto_asn` - (Optional) Empty. This can be used for messages where no values are needed. See [Auto Asn](#direct-connect-enabled-auto-asn) below.
+`auto_asn` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `custom_asn` - (Optional) Custom ASN. Custom Autonomous System Number (`Number`).
 
 `hosted_vifs` - (Optional) AWS Direct Connect Hosted VIF Config. x-example: 'value' AWS Direct Connect Hosted VIF Configuration. See [Hosted Vifs](#direct-connect-enabled-hosted-vifs) below.
 
-`standard_vifs` - (Optional) Empty. This can be used for messages where no values are needed. See [Standard Vifs](#direct-connect-enabled-standard-vifs) below.
-
-<a id="direct-connect-enabled-auto-asn"></a>
-
-### Direct Connect Enabled Auto Asn
+`standard_vifs` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="direct-connect-enabled-hosted-vifs"></a>
 
@@ -317,7 +289,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `site_registration_over_direct_connect` - (Optional) CloudLink ADN Network Config. See [Site Registration Over Direct Connect](#direct-connect-enabled-hosted-vifs-site-registration-over-direct-connect) below.
 
-`site_registration_over_internet` - (Optional) Empty. This can be used for messages where no values are needed. See [Site Registration Over Internet](#direct-connect-enabled-hosted-vifs-site-registration-over-internet) below.
+`site_registration_over_internet` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `vif_list` - (Optional) List of Hosted VIF Config. List of Hosted VIF Config. See [Vif List](#direct-connect-enabled-hosted-vifs-vif-list) below.
 
@@ -327,35 +299,15 @@ In addition to all arguments above, the following attributes are exported:
 
 `cloudlink_network_name` - (Optional) Private ADN Network. Establish private connectivity with the F5 Distributed Cloud Global Network using a Private ADN network. To provision a Private ADN network, please contact F5 Distributed Cloud support (`String`).
 
-<a id="direct-connect-enabled-hosted-vifs-site-registration-over-internet"></a>
-
-### Direct Connect Enabled Hosted Vifs Site Registration Over Internet
-
 <a id="direct-connect-enabled-hosted-vifs-vif-list"></a>
 
 ### Direct Connect Enabled Hosted Vifs Vif List
 
 `other_region` - (Optional) Other Region. Other Region (`String`).
 
-`same_as_site_region` - (Optional) Empty. This can be used for messages where no values are needed. See [Same As Site Region](#direct-connect-enabled-hosted-vifs-vif-list-same-as-site-region) below.
+`same_as_site_region` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `vif_id` - (Optional) VIF ID. AWS Direct Connect VIF ID that needs to be connected to the site (`String`).
-
-<a id="direct-connect-enabled-hosted-vifs-vif-list-same-as-site-region"></a>
-
-### Direct Connect Enabled Hosted Vifs Vif List Same As Site Region
-
-<a id="direct-connect-enabled-standard-vifs"></a>
-
-### Direct Connect Enabled Standard Vifs
-
-<a id="disable-internet-vip"></a>
-
-### Disable Internet VIP
-
-<a id="egress-gateway-default"></a>
-
-### Egress Gateway Default
 
 <a id="egress-nat-gw"></a>
 
@@ -368,18 +320,6 @@ In addition to all arguments above, the following attributes are exported:
 ### Egress Virtual Private Gateway
 
 `vgw_id` - (Optional) Existing Virtual Private Gateway ID (`String`).
-
-<a id="enable-internet-vip"></a>
-
-### Enable Internet VIP
-
-<a id="f5-orchestrated-routing"></a>
-
-### F5 Orchestrated Routing
-
-<a id="f5xc-security-group"></a>
-
-### F5xc Security Group
 
 <a id="ingress-egress-gw"></a>
 
@@ -403,31 +343,31 @@ In addition to all arguments above, the following attributes are exported:
 
 `dc_cluster_group_outside_vn` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Dc Cluster Group Outside Vn](#ingress-egress-gw-dc-cluster-group-outside-vn) below.
 
-`forward_proxy_allow_all` - (Optional) Empty. This can be used for messages where no values are needed. See [Forward Proxy Allow All](#ingress-egress-gw-forward-proxy-allow-all) below.
+`forward_proxy_allow_all` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `global_network_list` - (Optional) Global Network Connection List. List of global network connections. See [Global Network List](#ingress-egress-gw-global-network-list) below.
 
 `inside_static_routes` - (Optional) Static Route List Type. List of static routes. See [Inside Static Routes](#ingress-egress-gw-inside-static-routes) below.
 
-`no_dc_cluster_group` - (Optional) Empty. This can be used for messages where no values are needed. See [No Dc Cluster Group](#ingress-egress-gw-no-dc-cluster-group) below.
+`no_dc_cluster_group` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_forward_proxy` - (Optional) Empty. This can be used for messages where no values are needed. See [No Forward Proxy](#ingress-egress-gw-no-forward-proxy) below.
+`no_forward_proxy` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_global_network` - (Optional) Empty. This can be used for messages where no values are needed. See [No Global Network](#ingress-egress-gw-no-global-network) below.
+`no_global_network` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_inside_static_routes` - (Optional) Empty. This can be used for messages where no values are needed. See [No Inside Static Routes](#ingress-egress-gw-no-inside-static-routes) below.
+`no_inside_static_routes` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_network_policy` - (Optional) Empty. This can be used for messages where no values are needed. See [No Network Policy](#ingress-egress-gw-no-network-policy) below.
+`no_network_policy` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_outside_static_routes` - (Optional) Empty. This can be used for messages where no values are needed. See [No Outside Static Routes](#ingress-egress-gw-no-outside-static-routes) below.
+`no_outside_static_routes` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `outside_static_routes` - (Optional) Static Route List Type. List of static routes. See [Outside Static Routes](#ingress-egress-gw-outside-static-routes) below.
 
 `performance_enhancement_mode` - (Optional) Performance Enhancement Mode. x-required Optimize the site for L3 or L7 traffic processing. L7 optimized is the default. See [Performance Enhancement Mode](#ingress-egress-gw-performance-enhancement-mode) below.
 
-`sm_connection_public_ip` - (Optional) Empty. This can be used for messages where no values are needed. See [Sm Connection Public IP](#ingress-egress-gw-sm-connection-public-ip) below.
+`sm_connection_public_ip` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`sm_connection_pvt_ip` - (Optional) Empty. This can be used for messages where no values are needed. See [Sm Connection Pvt IP](#ingress-egress-gw-sm-connection-pvt-ip) below.
+`sm_connection_pvt_ip` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="ingress-egress-gw-active-enhanced-firewall-policies"></a>
 
@@ -483,13 +423,13 @@ In addition to all arguments above, the following attributes are exported:
 
 `custom_ports` - (Optional) Custom Ports. List of Custom port. See [Custom Ports](#ingress-egress-gw-allowed-vip-port-custom-ports) below.
 
-`disable_allowed_vip_port` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Allowed VIP Port](#ingress-egress-gw-allowed-vip-port-disable-allowed-vip-port) below.
+`disable_allowed_vip_port` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`use_http_https_port` - (Optional) Empty. This can be used for messages where no values are needed. See [Use HTTP HTTPS Port](#ingress-egress-gw-allowed-vip-port-use-http-https-port) below.
+`use_http_https_port` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`use_http_port` - (Optional) Empty. This can be used for messages where no values are needed. See [Use HTTP Port](#ingress-egress-gw-allowed-vip-port-use-http-port) below.
+`use_http_port` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`use_https_port` - (Optional) Empty. This can be used for messages where no values are needed. See [Use HTTPS Port](#ingress-egress-gw-allowed-vip-port-use-https-port) below.
+`use_https_port` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="ingress-egress-gw-allowed-vip-port-custom-ports"></a>
 
@@ -497,57 +437,25 @@ In addition to all arguments above, the following attributes are exported:
 
 `port_ranges` - (Optional) Port Ranges. Port Ranges (`String`).
 
-<a id="ingress-egress-gw-allowed-vip-port-disable-allowed-vip-port"></a>
-
-### Ingress Egress Gw Allowed VIP Port Disable Allowed VIP Port
-
-<a id="ingress-egress-gw-allowed-vip-port-use-http-https-port"></a>
-
-### Ingress Egress Gw Allowed VIP Port Use HTTP HTTPS Port
-
-<a id="ingress-egress-gw-allowed-vip-port-use-http-port"></a>
-
-### Ingress Egress Gw Allowed VIP Port Use HTTP Port
-
-<a id="ingress-egress-gw-allowed-vip-port-use-https-port"></a>
-
-### Ingress Egress Gw Allowed VIP Port Use HTTPS Port
-
 <a id="ingress-egress-gw-allowed-vip-port-sli"></a>
 
 ### Ingress Egress Gw Allowed VIP Port Sli
 
 `custom_ports` - (Optional) Custom Ports. List of Custom port. See [Custom Ports](#ingress-egress-gw-allowed-vip-port-sli-custom-ports) below.
 
-`disable_allowed_vip_port` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Allowed VIP Port](#ingress-egress-gw-allowed-vip-port-sli-disable-allowed-vip-port) below.
+`disable_allowed_vip_port` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`use_http_https_port` - (Optional) Empty. This can be used for messages where no values are needed. See [Use HTTP HTTPS Port](#ingress-egress-gw-allowed-vip-port-sli-use-http-https-port) below.
+`use_http_https_port` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`use_http_port` - (Optional) Empty. This can be used for messages where no values are needed. See [Use HTTP Port](#ingress-egress-gw-allowed-vip-port-sli-use-http-port) below.
+`use_http_port` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`use_https_port` - (Optional) Empty. This can be used for messages where no values are needed. See [Use HTTPS Port](#ingress-egress-gw-allowed-vip-port-sli-use-https-port) below.
+`use_https_port` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="ingress-egress-gw-allowed-vip-port-sli-custom-ports"></a>
 
 ### Ingress Egress Gw Allowed VIP Port Sli Custom Ports
 
 `port_ranges` - (Optional) Port Ranges. Port Ranges (`String`).
-
-<a id="ingress-egress-gw-allowed-vip-port-sli-disable-allowed-vip-port"></a>
-
-### Ingress Egress Gw Allowed VIP Port Sli Disable Allowed VIP Port
-
-<a id="ingress-egress-gw-allowed-vip-port-sli-use-http-https-port"></a>
-
-### Ingress Egress Gw Allowed VIP Port Sli Use HTTP HTTPS Port
-
-<a id="ingress-egress-gw-allowed-vip-port-sli-use-http-port"></a>
-
-### Ingress Egress Gw Allowed VIP Port Sli Use HTTP Port
-
-<a id="ingress-egress-gw-allowed-vip-port-sli-use-https-port"></a>
-
-### Ingress Egress Gw Allowed VIP Port Sli Use HTTPS Port
 
 <a id="ingress-egress-gw-az-nodes"></a>
 
@@ -559,7 +467,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `outside_subnet` - (Optional) AWS Subnet. Parameters for AWS subnet. See [Outside Subnet](#ingress-egress-gw-az-nodes-outside-subnet) below.
 
-`reserved_inside_subnet` - (Optional) Empty. This can be used for messages where no values are needed. See [Reserved Inside Subnet](#ingress-egress-gw-az-nodes-reserved-inside-subnet) below.
+`reserved_inside_subnet` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `workload_subnet` - (Optional) AWS Subnet. Parameters for AWS subnet. See [Workload Subnet](#ingress-egress-gw-az-nodes-workload-subnet) below.
 
@@ -569,11 +477,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `existing_subnet_id` - (Optional) Existing Subnet ID. Information about existing subnet ID (`String`).
 
-`subnet_param` - (Optional) New Cloud Subnet Parameters. Parameters for creating a new cloud subnet. See [Subnet Param](#ingress-egress-gw-az-nodes-inside-subnet-subnet-param) below.
-
-<a id="ingress-egress-gw-az-nodes-inside-subnet-subnet-param"></a>
-
-### Ingress Egress Gw Az Nodes Inside Subnet Subnet Param
+`subnet_param` - (Optional) New Cloud Subnet Parameters. Parameters for creating a new cloud subnet (`Block`).
 
 <a id="ingress-egress-gw-az-nodes-outside-subnet"></a>
 
@@ -581,15 +485,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `existing_subnet_id` - (Optional) Existing Subnet ID. Information about existing subnet ID (`String`).
 
-`subnet_param` - (Optional) New Cloud Subnet Parameters. Parameters for creating a new cloud subnet. See [Subnet Param](#ingress-egress-gw-az-nodes-outside-subnet-subnet-param) below.
-
-<a id="ingress-egress-gw-az-nodes-outside-subnet-subnet-param"></a>
-
-### Ingress Egress Gw Az Nodes Outside Subnet Subnet Param
-
-<a id="ingress-egress-gw-az-nodes-reserved-inside-subnet"></a>
-
-### Ingress Egress Gw Az Nodes Reserved Inside Subnet
+`subnet_param` - (Optional) New Cloud Subnet Parameters. Parameters for creating a new cloud subnet (`Block`).
 
 <a id="ingress-egress-gw-az-nodes-workload-subnet"></a>
 
@@ -597,11 +493,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `existing_subnet_id` - (Optional) Existing Subnet ID. Information about existing subnet ID (`String`).
 
-`subnet_param` - (Optional) New Cloud Subnet Parameters. Parameters for creating a new cloud subnet. See [Subnet Param](#ingress-egress-gw-az-nodes-workload-subnet-subnet-param) below.
-
-<a id="ingress-egress-gw-az-nodes-workload-subnet-subnet-param"></a>
-
-### Ingress Egress Gw Az Nodes Workload Subnet Subnet Param
+`subnet_param` - (Optional) New Cloud Subnet Parameters. Parameters for creating a new cloud subnet (`Block`).
 
 <a id="ingress-egress-gw-dc-cluster-group-inside-vn"></a>
 
@@ -623,10 +515,6 @@ In addition to all arguments above, the following attributes are exported:
 
 `tenant` - (Optional) Tenant. When a configuration object(e.g. virtual_host) refers to another(e.g route) then tenant will hold the referred object's(e.g. route's) tenant (`String`).
 
-<a id="ingress-egress-gw-forward-proxy-allow-all"></a>
-
-### Ingress Egress Gw Forward Proxy Allow All
-
 <a id="ingress-egress-gw-global-network-list"></a>
 
 ### Ingress Egress Gw Global Network List
@@ -637,17 +525,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Ingress Egress Gw Global Network List Global Network Connections
 
-`sli_to_global_dr` - (Optional) Global Network. Global network reference for direct connection. See [Sli To Global DR](#ingress-egress-gw-global-network-list-global-network-connections-sli-to-global-dr) below.
+`sli_to_global_dr` - (Optional) Global Network. Global network reference for direct connection (`Block`).
 
-`slo_to_global_dr` - (Optional) Global Network. Global network reference for direct connection. See [Slo To Global DR](#ingress-egress-gw-global-network-list-global-network-connections-slo-to-global-dr) below.
-
-<a id="ingress-egress-gw-global-network-list-global-network-connections-sli-to-global-dr"></a>
-
-### Ingress Egress Gw Global Network List Global Network Connections Sli To Global DR
-
-<a id="ingress-egress-gw-global-network-list-global-network-connections-slo-to-global-dr"></a>
-
-### Ingress Egress Gw Global Network List Global Network Connections Slo To Global DR
+`slo_to_global_dr` - (Optional) Global Network. Global network reference for direct connection (`Block`).
 
 <a id="ingress-egress-gw-inside-static-routes"></a>
 
@@ -659,37 +539,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Ingress Egress Gw Inside Static Routes Static Route List
 
-`custom_static_route` - (Optional) Static Route. Defines a static route, configuring a list of prefixes and a next-hop to be used for them. See [Custom Static Route](#ingress-egress-gw-inside-static-routes-static-route-list-custom-static-route) below.
+`custom_static_route` - (Optional) Static Route. Defines a static route, configuring a list of prefixes and a next-hop to be used for them (`Block`).
 
 `simple_static_route` - (Optional) Simple Static Route. Use simple static route for prefix pointing to single interface in the network (`String`).
-
-<a id="ingress-egress-gw-inside-static-routes-static-route-list-custom-static-route"></a>
-
-### Ingress Egress Gw Inside Static Routes Static Route List Custom Static Route
-
-<a id="ingress-egress-gw-no-dc-cluster-group"></a>
-
-### Ingress Egress Gw No Dc Cluster Group
-
-<a id="ingress-egress-gw-no-forward-proxy"></a>
-
-### Ingress Egress Gw No Forward Proxy
-
-<a id="ingress-egress-gw-no-global-network"></a>
-
-### Ingress Egress Gw No Global Network
-
-<a id="ingress-egress-gw-no-inside-static-routes"></a>
-
-### Ingress Egress Gw No Inside Static Routes
-
-<a id="ingress-egress-gw-no-network-policy"></a>
-
-### Ingress Egress Gw No Network Policy
-
-<a id="ingress-egress-gw-no-outside-static-routes"></a>
-
-### Ingress Egress Gw No Outside Static Routes
 
 <a id="ingress-egress-gw-outside-static-routes"></a>
 
@@ -701,13 +553,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Ingress Egress Gw Outside Static Routes Static Route List
 
-`custom_static_route` - (Optional) Static Route. Defines a static route, configuring a list of prefixes and a next-hop to be used for them. See [Custom Static Route](#ingress-egress-gw-outside-static-routes-static-route-list-custom-static-route) below.
+`custom_static_route` - (Optional) Static Route. Defines a static route, configuring a list of prefixes and a next-hop to be used for them (`Block`).
 
 `simple_static_route` - (Optional) Simple Static Route. Use simple static route for prefix pointing to single interface in the network (`String`).
-
-<a id="ingress-egress-gw-outside-static-routes-static-route-list-custom-static-route"></a>
-
-### Ingress Egress Gw Outside Static Routes Static Route List Custom Static Route
 
 <a id="ingress-egress-gw-performance-enhancement-mode"></a>
 
@@ -715,35 +563,15 @@ In addition to all arguments above, the following attributes are exported:
 
 `perf_mode_l3_enhanced` - (Optional) L3 Mode Enhanced Performance. x-required L3 enhanced performance mode options. See [Perf Mode L3 Enhanced](#ingress-egress-gw-performance-enhancement-mode-perf-mode-l3-enhanced) below.
 
-`perf_mode_l7_enhanced` - (Optional) Empty. This can be used for messages where no values are needed. See [Perf Mode L7 Enhanced](#ingress-egress-gw-performance-enhancement-mode-perf-mode-l7-enhanced) below.
+`perf_mode_l7_enhanced` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="ingress-egress-gw-performance-enhancement-mode-perf-mode-l3-enhanced"></a>
 
 ### Ingress Egress Gw Performance Enhancement Mode Perf Mode L3 Enhanced
 
-`jumbo` - (Optional) Empty. This can be used for messages where no values are needed. See [Jumbo](#ingress-egress-gw-performance-enhancement-mode-perf-mode-l3-enhanced-jumbo) below.
+`jumbo` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_jumbo` - (Optional) Empty. This can be used for messages where no values are needed. See [No Jumbo](#ingress-egress-gw-performance-enhancement-mode-perf-mode-l3-enhanced-no-jumbo) below.
-
-<a id="ingress-egress-gw-performance-enhancement-mode-perf-mode-l3-enhanced-jumbo"></a>
-
-### Ingress Egress Gw Performance Enhancement Mode Perf Mode L3 Enhanced Jumbo
-
-<a id="ingress-egress-gw-performance-enhancement-mode-perf-mode-l3-enhanced-no-jumbo"></a>
-
-### Ingress Egress Gw Performance Enhancement Mode Perf Mode L3 Enhanced No Jumbo
-
-<a id="ingress-egress-gw-performance-enhancement-mode-perf-mode-l7-enhanced"></a>
-
-### Ingress Egress Gw Performance Enhancement Mode Perf Mode L7 Enhanced
-
-<a id="ingress-egress-gw-sm-connection-public-ip"></a>
-
-### Ingress Egress Gw Sm Connection Public IP
-
-<a id="ingress-egress-gw-sm-connection-pvt-ip"></a>
-
-### Ingress Egress Gw Sm Connection Pvt IP
+`no_jumbo` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="ingress-gw"></a>
 
@@ -763,35 +591,19 @@ In addition to all arguments above, the following attributes are exported:
 
 `custom_ports` - (Optional) Custom Ports. List of Custom port. See [Custom Ports](#ingress-gw-allowed-vip-port-custom-ports) below.
 
-`disable_allowed_vip_port` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Allowed VIP Port](#ingress-gw-allowed-vip-port-disable-allowed-vip-port) below.
+`disable_allowed_vip_port` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`use_http_https_port` - (Optional) Empty. This can be used for messages where no values are needed. See [Use HTTP HTTPS Port](#ingress-gw-allowed-vip-port-use-http-https-port) below.
+`use_http_https_port` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`use_http_port` - (Optional) Empty. This can be used for messages where no values are needed. See [Use HTTP Port](#ingress-gw-allowed-vip-port-use-http-port) below.
+`use_http_port` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`use_https_port` - (Optional) Empty. This can be used for messages where no values are needed. See [Use HTTPS Port](#ingress-gw-allowed-vip-port-use-https-port) below.
+`use_https_port` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="ingress-gw-allowed-vip-port-custom-ports"></a>
 
 ### Ingress Gw Allowed VIP Port Custom Ports
 
 `port_ranges` - (Optional) Port Ranges. Port Ranges (`String`).
-
-<a id="ingress-gw-allowed-vip-port-disable-allowed-vip-port"></a>
-
-### Ingress Gw Allowed VIP Port Disable Allowed VIP Port
-
-<a id="ingress-gw-allowed-vip-port-use-http-https-port"></a>
-
-### Ingress Gw Allowed VIP Port Use HTTP HTTPS Port
-
-<a id="ingress-gw-allowed-vip-port-use-http-port"></a>
-
-### Ingress Gw Allowed VIP Port Use HTTP Port
-
-<a id="ingress-gw-allowed-vip-port-use-https-port"></a>
-
-### Ingress Gw Allowed VIP Port Use HTTPS Port
 
 <a id="ingress-gw-az-nodes"></a>
 
@@ -807,11 +619,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `existing_subnet_id` - (Optional) Existing Subnet ID. Information about existing subnet ID (`String`).
 
-`subnet_param` - (Optional) New Cloud Subnet Parameters. Parameters for creating a new cloud subnet. See [Subnet Param](#ingress-gw-az-nodes-local-subnet-subnet-param) below.
-
-<a id="ingress-gw-az-nodes-local-subnet-subnet-param"></a>
-
-### Ingress Gw Az Nodes Local Subnet Subnet Param
+`subnet_param` - (Optional) New Cloud Subnet Parameters. Parameters for creating a new cloud subnet (`Block`).
 
 <a id="ingress-gw-performance-enhancement-mode"></a>
 
@@ -819,59 +627,35 @@ In addition to all arguments above, the following attributes are exported:
 
 `perf_mode_l3_enhanced` - (Optional) L3 Mode Enhanced Performance. x-required L3 enhanced performance mode options. See [Perf Mode L3 Enhanced](#ingress-gw-performance-enhancement-mode-perf-mode-l3-enhanced) below.
 
-`perf_mode_l7_enhanced` - (Optional) Empty. This can be used for messages where no values are needed. See [Perf Mode L7 Enhanced](#ingress-gw-performance-enhancement-mode-perf-mode-l7-enhanced) below.
+`perf_mode_l7_enhanced` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="ingress-gw-performance-enhancement-mode-perf-mode-l3-enhanced"></a>
 
 ### Ingress Gw Performance Enhancement Mode Perf Mode L3 Enhanced
 
-`jumbo` - (Optional) Empty. This can be used for messages where no values are needed. See [Jumbo](#ingress-gw-performance-enhancement-mode-perf-mode-l3-enhanced-jumbo) below.
+`jumbo` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_jumbo` - (Optional) Empty. This can be used for messages where no values are needed. See [No Jumbo](#ingress-gw-performance-enhancement-mode-perf-mode-l3-enhanced-no-jumbo) below.
-
-<a id="ingress-gw-performance-enhancement-mode-perf-mode-l3-enhanced-jumbo"></a>
-
-### Ingress Gw Performance Enhancement Mode Perf Mode L3 Enhanced Jumbo
-
-<a id="ingress-gw-performance-enhancement-mode-perf-mode-l3-enhanced-no-jumbo"></a>
-
-### Ingress Gw Performance Enhancement Mode Perf Mode L3 Enhanced No Jumbo
-
-<a id="ingress-gw-performance-enhancement-mode-perf-mode-l7-enhanced"></a>
-
-### Ingress Gw Performance Enhancement Mode Perf Mode L7 Enhanced
+`no_jumbo` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="kubernetes-upgrade-drain"></a>
 
 ### Kubernetes Upgrade Drain
 
-`disable_upgrade_drain` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Upgrade Drain](#kubernetes-upgrade-drain-disable-upgrade-drain) below.
+`disable_upgrade_drain` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `enable_upgrade_drain` - (Optional) Enable Node by Node Upgrade. Specify batch upgrade settings for worker nodes within a site. See [Enable Upgrade Drain](#kubernetes-upgrade-drain-enable-upgrade-drain) below.
-
-<a id="kubernetes-upgrade-drain-disable-upgrade-drain"></a>
-
-### Kubernetes Upgrade Drain Disable Upgrade Drain
 
 <a id="kubernetes-upgrade-drain-enable-upgrade-drain"></a>
 
 ### Kubernetes Upgrade Drain Enable Upgrade Drain
 
-`disable_vega_upgrade_mode` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Vega Upgrade Mode](#kubernetes-upgrade-drain-enable-upgrade-drain-disable-vega-upgrade-mode) below.
+`disable_vega_upgrade_mode` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `drain_max_unavailable_node_count` - (Optional) Node Batch Size Count (`Number`).
 
 `drain_node_timeout` - (Optional) Upgrade Wait Time. Seconds to wait before initiating upgrade on the next set of nodes. Setting it to 0 will wait indefinitely for all services on nodes to be upgraded gracefully before proceeding to the next set of nodes. (Warning: It may block upgrade if services on a node cannot be gracefully upgraded. It is recommended to use the default value) (`Number`).
 
-`enable_vega_upgrade_mode` - (Optional) Empty. This can be used for messages where no values are needed. See [Enable Vega Upgrade Mode](#kubernetes-upgrade-drain-enable-upgrade-drain-enable-vega-upgrade-mode) below.
-
-<a id="kubernetes-upgrade-drain-enable-upgrade-drain-disable-vega-upgrade-mode"></a>
-
-### Kubernetes Upgrade Drain Enable Upgrade Drain Disable Vega Upgrade Mode
-
-<a id="kubernetes-upgrade-drain-enable-upgrade-drain-enable-vega-upgrade-mode"></a>
-
-### Kubernetes Upgrade Drain Enable Upgrade Drain Enable Vega Upgrade Mode
+`enable_vega_upgrade_mode` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="log-receiver"></a>
 
@@ -883,45 +667,21 @@ In addition to all arguments above, the following attributes are exported:
 
 `tenant` - (Optional) Tenant. When a configuration object(e.g. virtual_host) refers to another(e.g route) then tenant will hold the referred object's(e.g. route's) tenant (`String`).
 
-<a id="logs-streaming-disabled"></a>
-
-### Logs Streaming Disabled
-
-<a id="manual-routing"></a>
-
-### Manual Routing
-
-<a id="no-worker-nodes"></a>
-
-### No Worker Nodes
-
 <a id="offline-survivability-mode"></a>
 
 ### Offline Survivability Mode
 
-`enable_offline_survivability_mode` - (Optional) Empty. This can be used for messages where no values are needed. See [Enable Offline Survivability Mode](#offline-survivability-mode-enable-offline-survivability-mode) below.
+`enable_offline_survivability_mode` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_offline_survivability_mode` - (Optional) Empty. This can be used for messages where no values are needed. See [No Offline Survivability Mode](#offline-survivability-mode-no-offline-survivability-mode) below.
-
-<a id="offline-survivability-mode-enable-offline-survivability-mode"></a>
-
-### Offline Survivability Mode Enable Offline Survivability Mode
-
-<a id="offline-survivability-mode-no-offline-survivability-mode"></a>
-
-### Offline Survivability Mode No Offline Survivability Mode
+`no_offline_survivability_mode` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="os"></a>
 
 ### OS
 
-`default_os_version` - (Optional) Empty. This can be used for messages where no values are needed. See [Default OS Version](#os-default-os-version) below.
+`default_os_version` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `operating_system_version` - (Optional) Operating System Version. Specify a OS version to be used e.g. 9.2024.6 (`String`).
-
-<a id="os-default-os-version"></a>
-
-### OS Default OS Version
 
 <a id="private-connectivity"></a>
 
@@ -929,9 +689,9 @@ In addition to all arguments above, the following attributes are exported:
 
 `cloud_link` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Cloud Link](#private-connectivity-cloud-link) below.
 
-`inside` - (Optional) Empty. This can be used for messages where no values are needed. See [Inside](#private-connectivity-inside) below.
+`inside` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`outside` - (Optional) Empty. This can be used for messages where no values are needed. See [Outside](#private-connectivity-outside) below.
+`outside` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="private-connectivity-cloud-link"></a>
 
@@ -943,29 +703,13 @@ In addition to all arguments above, the following attributes are exported:
 
 `tenant` - (Optional) Tenant. When a configuration object(e.g. virtual_host) refers to another(e.g route) then tenant will hold the referred object's(e.g. route's) tenant (`String`).
 
-<a id="private-connectivity-inside"></a>
-
-### Private Connectivity Inside
-
-<a id="private-connectivity-outside"></a>
-
-### Private Connectivity Outside
-
 <a id="sw"></a>
 
 ### Sw
 
-`default_sw_version` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Sw Version](#sw-default-sw-version) below.
+`default_sw_version` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `volterra_software_version` - (Optional) F5XC Software Version. Specify a F5XC Software Version to be used e.g. crt-20210329-1002 (`String`).
-
-<a id="sw-default-sw-version"></a>
-
-### Sw Default Sw Version
-
-<a id="tags"></a>
-
-### Tags
 
 <a id="timeouts"></a>
 
@@ -997,31 +741,31 @@ In addition to all arguments above, the following attributes are exported:
 
 `dc_cluster_group` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Dc Cluster Group](#voltstack-cluster-dc-cluster-group) below.
 
-`default_storage` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Storage](#voltstack-cluster-default-storage) below.
+`default_storage` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`forward_proxy_allow_all` - (Optional) Empty. This can be used for messages where no values are needed. See [Forward Proxy Allow All](#voltstack-cluster-forward-proxy-allow-all) below.
+`forward_proxy_allow_all` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `global_network_list` - (Optional) Global Network Connection List. List of global network connections. See [Global Network List](#voltstack-cluster-global-network-list) below.
 
 `k8s_cluster` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [K8s Cluster](#voltstack-cluster-k8s-cluster) below.
 
-`no_dc_cluster_group` - (Optional) Empty. This can be used for messages where no values are needed. See [No Dc Cluster Group](#voltstack-cluster-no-dc-cluster-group) below.
+`no_dc_cluster_group` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_forward_proxy` - (Optional) Empty. This can be used for messages where no values are needed. See [No Forward Proxy](#voltstack-cluster-no-forward-proxy) below.
+`no_forward_proxy` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_global_network` - (Optional) Empty. This can be used for messages where no values are needed. See [No Global Network](#voltstack-cluster-no-global-network) below.
+`no_global_network` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_k8s_cluster` - (Optional) Empty. This can be used for messages where no values are needed. See [No K8s Cluster](#voltstack-cluster-no-k8s-cluster) below.
+`no_k8s_cluster` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_network_policy` - (Optional) Empty. This can be used for messages where no values are needed. See [No Network Policy](#voltstack-cluster-no-network-policy) below.
+`no_network_policy` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_outside_static_routes` - (Optional) Empty. This can be used for messages where no values are needed. See [No Outside Static Routes](#voltstack-cluster-no-outside-static-routes) below.
+`no_outside_static_routes` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `outside_static_routes` - (Optional) Static Route List Type. List of static routes. See [Outside Static Routes](#voltstack-cluster-outside-static-routes) below.
 
-`sm_connection_public_ip` - (Optional) Empty. This can be used for messages where no values are needed. See [Sm Connection Public IP](#voltstack-cluster-sm-connection-public-ip) below.
+`sm_connection_public_ip` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`sm_connection_pvt_ip` - (Optional) Empty. This can be used for messages where no values are needed. See [Sm Connection Pvt IP](#voltstack-cluster-sm-connection-pvt-ip) below.
+`sm_connection_pvt_ip` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `storage_class_list` - (Optional) Custom Storage Class List. Add additional custom storage classes in kubernetes for this site. See [Storage Class List](#voltstack-cluster-storage-class-list) below.
 
@@ -1079,35 +823,19 @@ In addition to all arguments above, the following attributes are exported:
 
 `custom_ports` - (Optional) Custom Ports. List of Custom port. See [Custom Ports](#voltstack-cluster-allowed-vip-port-custom-ports) below.
 
-`disable_allowed_vip_port` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Allowed VIP Port](#voltstack-cluster-allowed-vip-port-disable-allowed-vip-port) below.
+`disable_allowed_vip_port` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`use_http_https_port` - (Optional) Empty. This can be used for messages where no values are needed. See [Use HTTP HTTPS Port](#voltstack-cluster-allowed-vip-port-use-http-https-port) below.
+`use_http_https_port` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`use_http_port` - (Optional) Empty. This can be used for messages where no values are needed. See [Use HTTP Port](#voltstack-cluster-allowed-vip-port-use-http-port) below.
+`use_http_port` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`use_https_port` - (Optional) Empty. This can be used for messages where no values are needed. See [Use HTTPS Port](#voltstack-cluster-allowed-vip-port-use-https-port) below.
+`use_https_port` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="voltstack-cluster-allowed-vip-port-custom-ports"></a>
 
 ### Voltstack Cluster Allowed VIP Port Custom Ports
 
 `port_ranges` - (Optional) Port Ranges. Port Ranges (`String`).
-
-<a id="voltstack-cluster-allowed-vip-port-disable-allowed-vip-port"></a>
-
-### Voltstack Cluster Allowed VIP Port Disable Allowed VIP Port
-
-<a id="voltstack-cluster-allowed-vip-port-use-http-https-port"></a>
-
-### Voltstack Cluster Allowed VIP Port Use HTTP HTTPS Port
-
-<a id="voltstack-cluster-allowed-vip-port-use-http-port"></a>
-
-### Voltstack Cluster Allowed VIP Port Use HTTP Port
-
-<a id="voltstack-cluster-allowed-vip-port-use-https-port"></a>
-
-### Voltstack Cluster Allowed VIP Port Use HTTPS Port
 
 <a id="voltstack-cluster-az-nodes"></a>
 
@@ -1123,11 +851,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `existing_subnet_id` - (Optional) Existing Subnet ID. Information about existing subnet ID (`String`).
 
-`subnet_param` - (Optional) New Cloud Subnet Parameters. Parameters for creating a new cloud subnet. See [Subnet Param](#voltstack-cluster-az-nodes-local-subnet-subnet-param) below.
-
-<a id="voltstack-cluster-az-nodes-local-subnet-subnet-param"></a>
-
-### Voltstack Cluster Az Nodes Local Subnet Subnet Param
+`subnet_param` - (Optional) New Cloud Subnet Parameters. Parameters for creating a new cloud subnet (`Block`).
 
 <a id="voltstack-cluster-dc-cluster-group"></a>
 
@@ -1139,14 +863,6 @@ In addition to all arguments above, the following attributes are exported:
 
 `tenant` - (Optional) Tenant. When a configuration object(e.g. virtual_host) refers to another(e.g route) then tenant will hold the referred object's(e.g. route's) tenant (`String`).
 
-<a id="voltstack-cluster-default-storage"></a>
-
-### Voltstack Cluster Default Storage
-
-<a id="voltstack-cluster-forward-proxy-allow-all"></a>
-
-### Voltstack Cluster Forward Proxy Allow All
-
 <a id="voltstack-cluster-global-network-list"></a>
 
 ### Voltstack Cluster Global Network List
@@ -1157,17 +873,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Voltstack Cluster Global Network List Global Network Connections
 
-`sli_to_global_dr` - (Optional) Global Network. Global network reference for direct connection. See [Sli To Global DR](#voltstack-cluster-global-network-list-global-network-connections-sli-to-global-dr) below.
+`sli_to_global_dr` - (Optional) Global Network. Global network reference for direct connection (`Block`).
 
-`slo_to_global_dr` - (Optional) Global Network. Global network reference for direct connection. See [Slo To Global DR](#voltstack-cluster-global-network-list-global-network-connections-slo-to-global-dr) below.
-
-<a id="voltstack-cluster-global-network-list-global-network-connections-sli-to-global-dr"></a>
-
-### Voltstack Cluster Global Network List Global Network Connections Sli To Global DR
-
-<a id="voltstack-cluster-global-network-list-global-network-connections-slo-to-global-dr"></a>
-
-### Voltstack Cluster Global Network List Global Network Connections Slo To Global DR
+`slo_to_global_dr` - (Optional) Global Network. Global network reference for direct connection (`Block`).
 
 <a id="voltstack-cluster-k8s-cluster"></a>
 
@@ -1179,30 +887,6 @@ In addition to all arguments above, the following attributes are exported:
 
 `tenant` - (Optional) Tenant. When a configuration object(e.g. virtual_host) refers to another(e.g route) then tenant will hold the referred object's(e.g. route's) tenant (`String`).
 
-<a id="voltstack-cluster-no-dc-cluster-group"></a>
-
-### Voltstack Cluster No Dc Cluster Group
-
-<a id="voltstack-cluster-no-forward-proxy"></a>
-
-### Voltstack Cluster No Forward Proxy
-
-<a id="voltstack-cluster-no-global-network"></a>
-
-### Voltstack Cluster No Global Network
-
-<a id="voltstack-cluster-no-k8s-cluster"></a>
-
-### Voltstack Cluster No K8s Cluster
-
-<a id="voltstack-cluster-no-network-policy"></a>
-
-### Voltstack Cluster No Network Policy
-
-<a id="voltstack-cluster-no-outside-static-routes"></a>
-
-### Voltstack Cluster No Outside Static Routes
-
 <a id="voltstack-cluster-outside-static-routes"></a>
 
 ### Voltstack Cluster Outside Static Routes
@@ -1213,21 +897,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Voltstack Cluster Outside Static Routes Static Route List
 
-`custom_static_route` - (Optional) Static Route. Defines a static route, configuring a list of prefixes and a next-hop to be used for them. See [Custom Static Route](#voltstack-cluster-outside-static-routes-static-route-list-custom-static-route) below.
+`custom_static_route` - (Optional) Static Route. Defines a static route, configuring a list of prefixes and a next-hop to be used for them (`Block`).
 
 `simple_static_route` - (Optional) Simple Static Route. Use simple static route for prefix pointing to single interface in the network (`String`).
-
-<a id="voltstack-cluster-outside-static-routes-static-route-list-custom-static-route"></a>
-
-### Voltstack Cluster Outside Static Routes Static Route List Custom Static Route
-
-<a id="voltstack-cluster-sm-connection-public-ip"></a>
-
-### Voltstack Cluster Sm Connection Public IP
-
-<a id="voltstack-cluster-sm-connection-pvt-ip"></a>
-
-### Voltstack Cluster Sm Connection Pvt IP
 
 <a id="voltstack-cluster-storage-class-list"></a>
 
@@ -1255,15 +927,11 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Vpc New Vpc
 
-`autogenerate` - (Optional) Empty. This can be used for messages where no values are needed. See [Autogenerate](#vpc-new-vpc-autogenerate) below.
+`autogenerate` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `name_tag` - (Optional) Choose VPC Name. Specify the VPC Name (`String`).
 
 `primary_ipv4` - (Optional) Primary IPv4 CIDR block. IPv4 CIDR block for this VPC. It has to be private address space. The Primary IPv4 block cannot be modified. All subnets prefixes in this VPC must be part of this CIDR block (`String`).
-
-<a id="vpc-new-vpc-autogenerate"></a>
-
-### Vpc New Vpc Autogenerate
 
 ## Import
 

--- a/docs/resources/azure_vnet_site.md
+++ b/docs/resources/azure_vnet_site.md
@@ -106,11 +106,11 @@ resource "f5xc_azure_vnet_site" "example" {
 
 > **Note:** One of the arguments from this list "block_all_services, blocked_services, default_blocked_services" must be set.
 
-`block_all_services` - (Optional) Empty. This can be used for messages where no values are needed. See [Block All Services](#block-all-services) below for details.
+`block_all_services` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `blocked_services` - (Optional) Disable Node Local Services. Disable node local services on this site. Note: The chosen services will get disabled on all nodes in the site. See [Blocked Services](#blocked-services) below for details.
 
-`default_blocked_services` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Blocked Services](#default-blocked-services) below for details.
+`default_blocked_services` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `coordinates` - (Optional) Site Coordinates. Coordinates of the site which provides the site physical location. See [Coordinates](#coordinates) below for details.
 
@@ -138,13 +138,13 @@ resource "f5xc_azure_vnet_site" "example" {
 
 `log_receiver` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Log Receiver](#log-receiver) below for details.
 
-`logs_streaming_disabled` - (Optional) Empty. This can be used for messages where no values are needed. See [Logs Streaming Disabled](#logs-streaming-disabled) below for details.
+`logs_streaming_disabled` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `machine_type` - (Optional) Azure Machine Type for Node. Select Instance size based on performance needed. The default setting for Accelerated Networking is enabled, thus make sure you select a Virtual Machine that supports accelerated networking or disable the setting under, Select Ingress Gateway or Ingress/Egress Gateway > advanced options (`String`).
 
 > **Note:** One of the arguments from this list "no_worker_nodes, nodes_per_az, total_nodes" must be set.
 
-`no_worker_nodes` - (Optional) Empty. This can be used for messages where no values are needed. See [No Worker Nodes](#no-worker-nodes) below for details.
+`no_worker_nodes` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `nodes_per_az` - (Optional) Desired Worker Nodes Per AZ. Desired Worker Nodes Per AZ. Max limit is up to 21 (`Number`).
 
@@ -160,7 +160,7 @@ resource "f5xc_azure_vnet_site" "example" {
 
 `sw` - (Optional) F5XC Software Version. Select the F5XC Software Version for the site. By default, latest available F5XC Software Version will be used. Refer to release notes to find required released SW versions. See [Sw](#sw) below for details.
 
-`tags` - (Optional) Azure Tags. Azure Tags is a label consisting of a user-defined key and value. It helps to manage, identify, organize, search for, and filter resources in Azure console. See [Tags](#tags) below for details.
+`tags` - (Optional) Azure Tags. Azure Tags is a label consisting of a user-defined key and value. It helps to manage, identify, organize, search for, and filter resources in Azure console (`Block`).
 
 `timeouts` - (Optional) See [Timeouts](#timeouts) below for details.
 
@@ -210,10 +210,6 @@ In addition to all arguments above, the following attributes are exported:
 
 `tenant` - (Optional) Tenant. When a configuration object(e.g. virtual_host) refers to another(e.g route) then tenant will hold the referred object's(e.g. route's) tenant (`String`).
 
-<a id="block-all-services"></a>
-
-### Block All Services
-
 <a id="blocked-services"></a>
 
 ### Blocked Services
@@ -224,25 +220,13 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Blocked Services Blocked Sevice
 
-`dns` - (Optional) Empty. This can be used for messages where no values are needed. See [DNS](#blocked-services-blocked-sevice-dns) below.
+`dns` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `network_type` - (Optional) Virtual Network Type. Different types of virtual networks understood by the system Virtual-network of type VIRTUAL_NETWORK_SITE_LOCAL provides connectivity to public (outside) network. This is an insecure network and is connected to public internet via NAT Gateways/firwalls Virtual-network of this type is local to every site. Two virtual networks of this type on different sites are neither related nor connected. Constraints: There can be atmost one virtual network of this type in a given site... Possible values include `VIRTUAL_NETWORK_SITE_LOCAL`, `VIRTUAL_NETWORK_SITE_LOCAL_INSIDE`, `VIRTUAL_NETWORK_PER_SITE`, `VIRTUAL_NETWORK_PUBLIC`, `VIRTUAL_NETWORK_GLOBAL`, `VIRTUAL_NETWORK_SITE_SERVICE`, `VIRTUAL_NETWORK_VER_INTERNAL`, `VIRTUAL_NETWORK_SITE_LOCAL_INSIDE_OUTSIDE`, `VIRTUAL_NETWORK_IP_AUTO`, `VIRTUAL_NETWORK_VOLTADN_PRIVATE_NETWORK`, and others. Defaults to `VIRTUAL_NETWORK_SITE_LOCAL` (`String`).
 
-`ssh` - (Optional) Empty. This can be used for messages where no values are needed. See [SSH](#blocked-services-blocked-sevice-ssh) below.
+`ssh` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`web_user_interface` - (Optional) Empty. This can be used for messages where no values are needed. See [Web User Interface](#blocked-services-blocked-sevice-web-user-interface) below.
-
-<a id="blocked-services-blocked-sevice-dns"></a>
-
-### Blocked Services Blocked Sevice DNS
-
-<a id="blocked-services-blocked-sevice-ssh"></a>
-
-### Blocked Services Blocked Sevice SSH
-
-<a id="blocked-services-blocked-sevice-web-user-interface"></a>
-
-### Blocked Services Blocked Sevice Web User Interface
+`web_user_interface` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="coordinates"></a>
 
@@ -259,10 +243,6 @@ In addition to all arguments above, the following attributes are exported:
 `inside_nameserver` - (Optional) DNS Server for Inside Network. Optional DNS server IP to be used for name resolution in inside network (`String`).
 
 `outside_nameserver` - (Optional) DNS Server for Outside Network. Optional DNS server IP to be used for name resolution in outside network (`String`).
-
-<a id="default-blocked-services"></a>
-
-### Default Blocked Services
 
 <a id="ingress-egress-gw"></a>
 
@@ -284,7 +264,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `dc_cluster_group_outside_vn` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Dc Cluster Group Outside Vn](#ingress-egress-gw-dc-cluster-group-outside-vn) below.
 
-`forward_proxy_allow_all` - (Optional) Empty. This can be used for messages where no values are needed. See [Forward Proxy Allow All](#ingress-egress-gw-forward-proxy-allow-all) below.
+`forward_proxy_allow_all` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `global_network_list` - (Optional) Global Network Connection List. List of global network connections. See [Global Network List](#ingress-egress-gw-global-network-list) below.
 
@@ -292,43 +272,35 @@ In addition to all arguments above, the following attributes are exported:
 
 `inside_static_routes` - (Optional) Static Route List Type. List of static routes. See [Inside Static Routes](#ingress-egress-gw-inside-static-routes) below.
 
-`no_dc_cluster_group` - (Optional) Empty. This can be used for messages where no values are needed. See [No Dc Cluster Group](#ingress-egress-gw-no-dc-cluster-group) below.
+`no_dc_cluster_group` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_forward_proxy` - (Optional) Empty. This can be used for messages where no values are needed. See [No Forward Proxy](#ingress-egress-gw-no-forward-proxy) below.
+`no_forward_proxy` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_global_network` - (Optional) Empty. This can be used for messages where no values are needed. See [No Global Network](#ingress-egress-gw-no-global-network) below.
+`no_global_network` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_inside_static_routes` - (Optional) Empty. This can be used for messages where no values are needed. See [No Inside Static Routes](#ingress-egress-gw-no-inside-static-routes) below.
+`no_inside_static_routes` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_network_policy` - (Optional) Empty. This can be used for messages where no values are needed. See [No Network Policy](#ingress-egress-gw-no-network-policy) below.
+`no_network_policy` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_outside_static_routes` - (Optional) Empty. This can be used for messages where no values are needed. See [No Outside Static Routes](#ingress-egress-gw-no-outside-static-routes) below.
+`no_outside_static_routes` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`not_hub` - (Optional) Empty. This can be used for messages where no values are needed. See [Not Hub](#ingress-egress-gw-not-hub) below.
+`not_hub` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `outside_static_routes` - (Optional) Static Route List Type. List of static routes. See [Outside Static Routes](#ingress-egress-gw-outside-static-routes) below.
 
 `performance_enhancement_mode` - (Optional) Performance Enhancement Mode. x-required Optimize the site for L3 or L7 traffic processing. L7 optimized is the default. See [Performance Enhancement Mode](#ingress-egress-gw-performance-enhancement-mode) below.
 
-`sm_connection_public_ip` - (Optional) Empty. This can be used for messages where no values are needed. See [Sm Connection Public IP](#ingress-egress-gw-sm-connection-public-ip) below.
+`sm_connection_public_ip` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`sm_connection_pvt_ip` - (Optional) Empty. This can be used for messages where no values are needed. See [Sm Connection Pvt IP](#ingress-egress-gw-sm-connection-pvt-ip) below.
+`sm_connection_pvt_ip` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="ingress-egress-gw-accelerated-networking"></a>
 
 ### Ingress Egress Gw Accelerated Networking
 
-`disable` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable](#ingress-egress-gw-accelerated-networking-disable) below.
+`disable` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`enable` - (Optional) Empty. This can be used for messages where no values are needed. See [Enable](#ingress-egress-gw-accelerated-networking-enable) below.
-
-<a id="ingress-egress-gw-accelerated-networking-disable"></a>
-
-### Ingress Egress Gw Accelerated Networking Disable
-
-<a id="ingress-egress-gw-accelerated-networking-enable"></a>
-
-### Ingress Egress Gw Accelerated Networking Enable
+`enable` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="ingress-egress-gw-active-enhanced-firewall-policies"></a>
 
@@ -392,33 +364,17 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Ingress Egress Gw Az Nodes Inside Subnet
 
-`subnet` - (Optional) Azure Subnet. Parameters for Azure subnet. See [Subnet](#ingress-egress-gw-az-nodes-inside-subnet-subnet) below.
+`subnet` - (Optional) Azure Subnet. Parameters for Azure subnet (`Block`).
 
-`subnet_param` - (Optional) New Cloud Subnet Parameters. Parameters for creating a new cloud subnet. See [Subnet Param](#ingress-egress-gw-az-nodes-inside-subnet-subnet-param) below.
-
-<a id="ingress-egress-gw-az-nodes-inside-subnet-subnet"></a>
-
-### Ingress Egress Gw Az Nodes Inside Subnet Subnet
-
-<a id="ingress-egress-gw-az-nodes-inside-subnet-subnet-param"></a>
-
-### Ingress Egress Gw Az Nodes Inside Subnet Subnet Param
+`subnet_param` - (Optional) New Cloud Subnet Parameters. Parameters for creating a new cloud subnet (`Block`).
 
 <a id="ingress-egress-gw-az-nodes-outside-subnet"></a>
 
 ### Ingress Egress Gw Az Nodes Outside Subnet
 
-`subnet` - (Optional) Azure Subnet. Parameters for Azure subnet. See [Subnet](#ingress-egress-gw-az-nodes-outside-subnet-subnet) below.
+`subnet` - (Optional) Azure Subnet. Parameters for Azure subnet (`Block`).
 
-`subnet_param` - (Optional) New Cloud Subnet Parameters. Parameters for creating a new cloud subnet. See [Subnet Param](#ingress-egress-gw-az-nodes-outside-subnet-subnet-param) below.
-
-<a id="ingress-egress-gw-az-nodes-outside-subnet-subnet"></a>
-
-### Ingress Egress Gw Az Nodes Outside Subnet Subnet
-
-<a id="ingress-egress-gw-az-nodes-outside-subnet-subnet-param"></a>
-
-### Ingress Egress Gw Az Nodes Outside Subnet Subnet Param
+`subnet_param` - (Optional) New Cloud Subnet Parameters. Parameters for creating a new cloud subnet (`Block`).
 
 <a id="ingress-egress-gw-dc-cluster-group-inside-vn"></a>
 
@@ -440,10 +396,6 @@ In addition to all arguments above, the following attributes are exported:
 
 `tenant` - (Optional) Tenant. When a configuration object(e.g. virtual_host) refers to another(e.g route) then tenant will hold the referred object's(e.g. route's) tenant (`String`).
 
-<a id="ingress-egress-gw-forward-proxy-allow-all"></a>
-
-### Ingress Egress Gw Forward Proxy Allow All
-
 <a id="ingress-egress-gw-global-network-list"></a>
 
 ### Ingress Egress Gw Global Network List
@@ -454,137 +406,61 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Ingress Egress Gw Global Network List Global Network Connections
 
-`sli_to_global_dr` - (Optional) Global Network. Global network reference for direct connection. See [Sli To Global DR](#ingress-egress-gw-global-network-list-global-network-connections-sli-to-global-dr) below.
+`sli_to_global_dr` - (Optional) Global Network. Global network reference for direct connection (`Block`).
 
-`slo_to_global_dr` - (Optional) Global Network. Global network reference for direct connection. See [Slo To Global DR](#ingress-egress-gw-global-network-list-global-network-connections-slo-to-global-dr) below.
-
-<a id="ingress-egress-gw-global-network-list-global-network-connections-sli-to-global-dr"></a>
-
-### Ingress Egress Gw Global Network List Global Network Connections Sli To Global DR
-
-<a id="ingress-egress-gw-global-network-list-global-network-connections-slo-to-global-dr"></a>
-
-### Ingress Egress Gw Global Network List Global Network Connections Slo To Global DR
+`slo_to_global_dr` - (Optional) Global Network. Global network reference for direct connection (`Block`).
 
 <a id="ingress-egress-gw-hub"></a>
 
 ### Ingress Egress Gw Hub
 
-`express_route_disabled` - (Optional) Empty. This can be used for messages where no values are needed. See [Express Route Disabled](#ingress-egress-gw-hub-express-route-disabled) below.
+`express_route_disabled` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `express_route_enabled` - (Optional) Express Route Configuration. Express Route Configuration. See [Express Route Enabled](#ingress-egress-gw-hub-express-route-enabled) below.
 
 `spoke_vnets` - (Optional) Spoke VNet Peering (Legacy). Spoke VNet Peering. See [Spoke Vnets](#ingress-egress-gw-hub-spoke-vnets) below.
 
-<a id="ingress-egress-gw-hub-express-route-disabled"></a>
-
-### Ingress Egress Gw Hub Express Route Disabled
-
 <a id="ingress-egress-gw-hub-express-route-enabled"></a>
 
 ### Ingress Egress Gw Hub Express Route Enabled
 
-`advertise_to_route_server` - (Optional) Empty. This can be used for messages where no values are needed. See [Advertise To Route Server](#ingress-egress-gw-hub-express-route-enabled-advertise-to-route-server) below.
+`advertise_to_route_server` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`auto_asn` - (Optional) Empty. This can be used for messages where no values are needed. See [Auto Asn](#ingress-egress-gw-hub-express-route-enabled-auto-asn) below.
+`auto_asn` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`connections` - (Optional) Connections. Add the ExpressRoute Circuit Connections to this site. See [Connections](#ingress-egress-gw-hub-express-route-enabled-connections) below.
+`connections` - (Optional) Connections. Add the ExpressRoute Circuit Connections to this site (`Block`).
 
 `custom_asn` - (Optional) Custom ASN. Set custom ASN for F5XC Site (`Number`).
 
-`do_not_advertise_to_route_server` - (Optional) Empty. This can be used for messages where no values are needed. See [Do Not Advertise To Route Server](#ingress-egress-gw-hub-express-route-enabled-do-not-advertise-to-route-server) below.
+`do_not_advertise_to_route_server` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`gateway_subnet` - (Optional) Azure Subnet. Parameters for Azure subnet. See [Gateway Subnet](#ingress-egress-gw-hub-express-route-enabled-gateway-subnet) below.
+`gateway_subnet` - (Optional) Azure Subnet. Parameters for Azure subnet (`Block`).
 
-`route_server_subnet` - (Optional) Azure Subnet. Parameters for Azure subnet. See [Route Server Subnet](#ingress-egress-gw-hub-express-route-enabled-route-server-subnet) below.
+`route_server_subnet` - (Optional) Azure Subnet. Parameters for Azure subnet (`Block`).
 
-`site_registration_over_express_route` - (Optional) CloudLink ADN Network Config. See [Site Registration Over Express Route](#ingress-egress-gw-hub-express-route-enabled-site-registration-over-express-route) below.
+`site_registration_over_express_route` - (Optional) CloudLink ADN Network Config (`Block`).
 
-`site_registration_over_internet` - (Optional) Empty. This can be used for messages where no values are needed. See [Site Registration Over Internet](#ingress-egress-gw-hub-express-route-enabled-site-registration-over-internet) below.
+`site_registration_over_internet` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`sku_ergw1az` - (Optional) Empty. This can be used for messages where no values are needed. See [Sku Ergw1az](#ingress-egress-gw-hub-express-route-enabled-sku-ergw1az) below.
+`sku_ergw1az` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`sku_ergw2az` - (Optional) Empty. This can be used for messages where no values are needed. See [Sku Ergw2az](#ingress-egress-gw-hub-express-route-enabled-sku-ergw2az) below.
+`sku_ergw2az` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`sku_high_perf` - (Optional) Empty. This can be used for messages where no values are needed. See [Sku High Perf](#ingress-egress-gw-hub-express-route-enabled-sku-high-perf) below.
+`sku_high_perf` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`sku_standard` - (Optional) Empty. This can be used for messages where no values are needed. See [Sku Standard](#ingress-egress-gw-hub-express-route-enabled-sku-standard) below.
-
-<a id="ingress-egress-gw-hub-express-route-enabled-advertise-to-route-server"></a>
-
-### Ingress Egress Gw Hub Express Route Enabled Advertise To Route Server
-
-<a id="ingress-egress-gw-hub-express-route-enabled-auto-asn"></a>
-
-### Ingress Egress Gw Hub Express Route Enabled Auto Asn
-
-<a id="ingress-egress-gw-hub-express-route-enabled-connections"></a>
-
-### Ingress Egress Gw Hub Express Route Enabled Connections
-
-<a id="ingress-egress-gw-hub-express-route-enabled-do-not-advertise-to-route-server"></a>
-
-### Ingress Egress Gw Hub Express Route Enabled Do Not Advertise To Route Server
-
-<a id="ingress-egress-gw-hub-express-route-enabled-gateway-subnet"></a>
-
-### Ingress Egress Gw Hub Express Route Enabled Gateway Subnet
-
-<a id="ingress-egress-gw-hub-express-route-enabled-route-server-subnet"></a>
-
-### Ingress Egress Gw Hub Express Route Enabled Route Server Subnet
-
-<a id="ingress-egress-gw-hub-express-route-enabled-site-registration-over-express-route"></a>
-
-### Ingress Egress Gw Hub Express Route Enabled Site Registration Over Express Route
-
-<a id="ingress-egress-gw-hub-express-route-enabled-site-registration-over-internet"></a>
-
-### Ingress Egress Gw Hub Express Route Enabled Site Registration Over Internet
-
-<a id="ingress-egress-gw-hub-express-route-enabled-sku-ergw1az"></a>
-
-### Ingress Egress Gw Hub Express Route Enabled Sku Ergw1az
-
-<a id="ingress-egress-gw-hub-express-route-enabled-sku-ergw2az"></a>
-
-### Ingress Egress Gw Hub Express Route Enabled Sku Ergw2az
-
-<a id="ingress-egress-gw-hub-express-route-enabled-sku-high-perf"></a>
-
-### Ingress Egress Gw Hub Express Route Enabled Sku High Perf
-
-<a id="ingress-egress-gw-hub-express-route-enabled-sku-standard"></a>
-
-### Ingress Egress Gw Hub Express Route Enabled Sku Standard
+`sku_standard` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="ingress-egress-gw-hub-spoke-vnets"></a>
 
 ### Ingress Egress Gw Hub Spoke Vnets
 
-`auto` - (Optional) Empty. This can be used for messages where no values are needed. See [Auto](#ingress-egress-gw-hub-spoke-vnets-auto) below.
+`auto` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`labels` - (Optional) Labels For VNets Peering. Add Labels for each of the VNets peered with transit VNet, these labels can be used in firewall policy These labels used must be from known key and label defined in shared namespace. See [Labels](#ingress-egress-gw-hub-spoke-vnets-labels) below.
+`labels` - (Optional) Labels For VNets Peering. Add Labels for each of the VNets peered with transit VNet, these labels can be used in firewall policy These labels used must be from known key and label defined in shared namespace (`Block`).
 
-`manual` - (Optional) Empty. This can be used for messages where no values are needed. See [Manual](#ingress-egress-gw-hub-spoke-vnets-manual) below.
+`manual` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`vnet` - (Optional) Azure Existing Vnet Type. Resource group and name of existing Azure Vnet. See [Vnet](#ingress-egress-gw-hub-spoke-vnets-vnet) below.
-
-<a id="ingress-egress-gw-hub-spoke-vnets-auto"></a>
-
-### Ingress Egress Gw Hub Spoke Vnets Auto
-
-<a id="ingress-egress-gw-hub-spoke-vnets-labels"></a>
-
-### Ingress Egress Gw Hub Spoke Vnets Labels
-
-<a id="ingress-egress-gw-hub-spoke-vnets-manual"></a>
-
-### Ingress Egress Gw Hub Spoke Vnets Manual
-
-<a id="ingress-egress-gw-hub-spoke-vnets-vnet"></a>
-
-### Ingress Egress Gw Hub Spoke Vnets Vnet
+`vnet` - (Optional) Azure Existing Vnet Type. Resource group and name of existing Azure Vnet (`Block`).
 
 <a id="ingress-egress-gw-inside-static-routes"></a>
 
@@ -596,41 +472,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Ingress Egress Gw Inside Static Routes Static Route List
 
-`custom_static_route` - (Optional) Static Route. Defines a static route, configuring a list of prefixes and a next-hop to be used for them. See [Custom Static Route](#ingress-egress-gw-inside-static-routes-static-route-list-custom-static-route) below.
+`custom_static_route` - (Optional) Static Route. Defines a static route, configuring a list of prefixes and a next-hop to be used for them (`Block`).
 
 `simple_static_route` - (Optional) Simple Static Route. Use simple static route for prefix pointing to single interface in the network (`String`).
-
-<a id="ingress-egress-gw-inside-static-routes-static-route-list-custom-static-route"></a>
-
-### Ingress Egress Gw Inside Static Routes Static Route List Custom Static Route
-
-<a id="ingress-egress-gw-no-dc-cluster-group"></a>
-
-### Ingress Egress Gw No Dc Cluster Group
-
-<a id="ingress-egress-gw-no-forward-proxy"></a>
-
-### Ingress Egress Gw No Forward Proxy
-
-<a id="ingress-egress-gw-no-global-network"></a>
-
-### Ingress Egress Gw No Global Network
-
-<a id="ingress-egress-gw-no-inside-static-routes"></a>
-
-### Ingress Egress Gw No Inside Static Routes
-
-<a id="ingress-egress-gw-no-network-policy"></a>
-
-### Ingress Egress Gw No Network Policy
-
-<a id="ingress-egress-gw-no-outside-static-routes"></a>
-
-### Ingress Egress Gw No Outside Static Routes
-
-<a id="ingress-egress-gw-not-hub"></a>
-
-### Ingress Egress Gw Not Hub
 
 <a id="ingress-egress-gw-outside-static-routes"></a>
 
@@ -642,13 +486,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Ingress Egress Gw Outside Static Routes Static Route List
 
-`custom_static_route` - (Optional) Static Route. Defines a static route, configuring a list of prefixes and a next-hop to be used for them. See [Custom Static Route](#ingress-egress-gw-outside-static-routes-static-route-list-custom-static-route) below.
+`custom_static_route` - (Optional) Static Route. Defines a static route, configuring a list of prefixes and a next-hop to be used for them (`Block`).
 
 `simple_static_route` - (Optional) Simple Static Route. Use simple static route for prefix pointing to single interface in the network (`String`).
-
-<a id="ingress-egress-gw-outside-static-routes-static-route-list-custom-static-route"></a>
-
-### Ingress Egress Gw Outside Static Routes Static Route List Custom Static Route
 
 <a id="ingress-egress-gw-performance-enhancement-mode"></a>
 
@@ -656,35 +496,15 @@ In addition to all arguments above, the following attributes are exported:
 
 `perf_mode_l3_enhanced` - (Optional) L3 Mode Enhanced Performance. x-required L3 enhanced performance mode options. See [Perf Mode L3 Enhanced](#ingress-egress-gw-performance-enhancement-mode-perf-mode-l3-enhanced) below.
 
-`perf_mode_l7_enhanced` - (Optional) Empty. This can be used for messages where no values are needed. See [Perf Mode L7 Enhanced](#ingress-egress-gw-performance-enhancement-mode-perf-mode-l7-enhanced) below.
+`perf_mode_l7_enhanced` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="ingress-egress-gw-performance-enhancement-mode-perf-mode-l3-enhanced"></a>
 
 ### Ingress Egress Gw Performance Enhancement Mode Perf Mode L3 Enhanced
 
-`jumbo` - (Optional) Empty. This can be used for messages where no values are needed. See [Jumbo](#ingress-egress-gw-performance-enhancement-mode-perf-mode-l3-enhanced-jumbo) below.
+`jumbo` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_jumbo` - (Optional) Empty. This can be used for messages where no values are needed. See [No Jumbo](#ingress-egress-gw-performance-enhancement-mode-perf-mode-l3-enhanced-no-jumbo) below.
-
-<a id="ingress-egress-gw-performance-enhancement-mode-perf-mode-l3-enhanced-jumbo"></a>
-
-### Ingress Egress Gw Performance Enhancement Mode Perf Mode L3 Enhanced Jumbo
-
-<a id="ingress-egress-gw-performance-enhancement-mode-perf-mode-l3-enhanced-no-jumbo"></a>
-
-### Ingress Egress Gw Performance Enhancement Mode Perf Mode L3 Enhanced No Jumbo
-
-<a id="ingress-egress-gw-performance-enhancement-mode-perf-mode-l7-enhanced"></a>
-
-### Ingress Egress Gw Performance Enhancement Mode Perf Mode L7 Enhanced
-
-<a id="ingress-egress-gw-sm-connection-public-ip"></a>
-
-### Ingress Egress Gw Sm Connection Public IP
-
-<a id="ingress-egress-gw-sm-connection-pvt-ip"></a>
-
-### Ingress Egress Gw Sm Connection Pvt IP
+`no_jumbo` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="ingress-egress-gw-ar"></a>
 
@@ -704,7 +524,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `dc_cluster_group_outside_vn` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Dc Cluster Group Outside Vn](#ingress-egress-gw-ar-dc-cluster-group-outside-vn) below.
 
-`forward_proxy_allow_all` - (Optional) Empty. This can be used for messages where no values are needed. See [Forward Proxy Allow All](#ingress-egress-gw-ar-forward-proxy-allow-all) below.
+`forward_proxy_allow_all` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `global_network_list` - (Optional) Global Network Connection List. List of global network connections. See [Global Network List](#ingress-egress-gw-ar-global-network-list) below.
 
@@ -712,45 +532,37 @@ In addition to all arguments above, the following attributes are exported:
 
 `inside_static_routes` - (Optional) Static Route List Type. List of static routes. See [Inside Static Routes](#ingress-egress-gw-ar-inside-static-routes) below.
 
-`no_dc_cluster_group` - (Optional) Empty. This can be used for messages where no values are needed. See [No Dc Cluster Group](#ingress-egress-gw-ar-no-dc-cluster-group) below.
+`no_dc_cluster_group` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_forward_proxy` - (Optional) Empty. This can be used for messages where no values are needed. See [No Forward Proxy](#ingress-egress-gw-ar-no-forward-proxy) below.
+`no_forward_proxy` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_global_network` - (Optional) Empty. This can be used for messages where no values are needed. See [No Global Network](#ingress-egress-gw-ar-no-global-network) below.
+`no_global_network` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_inside_static_routes` - (Optional) Empty. This can be used for messages where no values are needed. See [No Inside Static Routes](#ingress-egress-gw-ar-no-inside-static-routes) below.
+`no_inside_static_routes` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_network_policy` - (Optional) Empty. This can be used for messages where no values are needed. See [No Network Policy](#ingress-egress-gw-ar-no-network-policy) below.
+`no_network_policy` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_outside_static_routes` - (Optional) Empty. This can be used for messages where no values are needed. See [No Outside Static Routes](#ingress-egress-gw-ar-no-outside-static-routes) below.
+`no_outside_static_routes` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `node` - (Optional) Two Interface Node. Parameters for creating two interface Node in one AZ. See [Node](#ingress-egress-gw-ar-node) below.
 
-`not_hub` - (Optional) Empty. This can be used for messages where no values are needed. See [Not Hub](#ingress-egress-gw-ar-not-hub) below.
+`not_hub` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `outside_static_routes` - (Optional) Static Route List Type. List of static routes. See [Outside Static Routes](#ingress-egress-gw-ar-outside-static-routes) below.
 
 `performance_enhancement_mode` - (Optional) Performance Enhancement Mode. x-required Optimize the site for L3 or L7 traffic processing. L7 optimized is the default. See [Performance Enhancement Mode](#ingress-egress-gw-ar-performance-enhancement-mode) below.
 
-`sm_connection_public_ip` - (Optional) Empty. This can be used for messages where no values are needed. See [Sm Connection Public IP](#ingress-egress-gw-ar-sm-connection-public-ip) below.
+`sm_connection_public_ip` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`sm_connection_pvt_ip` - (Optional) Empty. This can be used for messages where no values are needed. See [Sm Connection Pvt IP](#ingress-egress-gw-ar-sm-connection-pvt-ip) below.
+`sm_connection_pvt_ip` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="ingress-egress-gw-ar-accelerated-networking"></a>
 
 ### Ingress Egress Gw Ar Accelerated Networking
 
-`disable` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable](#ingress-egress-gw-ar-accelerated-networking-disable) below.
+`disable` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`enable` - (Optional) Empty. This can be used for messages where no values are needed. See [Enable](#ingress-egress-gw-ar-accelerated-networking-enable) below.
-
-<a id="ingress-egress-gw-ar-accelerated-networking-disable"></a>
-
-### Ingress Egress Gw Ar Accelerated Networking Disable
-
-<a id="ingress-egress-gw-ar-accelerated-networking-enable"></a>
-
-### Ingress Egress Gw Ar Accelerated Networking Enable
+`enable` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="ingress-egress-gw-ar-active-enhanced-firewall-policies"></a>
 
@@ -820,10 +632,6 @@ In addition to all arguments above, the following attributes are exported:
 
 `tenant` - (Optional) Tenant. When a configuration object(e.g. virtual_host) refers to another(e.g route) then tenant will hold the referred object's(e.g. route's) tenant (`String`).
 
-<a id="ingress-egress-gw-ar-forward-proxy-allow-all"></a>
-
-### Ingress Egress Gw Ar Forward Proxy Allow All
-
 <a id="ingress-egress-gw-ar-global-network-list"></a>
 
 ### Ingress Egress Gw Ar Global Network List
@@ -834,137 +642,61 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Ingress Egress Gw Ar Global Network List Global Network Connections
 
-`sli_to_global_dr` - (Optional) Global Network. Global network reference for direct connection. See [Sli To Global DR](#ingress-egress-gw-ar-global-network-list-global-network-connections-sli-to-global-dr) below.
+`sli_to_global_dr` - (Optional) Global Network. Global network reference for direct connection (`Block`).
 
-`slo_to_global_dr` - (Optional) Global Network. Global network reference for direct connection. See [Slo To Global DR](#ingress-egress-gw-ar-global-network-list-global-network-connections-slo-to-global-dr) below.
-
-<a id="ingress-egress-gw-ar-global-network-list-global-network-connections-sli-to-global-dr"></a>
-
-### Ingress Egress Gw Ar Global Network List Global Network Connections Sli To Global DR
-
-<a id="ingress-egress-gw-ar-global-network-list-global-network-connections-slo-to-global-dr"></a>
-
-### Ingress Egress Gw Ar Global Network List Global Network Connections Slo To Global DR
+`slo_to_global_dr` - (Optional) Global Network. Global network reference for direct connection (`Block`).
 
 <a id="ingress-egress-gw-ar-hub"></a>
 
 ### Ingress Egress Gw Ar Hub
 
-`express_route_disabled` - (Optional) Empty. This can be used for messages where no values are needed. See [Express Route Disabled](#ingress-egress-gw-ar-hub-express-route-disabled) below.
+`express_route_disabled` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `express_route_enabled` - (Optional) Express Route Configuration. Express Route Configuration. See [Express Route Enabled](#ingress-egress-gw-ar-hub-express-route-enabled) below.
 
 `spoke_vnets` - (Optional) Spoke VNet Peering (Legacy). Spoke VNet Peering. See [Spoke Vnets](#ingress-egress-gw-ar-hub-spoke-vnets) below.
 
-<a id="ingress-egress-gw-ar-hub-express-route-disabled"></a>
-
-### Ingress Egress Gw Ar Hub Express Route Disabled
-
 <a id="ingress-egress-gw-ar-hub-express-route-enabled"></a>
 
 ### Ingress Egress Gw Ar Hub Express Route Enabled
 
-`advertise_to_route_server` - (Optional) Empty. This can be used for messages where no values are needed. See [Advertise To Route Server](#ingress-egress-gw-ar-hub-express-route-enabled-advertise-to-route-server) below.
+`advertise_to_route_server` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`auto_asn` - (Optional) Empty. This can be used for messages where no values are needed. See [Auto Asn](#ingress-egress-gw-ar-hub-express-route-enabled-auto-asn) below.
+`auto_asn` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`connections` - (Optional) Connections. Add the ExpressRoute Circuit Connections to this site. See [Connections](#ingress-egress-gw-ar-hub-express-route-enabled-connections) below.
+`connections` - (Optional) Connections. Add the ExpressRoute Circuit Connections to this site (`Block`).
 
 `custom_asn` - (Optional) Custom ASN. Set custom ASN for F5XC Site (`Number`).
 
-`do_not_advertise_to_route_server` - (Optional) Empty. This can be used for messages where no values are needed. See [Do Not Advertise To Route Server](#ingress-egress-gw-ar-hub-express-route-enabled-do-not-advertise-to-route-server) below.
+`do_not_advertise_to_route_server` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`gateway_subnet` - (Optional) Azure Subnet. Parameters for Azure subnet. See [Gateway Subnet](#ingress-egress-gw-ar-hub-express-route-enabled-gateway-subnet) below.
+`gateway_subnet` - (Optional) Azure Subnet. Parameters for Azure subnet (`Block`).
 
-`route_server_subnet` - (Optional) Azure Subnet. Parameters for Azure subnet. See [Route Server Subnet](#ingress-egress-gw-ar-hub-express-route-enabled-route-server-subnet) below.
+`route_server_subnet` - (Optional) Azure Subnet. Parameters for Azure subnet (`Block`).
 
-`site_registration_over_express_route` - (Optional) CloudLink ADN Network Config. See [Site Registration Over Express Route](#ingress-egress-gw-ar-hub-express-route-enabled-site-registration-over-express-route) below.
+`site_registration_over_express_route` - (Optional) CloudLink ADN Network Config (`Block`).
 
-`site_registration_over_internet` - (Optional) Empty. This can be used for messages where no values are needed. See [Site Registration Over Internet](#ingress-egress-gw-ar-hub-express-route-enabled-site-registration-over-internet) below.
+`site_registration_over_internet` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`sku_ergw1az` - (Optional) Empty. This can be used for messages where no values are needed. See [Sku Ergw1az](#ingress-egress-gw-ar-hub-express-route-enabled-sku-ergw1az) below.
+`sku_ergw1az` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`sku_ergw2az` - (Optional) Empty. This can be used for messages where no values are needed. See [Sku Ergw2az](#ingress-egress-gw-ar-hub-express-route-enabled-sku-ergw2az) below.
+`sku_ergw2az` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`sku_high_perf` - (Optional) Empty. This can be used for messages where no values are needed. See [Sku High Perf](#ingress-egress-gw-ar-hub-express-route-enabled-sku-high-perf) below.
+`sku_high_perf` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`sku_standard` - (Optional) Empty. This can be used for messages where no values are needed. See [Sku Standard](#ingress-egress-gw-ar-hub-express-route-enabled-sku-standard) below.
-
-<a id="ingress-egress-gw-ar-hub-express-route-enabled-advertise-to-route-server"></a>
-
-### Ingress Egress Gw Ar Hub Express Route Enabled Advertise To Route Server
-
-<a id="ingress-egress-gw-ar-hub-express-route-enabled-auto-asn"></a>
-
-### Ingress Egress Gw Ar Hub Express Route Enabled Auto Asn
-
-<a id="ingress-egress-gw-ar-hub-express-route-enabled-connections"></a>
-
-### Ingress Egress Gw Ar Hub Express Route Enabled Connections
-
-<a id="ingress-egress-gw-ar-hub-express-route-enabled-do-not-advertise-to-route-server"></a>
-
-### Ingress Egress Gw Ar Hub Express Route Enabled Do Not Advertise To Route Server
-
-<a id="ingress-egress-gw-ar-hub-express-route-enabled-gateway-subnet"></a>
-
-### Ingress Egress Gw Ar Hub Express Route Enabled Gateway Subnet
-
-<a id="ingress-egress-gw-ar-hub-express-route-enabled-route-server-subnet"></a>
-
-### Ingress Egress Gw Ar Hub Express Route Enabled Route Server Subnet
-
-<a id="ingress-egress-gw-ar-hub-express-route-enabled-site-registration-over-express-route"></a>
-
-### Ingress Egress Gw Ar Hub Express Route Enabled Site Registration Over Express Route
-
-<a id="ingress-egress-gw-ar-hub-express-route-enabled-site-registration-over-internet"></a>
-
-### Ingress Egress Gw Ar Hub Express Route Enabled Site Registration Over Internet
-
-<a id="ingress-egress-gw-ar-hub-express-route-enabled-sku-ergw1az"></a>
-
-### Ingress Egress Gw Ar Hub Express Route Enabled Sku Ergw1az
-
-<a id="ingress-egress-gw-ar-hub-express-route-enabled-sku-ergw2az"></a>
-
-### Ingress Egress Gw Ar Hub Express Route Enabled Sku Ergw2az
-
-<a id="ingress-egress-gw-ar-hub-express-route-enabled-sku-high-perf"></a>
-
-### Ingress Egress Gw Ar Hub Express Route Enabled Sku High Perf
-
-<a id="ingress-egress-gw-ar-hub-express-route-enabled-sku-standard"></a>
-
-### Ingress Egress Gw Ar Hub Express Route Enabled Sku Standard
+`sku_standard` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="ingress-egress-gw-ar-hub-spoke-vnets"></a>
 
 ### Ingress Egress Gw Ar Hub Spoke Vnets
 
-`auto` - (Optional) Empty. This can be used for messages where no values are needed. See [Auto](#ingress-egress-gw-ar-hub-spoke-vnets-auto) below.
+`auto` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`labels` - (Optional) Labels For VNets Peering. Add Labels for each of the VNets peered with transit VNet, these labels can be used in firewall policy These labels used must be from known key and label defined in shared namespace. See [Labels](#ingress-egress-gw-ar-hub-spoke-vnets-labels) below.
+`labels` - (Optional) Labels For VNets Peering. Add Labels for each of the VNets peered with transit VNet, these labels can be used in firewall policy These labels used must be from known key and label defined in shared namespace (`Block`).
 
-`manual` - (Optional) Empty. This can be used for messages where no values are needed. See [Manual](#ingress-egress-gw-ar-hub-spoke-vnets-manual) below.
+`manual` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`vnet` - (Optional) Azure Existing Vnet Type. Resource group and name of existing Azure Vnet. See [Vnet](#ingress-egress-gw-ar-hub-spoke-vnets-vnet) below.
-
-<a id="ingress-egress-gw-ar-hub-spoke-vnets-auto"></a>
-
-### Ingress Egress Gw Ar Hub Spoke Vnets Auto
-
-<a id="ingress-egress-gw-ar-hub-spoke-vnets-labels"></a>
-
-### Ingress Egress Gw Ar Hub Spoke Vnets Labels
-
-<a id="ingress-egress-gw-ar-hub-spoke-vnets-manual"></a>
-
-### Ingress Egress Gw Ar Hub Spoke Vnets Manual
-
-<a id="ingress-egress-gw-ar-hub-spoke-vnets-vnet"></a>
-
-### Ingress Egress Gw Ar Hub Spoke Vnets Vnet
+`vnet` - (Optional) Azure Existing Vnet Type. Resource group and name of existing Azure Vnet (`Block`).
 
 <a id="ingress-egress-gw-ar-inside-static-routes"></a>
 
@@ -976,37 +708,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Ingress Egress Gw Ar Inside Static Routes Static Route List
 
-`custom_static_route` - (Optional) Static Route. Defines a static route, configuring a list of prefixes and a next-hop to be used for them. See [Custom Static Route](#ingress-egress-gw-ar-inside-static-routes-static-route-list-custom-static-route) below.
+`custom_static_route` - (Optional) Static Route. Defines a static route, configuring a list of prefixes and a next-hop to be used for them (`Block`).
 
 `simple_static_route` - (Optional) Simple Static Route. Use simple static route for prefix pointing to single interface in the network (`String`).
-
-<a id="ingress-egress-gw-ar-inside-static-routes-static-route-list-custom-static-route"></a>
-
-### Ingress Egress Gw Ar Inside Static Routes Static Route List Custom Static Route
-
-<a id="ingress-egress-gw-ar-no-dc-cluster-group"></a>
-
-### Ingress Egress Gw Ar No Dc Cluster Group
-
-<a id="ingress-egress-gw-ar-no-forward-proxy"></a>
-
-### Ingress Egress Gw Ar No Forward Proxy
-
-<a id="ingress-egress-gw-ar-no-global-network"></a>
-
-### Ingress Egress Gw Ar No Global Network
-
-<a id="ingress-egress-gw-ar-no-inside-static-routes"></a>
-
-### Ingress Egress Gw Ar No Inside Static Routes
-
-<a id="ingress-egress-gw-ar-no-network-policy"></a>
-
-### Ingress Egress Gw Ar No Network Policy
-
-<a id="ingress-egress-gw-ar-no-outside-static-routes"></a>
-
-### Ingress Egress Gw Ar No Outside Static Routes
 
 <a id="ingress-egress-gw-ar-node"></a>
 
@@ -1026,37 +730,17 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Ingress Egress Gw Ar Node Inside Subnet
 
-`subnet` - (Optional) Azure Subnet. Parameters for Azure subnet. See [Subnet](#ingress-egress-gw-ar-node-inside-subnet-subnet) below.
+`subnet` - (Optional) Azure Subnet. Parameters for Azure subnet (`Block`).
 
-`subnet_param` - (Optional) New Cloud Subnet Parameters. Parameters for creating a new cloud subnet. See [Subnet Param](#ingress-egress-gw-ar-node-inside-subnet-subnet-param) below.
-
-<a id="ingress-egress-gw-ar-node-inside-subnet-subnet"></a>
-
-### Ingress Egress Gw Ar Node Inside Subnet Subnet
-
-<a id="ingress-egress-gw-ar-node-inside-subnet-subnet-param"></a>
-
-### Ingress Egress Gw Ar Node Inside Subnet Subnet Param
+`subnet_param` - (Optional) New Cloud Subnet Parameters. Parameters for creating a new cloud subnet (`Block`).
 
 <a id="ingress-egress-gw-ar-node-outside-subnet"></a>
 
 ### Ingress Egress Gw Ar Node Outside Subnet
 
-`subnet` - (Optional) Azure Subnet. Parameters for Azure subnet. See [Subnet](#ingress-egress-gw-ar-node-outside-subnet-subnet) below.
+`subnet` - (Optional) Azure Subnet. Parameters for Azure subnet (`Block`).
 
-`subnet_param` - (Optional) New Cloud Subnet Parameters. Parameters for creating a new cloud subnet. See [Subnet Param](#ingress-egress-gw-ar-node-outside-subnet-subnet-param) below.
-
-<a id="ingress-egress-gw-ar-node-outside-subnet-subnet"></a>
-
-### Ingress Egress Gw Ar Node Outside Subnet Subnet
-
-<a id="ingress-egress-gw-ar-node-outside-subnet-subnet-param"></a>
-
-### Ingress Egress Gw Ar Node Outside Subnet Subnet Param
-
-<a id="ingress-egress-gw-ar-not-hub"></a>
-
-### Ingress Egress Gw Ar Not Hub
+`subnet_param` - (Optional) New Cloud Subnet Parameters. Parameters for creating a new cloud subnet (`Block`).
 
 <a id="ingress-egress-gw-ar-outside-static-routes"></a>
 
@@ -1068,13 +752,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Ingress Egress Gw Ar Outside Static Routes Static Route List
 
-`custom_static_route` - (Optional) Static Route. Defines a static route, configuring a list of prefixes and a next-hop to be used for them. See [Custom Static Route](#ingress-egress-gw-ar-outside-static-routes-static-route-list-custom-static-route) below.
+`custom_static_route` - (Optional) Static Route. Defines a static route, configuring a list of prefixes and a next-hop to be used for them (`Block`).
 
 `simple_static_route` - (Optional) Simple Static Route. Use simple static route for prefix pointing to single interface in the network (`String`).
-
-<a id="ingress-egress-gw-ar-outside-static-routes-static-route-list-custom-static-route"></a>
-
-### Ingress Egress Gw Ar Outside Static Routes Static Route List Custom Static Route
 
 <a id="ingress-egress-gw-ar-performance-enhancement-mode"></a>
 
@@ -1082,35 +762,15 @@ In addition to all arguments above, the following attributes are exported:
 
 `perf_mode_l3_enhanced` - (Optional) L3 Mode Enhanced Performance. x-required L3 enhanced performance mode options. See [Perf Mode L3 Enhanced](#ingress-egress-gw-ar-performance-enhancement-mode-perf-mode-l3-enhanced) below.
 
-`perf_mode_l7_enhanced` - (Optional) Empty. This can be used for messages where no values are needed. See [Perf Mode L7 Enhanced](#ingress-egress-gw-ar-performance-enhancement-mode-perf-mode-l7-enhanced) below.
+`perf_mode_l7_enhanced` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="ingress-egress-gw-ar-performance-enhancement-mode-perf-mode-l3-enhanced"></a>
 
 ### Ingress Egress Gw Ar Performance Enhancement Mode Perf Mode L3 Enhanced
 
-`jumbo` - (Optional) Empty. This can be used for messages where no values are needed. See [Jumbo](#ingress-egress-gw-ar-performance-enhancement-mode-perf-mode-l3-enhanced-jumbo) below.
+`jumbo` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_jumbo` - (Optional) Empty. This can be used for messages where no values are needed. See [No Jumbo](#ingress-egress-gw-ar-performance-enhancement-mode-perf-mode-l3-enhanced-no-jumbo) below.
-
-<a id="ingress-egress-gw-ar-performance-enhancement-mode-perf-mode-l3-enhanced-jumbo"></a>
-
-### Ingress Egress Gw Ar Performance Enhancement Mode Perf Mode L3 Enhanced Jumbo
-
-<a id="ingress-egress-gw-ar-performance-enhancement-mode-perf-mode-l3-enhanced-no-jumbo"></a>
-
-### Ingress Egress Gw Ar Performance Enhancement Mode Perf Mode L3 Enhanced No Jumbo
-
-<a id="ingress-egress-gw-ar-performance-enhancement-mode-perf-mode-l7-enhanced"></a>
-
-### Ingress Egress Gw Ar Performance Enhancement Mode Perf Mode L7 Enhanced
-
-<a id="ingress-egress-gw-ar-sm-connection-public-ip"></a>
-
-### Ingress Egress Gw Ar Sm Connection Public IP
-
-<a id="ingress-egress-gw-ar-sm-connection-pvt-ip"></a>
-
-### Ingress Egress Gw Ar Sm Connection Pvt IP
+`no_jumbo` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="ingress-gw"></a>
 
@@ -1128,17 +788,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Ingress Gw Accelerated Networking
 
-`disable` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable](#ingress-gw-accelerated-networking-disable) below.
+`disable` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`enable` - (Optional) Empty. This can be used for messages where no values are needed. See [Enable](#ingress-gw-accelerated-networking-enable) below.
-
-<a id="ingress-gw-accelerated-networking-disable"></a>
-
-### Ingress Gw Accelerated Networking Disable
-
-<a id="ingress-gw-accelerated-networking-enable"></a>
-
-### Ingress Gw Accelerated Networking Enable
+`enable` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="ingress-gw-az-nodes"></a>
 
@@ -1152,17 +804,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Ingress Gw Az Nodes Local Subnet
 
-`subnet` - (Optional) Azure Subnet. Parameters for Azure subnet. See [Subnet](#ingress-gw-az-nodes-local-subnet-subnet) below.
+`subnet` - (Optional) Azure Subnet. Parameters for Azure subnet (`Block`).
 
-`subnet_param` - (Optional) New Cloud Subnet Parameters. Parameters for creating a new cloud subnet. See [Subnet Param](#ingress-gw-az-nodes-local-subnet-subnet-param) below.
-
-<a id="ingress-gw-az-nodes-local-subnet-subnet"></a>
-
-### Ingress Gw Az Nodes Local Subnet Subnet
-
-<a id="ingress-gw-az-nodes-local-subnet-subnet-param"></a>
-
-### Ingress Gw Az Nodes Local Subnet Subnet Param
+`subnet_param` - (Optional) New Cloud Subnet Parameters. Parameters for creating a new cloud subnet (`Block`).
 
 <a id="ingress-gw-performance-enhancement-mode"></a>
 
@@ -1170,27 +814,15 @@ In addition to all arguments above, the following attributes are exported:
 
 `perf_mode_l3_enhanced` - (Optional) L3 Mode Enhanced Performance. x-required L3 enhanced performance mode options. See [Perf Mode L3 Enhanced](#ingress-gw-performance-enhancement-mode-perf-mode-l3-enhanced) below.
 
-`perf_mode_l7_enhanced` - (Optional) Empty. This can be used for messages where no values are needed. See [Perf Mode L7 Enhanced](#ingress-gw-performance-enhancement-mode-perf-mode-l7-enhanced) below.
+`perf_mode_l7_enhanced` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="ingress-gw-performance-enhancement-mode-perf-mode-l3-enhanced"></a>
 
 ### Ingress Gw Performance Enhancement Mode Perf Mode L3 Enhanced
 
-`jumbo` - (Optional) Empty. This can be used for messages where no values are needed. See [Jumbo](#ingress-gw-performance-enhancement-mode-perf-mode-l3-enhanced-jumbo) below.
+`jumbo` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_jumbo` - (Optional) Empty. This can be used for messages where no values are needed. See [No Jumbo](#ingress-gw-performance-enhancement-mode-perf-mode-l3-enhanced-no-jumbo) below.
-
-<a id="ingress-gw-performance-enhancement-mode-perf-mode-l3-enhanced-jumbo"></a>
-
-### Ingress Gw Performance Enhancement Mode Perf Mode L3 Enhanced Jumbo
-
-<a id="ingress-gw-performance-enhancement-mode-perf-mode-l3-enhanced-no-jumbo"></a>
-
-### Ingress Gw Performance Enhancement Mode Perf Mode L3 Enhanced No Jumbo
-
-<a id="ingress-gw-performance-enhancement-mode-perf-mode-l7-enhanced"></a>
-
-### Ingress Gw Performance Enhancement Mode Perf Mode L7 Enhanced
+`no_jumbo` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="ingress-gw-ar"></a>
 
@@ -1208,17 +840,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Ingress Gw Ar Accelerated Networking
 
-`disable` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable](#ingress-gw-ar-accelerated-networking-disable) below.
+`disable` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`enable` - (Optional) Empty. This can be used for messages where no values are needed. See [Enable](#ingress-gw-ar-accelerated-networking-enable) below.
-
-<a id="ingress-gw-ar-accelerated-networking-disable"></a>
-
-### Ingress Gw Ar Accelerated Networking Disable
-
-<a id="ingress-gw-ar-accelerated-networking-enable"></a>
-
-### Ingress Gw Ar Accelerated Networking Enable
+`enable` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="ingress-gw-ar-node"></a>
 
@@ -1236,17 +860,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Ingress Gw Ar Node Local Subnet
 
-`subnet` - (Optional) Azure Subnet. Parameters for Azure subnet. See [Subnet](#ingress-gw-ar-node-local-subnet-subnet) below.
+`subnet` - (Optional) Azure Subnet. Parameters for Azure subnet (`Block`).
 
-`subnet_param` - (Optional) New Cloud Subnet Parameters. Parameters for creating a new cloud subnet. See [Subnet Param](#ingress-gw-ar-node-local-subnet-subnet-param) below.
-
-<a id="ingress-gw-ar-node-local-subnet-subnet"></a>
-
-### Ingress Gw Ar Node Local Subnet Subnet
-
-<a id="ingress-gw-ar-node-local-subnet-subnet-param"></a>
-
-### Ingress Gw Ar Node Local Subnet Subnet Param
+`subnet_param` - (Optional) New Cloud Subnet Parameters. Parameters for creating a new cloud subnet (`Block`).
 
 <a id="ingress-gw-ar-performance-enhancement-mode"></a>
 
@@ -1254,59 +870,35 @@ In addition to all arguments above, the following attributes are exported:
 
 `perf_mode_l3_enhanced` - (Optional) L3 Mode Enhanced Performance. x-required L3 enhanced performance mode options. See [Perf Mode L3 Enhanced](#ingress-gw-ar-performance-enhancement-mode-perf-mode-l3-enhanced) below.
 
-`perf_mode_l7_enhanced` - (Optional) Empty. This can be used for messages where no values are needed. See [Perf Mode L7 Enhanced](#ingress-gw-ar-performance-enhancement-mode-perf-mode-l7-enhanced) below.
+`perf_mode_l7_enhanced` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="ingress-gw-ar-performance-enhancement-mode-perf-mode-l3-enhanced"></a>
 
 ### Ingress Gw Ar Performance Enhancement Mode Perf Mode L3 Enhanced
 
-`jumbo` - (Optional) Empty. This can be used for messages where no values are needed. See [Jumbo](#ingress-gw-ar-performance-enhancement-mode-perf-mode-l3-enhanced-jumbo) below.
+`jumbo` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_jumbo` - (Optional) Empty. This can be used for messages where no values are needed. See [No Jumbo](#ingress-gw-ar-performance-enhancement-mode-perf-mode-l3-enhanced-no-jumbo) below.
-
-<a id="ingress-gw-ar-performance-enhancement-mode-perf-mode-l3-enhanced-jumbo"></a>
-
-### Ingress Gw Ar Performance Enhancement Mode Perf Mode L3 Enhanced Jumbo
-
-<a id="ingress-gw-ar-performance-enhancement-mode-perf-mode-l3-enhanced-no-jumbo"></a>
-
-### Ingress Gw Ar Performance Enhancement Mode Perf Mode L3 Enhanced No Jumbo
-
-<a id="ingress-gw-ar-performance-enhancement-mode-perf-mode-l7-enhanced"></a>
-
-### Ingress Gw Ar Performance Enhancement Mode Perf Mode L7 Enhanced
+`no_jumbo` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="kubernetes-upgrade-drain"></a>
 
 ### Kubernetes Upgrade Drain
 
-`disable_upgrade_drain` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Upgrade Drain](#kubernetes-upgrade-drain-disable-upgrade-drain) below.
+`disable_upgrade_drain` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `enable_upgrade_drain` - (Optional) Enable Node by Node Upgrade. Specify batch upgrade settings for worker nodes within a site. See [Enable Upgrade Drain](#kubernetes-upgrade-drain-enable-upgrade-drain) below.
-
-<a id="kubernetes-upgrade-drain-disable-upgrade-drain"></a>
-
-### Kubernetes Upgrade Drain Disable Upgrade Drain
 
 <a id="kubernetes-upgrade-drain-enable-upgrade-drain"></a>
 
 ### Kubernetes Upgrade Drain Enable Upgrade Drain
 
-`disable_vega_upgrade_mode` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Vega Upgrade Mode](#kubernetes-upgrade-drain-enable-upgrade-drain-disable-vega-upgrade-mode) below.
+`disable_vega_upgrade_mode` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `drain_max_unavailable_node_count` - (Optional) Node Batch Size Count (`Number`).
 
 `drain_node_timeout` - (Optional) Upgrade Wait Time. Seconds to wait before initiating upgrade on the next set of nodes. Setting it to 0 will wait indefinitely for all services on nodes to be upgraded gracefully before proceeding to the next set of nodes. (Warning: It may block upgrade if services on a node cannot be gracefully upgraded. It is recommended to use the default value) (`Number`).
 
-`enable_vega_upgrade_mode` - (Optional) Empty. This can be used for messages where no values are needed. See [Enable Vega Upgrade Mode](#kubernetes-upgrade-drain-enable-upgrade-drain-enable-vega-upgrade-mode) below.
-
-<a id="kubernetes-upgrade-drain-enable-upgrade-drain-disable-vega-upgrade-mode"></a>
-
-### Kubernetes Upgrade Drain Enable Upgrade Drain Disable Vega Upgrade Mode
-
-<a id="kubernetes-upgrade-drain-enable-upgrade-drain-enable-vega-upgrade-mode"></a>
-
-### Kubernetes Upgrade Drain Enable Upgrade Drain Enable Vega Upgrade Mode
+`enable_vega_upgrade_mode` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="log-receiver"></a>
 
@@ -1318,57 +910,29 @@ In addition to all arguments above, the following attributes are exported:
 
 `tenant` - (Optional) Tenant. When a configuration object(e.g. virtual_host) refers to another(e.g route) then tenant will hold the referred object's(e.g. route's) tenant (`String`).
 
-<a id="logs-streaming-disabled"></a>
-
-### Logs Streaming Disabled
-
-<a id="no-worker-nodes"></a>
-
-### No Worker Nodes
-
 <a id="offline-survivability-mode"></a>
 
 ### Offline Survivability Mode
 
-`enable_offline_survivability_mode` - (Optional) Empty. This can be used for messages where no values are needed. See [Enable Offline Survivability Mode](#offline-survivability-mode-enable-offline-survivability-mode) below.
+`enable_offline_survivability_mode` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_offline_survivability_mode` - (Optional) Empty. This can be used for messages where no values are needed. See [No Offline Survivability Mode](#offline-survivability-mode-no-offline-survivability-mode) below.
-
-<a id="offline-survivability-mode-enable-offline-survivability-mode"></a>
-
-### Offline Survivability Mode Enable Offline Survivability Mode
-
-<a id="offline-survivability-mode-no-offline-survivability-mode"></a>
-
-### Offline Survivability Mode No Offline Survivability Mode
+`no_offline_survivability_mode` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="os"></a>
 
 ### OS
 
-`default_os_version` - (Optional) Empty. This can be used for messages where no values are needed. See [Default OS Version](#os-default-os-version) below.
+`default_os_version` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `operating_system_version` - (Optional) Operating System Version. Specify a OS version to be used e.g. 9.2024.6 (`String`).
-
-<a id="os-default-os-version"></a>
-
-### OS Default OS Version
 
 <a id="sw"></a>
 
 ### Sw
 
-`default_sw_version` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Sw Version](#sw-default-sw-version) below.
+`default_sw_version` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `volterra_software_version` - (Optional) F5XC Software Version. Specify a F5XC Software Version to be used e.g. crt-20210329-1002 (`String`).
-
-<a id="sw-default-sw-version"></a>
-
-### Sw Default Sw Version
-
-<a id="tags"></a>
-
-### Tags
 
 <a id="timeouts"></a>
 
@@ -1394,35 +958,23 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Vnet Existing Vnet
 
-`f5_orchestrated_routing` - (Optional) Empty. This can be used for messages where no values are needed. See [F5 Orchestrated Routing](#vnet-existing-vnet-f5-orchestrated-routing) below.
+`f5_orchestrated_routing` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`manual_routing` - (Optional) Empty. This can be used for messages where no values are needed. See [Manual Routing](#vnet-existing-vnet-manual-routing) below.
+`manual_routing` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `resource_group` - (Optional) Existing Vnet Resource Group. Resource group of existing Vnet (`String`).
 
 `vnet_name` - (Optional) Existing Vnet Name. Name of existing Vnet (`String`).
 
-<a id="vnet-existing-vnet-f5-orchestrated-routing"></a>
-
-### Vnet Existing Vnet F5 Orchestrated Routing
-
-<a id="vnet-existing-vnet-manual-routing"></a>
-
-### Vnet Existing Vnet Manual Routing
-
 <a id="vnet-new-vnet"></a>
 
 ### Vnet New Vnet
 
-`autogenerate` - (Optional) Empty. This can be used for messages where no values are needed. See [Autogenerate](#vnet-new-vnet-autogenerate) below.
+`autogenerate` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `name` - (Optional) Choose Vnet Name. Specify the Vnet Name (`String`).
 
 `primary_ipv4` - (Optional) IPv4 CIDR block. IPv4 CIDR block for this Vnet. It has to be private address space (`String`).
-
-<a id="vnet-new-vnet-autogenerate"></a>
-
-### Vnet New Vnet Autogenerate
 
 <a id="voltstack-cluster"></a>
 
@@ -1442,31 +994,31 @@ In addition to all arguments above, the following attributes are exported:
 
 `dc_cluster_group` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Dc Cluster Group](#voltstack-cluster-dc-cluster-group) below.
 
-`default_storage` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Storage](#voltstack-cluster-default-storage) below.
+`default_storage` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`forward_proxy_allow_all` - (Optional) Empty. This can be used for messages where no values are needed. See [Forward Proxy Allow All](#voltstack-cluster-forward-proxy-allow-all) below.
+`forward_proxy_allow_all` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `global_network_list` - (Optional) Global Network Connection List. List of global network connections. See [Global Network List](#voltstack-cluster-global-network-list) below.
 
 `k8s_cluster` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [K8s Cluster](#voltstack-cluster-k8s-cluster) below.
 
-`no_dc_cluster_group` - (Optional) Empty. This can be used for messages where no values are needed. See [No Dc Cluster Group](#voltstack-cluster-no-dc-cluster-group) below.
+`no_dc_cluster_group` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_forward_proxy` - (Optional) Empty. This can be used for messages where no values are needed. See [No Forward Proxy](#voltstack-cluster-no-forward-proxy) below.
+`no_forward_proxy` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_global_network` - (Optional) Empty. This can be used for messages where no values are needed. See [No Global Network](#voltstack-cluster-no-global-network) below.
+`no_global_network` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_k8s_cluster` - (Optional) Empty. This can be used for messages where no values are needed. See [No K8s Cluster](#voltstack-cluster-no-k8s-cluster) below.
+`no_k8s_cluster` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_network_policy` - (Optional) Empty. This can be used for messages where no values are needed. See [No Network Policy](#voltstack-cluster-no-network-policy) below.
+`no_network_policy` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_outside_static_routes` - (Optional) Empty. This can be used for messages where no values are needed. See [No Outside Static Routes](#voltstack-cluster-no-outside-static-routes) below.
+`no_outside_static_routes` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `outside_static_routes` - (Optional) Static Route List Type. List of static routes. See [Outside Static Routes](#voltstack-cluster-outside-static-routes) below.
 
-`sm_connection_public_ip` - (Optional) Empty. This can be used for messages where no values are needed. See [Sm Connection Public IP](#voltstack-cluster-sm-connection-public-ip) below.
+`sm_connection_public_ip` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`sm_connection_pvt_ip` - (Optional) Empty. This can be used for messages where no values are needed. See [Sm Connection Pvt IP](#voltstack-cluster-sm-connection-pvt-ip) below.
+`sm_connection_pvt_ip` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `storage_class_list` - (Optional) Custom Storage Class List. Add additional custom storage classes in kubernetes for this site. See [Storage Class List](#voltstack-cluster-storage-class-list) below.
 
@@ -1474,17 +1026,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Voltstack Cluster Accelerated Networking
 
-`disable` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable](#voltstack-cluster-accelerated-networking-disable) below.
+`disable` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`enable` - (Optional) Empty. This can be used for messages where no values are needed. See [Enable](#voltstack-cluster-accelerated-networking-enable) below.
-
-<a id="voltstack-cluster-accelerated-networking-disable"></a>
-
-### Voltstack Cluster Accelerated Networking Disable
-
-<a id="voltstack-cluster-accelerated-networking-enable"></a>
-
-### Voltstack Cluster Accelerated Networking Enable
+`enable` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="voltstack-cluster-active-enhanced-firewall-policies"></a>
 
@@ -1546,17 +1090,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Voltstack Cluster Az Nodes Local Subnet
 
-`subnet` - (Optional) Azure Subnet. Parameters for Azure subnet. See [Subnet](#voltstack-cluster-az-nodes-local-subnet-subnet) below.
+`subnet` - (Optional) Azure Subnet. Parameters for Azure subnet (`Block`).
 
-`subnet_param` - (Optional) New Cloud Subnet Parameters. Parameters for creating a new cloud subnet. See [Subnet Param](#voltstack-cluster-az-nodes-local-subnet-subnet-param) below.
-
-<a id="voltstack-cluster-az-nodes-local-subnet-subnet"></a>
-
-### Voltstack Cluster Az Nodes Local Subnet Subnet
-
-<a id="voltstack-cluster-az-nodes-local-subnet-subnet-param"></a>
-
-### Voltstack Cluster Az Nodes Local Subnet Subnet Param
+`subnet_param` - (Optional) New Cloud Subnet Parameters. Parameters for creating a new cloud subnet (`Block`).
 
 <a id="voltstack-cluster-dc-cluster-group"></a>
 
@@ -1568,14 +1104,6 @@ In addition to all arguments above, the following attributes are exported:
 
 `tenant` - (Optional) Tenant. When a configuration object(e.g. virtual_host) refers to another(e.g route) then tenant will hold the referred object's(e.g. route's) tenant (`String`).
 
-<a id="voltstack-cluster-default-storage"></a>
-
-### Voltstack Cluster Default Storage
-
-<a id="voltstack-cluster-forward-proxy-allow-all"></a>
-
-### Voltstack Cluster Forward Proxy Allow All
-
 <a id="voltstack-cluster-global-network-list"></a>
 
 ### Voltstack Cluster Global Network List
@@ -1586,17 +1114,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Voltstack Cluster Global Network List Global Network Connections
 
-`sli_to_global_dr` - (Optional) Global Network. Global network reference for direct connection. See [Sli To Global DR](#voltstack-cluster-global-network-list-global-network-connections-sli-to-global-dr) below.
+`sli_to_global_dr` - (Optional) Global Network. Global network reference for direct connection (`Block`).
 
-`slo_to_global_dr` - (Optional) Global Network. Global network reference for direct connection. See [Slo To Global DR](#voltstack-cluster-global-network-list-global-network-connections-slo-to-global-dr) below.
-
-<a id="voltstack-cluster-global-network-list-global-network-connections-sli-to-global-dr"></a>
-
-### Voltstack Cluster Global Network List Global Network Connections Sli To Global DR
-
-<a id="voltstack-cluster-global-network-list-global-network-connections-slo-to-global-dr"></a>
-
-### Voltstack Cluster Global Network List Global Network Connections Slo To Global DR
+`slo_to_global_dr` - (Optional) Global Network. Global network reference for direct connection (`Block`).
 
 <a id="voltstack-cluster-k8s-cluster"></a>
 
@@ -1608,30 +1128,6 @@ In addition to all arguments above, the following attributes are exported:
 
 `tenant` - (Optional) Tenant. When a configuration object(e.g. virtual_host) refers to another(e.g route) then tenant will hold the referred object's(e.g. route's) tenant (`String`).
 
-<a id="voltstack-cluster-no-dc-cluster-group"></a>
-
-### Voltstack Cluster No Dc Cluster Group
-
-<a id="voltstack-cluster-no-forward-proxy"></a>
-
-### Voltstack Cluster No Forward Proxy
-
-<a id="voltstack-cluster-no-global-network"></a>
-
-### Voltstack Cluster No Global Network
-
-<a id="voltstack-cluster-no-k8s-cluster"></a>
-
-### Voltstack Cluster No K8s Cluster
-
-<a id="voltstack-cluster-no-network-policy"></a>
-
-### Voltstack Cluster No Network Policy
-
-<a id="voltstack-cluster-no-outside-static-routes"></a>
-
-### Voltstack Cluster No Outside Static Routes
-
 <a id="voltstack-cluster-outside-static-routes"></a>
 
 ### Voltstack Cluster Outside Static Routes
@@ -1642,21 +1138,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Voltstack Cluster Outside Static Routes Static Route List
 
-`custom_static_route` - (Optional) Static Route. Defines a static route, configuring a list of prefixes and a next-hop to be used for them. See [Custom Static Route](#voltstack-cluster-outside-static-routes-static-route-list-custom-static-route) below.
+`custom_static_route` - (Optional) Static Route. Defines a static route, configuring a list of prefixes and a next-hop to be used for them (`Block`).
 
 `simple_static_route` - (Optional) Simple Static Route. Use simple static route for prefix pointing to single interface in the network (`String`).
-
-<a id="voltstack-cluster-outside-static-routes-static-route-list-custom-static-route"></a>
-
-### Voltstack Cluster Outside Static Routes Static Route List Custom Static Route
-
-<a id="voltstack-cluster-sm-connection-public-ip"></a>
-
-### Voltstack Cluster Sm Connection Public IP
-
-<a id="voltstack-cluster-sm-connection-pvt-ip"></a>
-
-### Voltstack Cluster Sm Connection Pvt IP
 
 <a id="voltstack-cluster-storage-class-list"></a>
 
@@ -1688,33 +1172,33 @@ In addition to all arguments above, the following attributes are exported:
 
 `dc_cluster_group` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Dc Cluster Group](#voltstack-cluster-ar-dc-cluster-group) below.
 
-`default_storage` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Storage](#voltstack-cluster-ar-default-storage) below.
+`default_storage` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`forward_proxy_allow_all` - (Optional) Empty. This can be used for messages where no values are needed. See [Forward Proxy Allow All](#voltstack-cluster-ar-forward-proxy-allow-all) below.
+`forward_proxy_allow_all` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `global_network_list` - (Optional) Global Network Connection List. List of global network connections. See [Global Network List](#voltstack-cluster-ar-global-network-list) below.
 
 `k8s_cluster` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [K8s Cluster](#voltstack-cluster-ar-k8s-cluster) below.
 
-`no_dc_cluster_group` - (Optional) Empty. This can be used for messages where no values are needed. See [No Dc Cluster Group](#voltstack-cluster-ar-no-dc-cluster-group) below.
+`no_dc_cluster_group` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_forward_proxy` - (Optional) Empty. This can be used for messages where no values are needed. See [No Forward Proxy](#voltstack-cluster-ar-no-forward-proxy) below.
+`no_forward_proxy` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_global_network` - (Optional) Empty. This can be used for messages where no values are needed. See [No Global Network](#voltstack-cluster-ar-no-global-network) below.
+`no_global_network` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_k8s_cluster` - (Optional) Empty. This can be used for messages where no values are needed. See [No K8s Cluster](#voltstack-cluster-ar-no-k8s-cluster) below.
+`no_k8s_cluster` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_network_policy` - (Optional) Empty. This can be used for messages where no values are needed. See [No Network Policy](#voltstack-cluster-ar-no-network-policy) below.
+`no_network_policy` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_outside_static_routes` - (Optional) Empty. This can be used for messages where no values are needed. See [No Outside Static Routes](#voltstack-cluster-ar-no-outside-static-routes) below.
+`no_outside_static_routes` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `node` - (Optional) Single Interface Node for Alternate Region. Parameters for creating Single interface Node for Alternate Region. See [Node](#voltstack-cluster-ar-node) below.
 
 `outside_static_routes` - (Optional) Static Route List Type. List of static routes. See [Outside Static Routes](#voltstack-cluster-ar-outside-static-routes) below.
 
-`sm_connection_public_ip` - (Optional) Empty. This can be used for messages where no values are needed. See [Sm Connection Public IP](#voltstack-cluster-ar-sm-connection-public-ip) below.
+`sm_connection_public_ip` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`sm_connection_pvt_ip` - (Optional) Empty. This can be used for messages where no values are needed. See [Sm Connection Pvt IP](#voltstack-cluster-ar-sm-connection-pvt-ip) below.
+`sm_connection_pvt_ip` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `storage_class_list` - (Optional) Custom Storage Class List. Add additional custom storage classes in kubernetes for this site. See [Storage Class List](#voltstack-cluster-ar-storage-class-list) below.
 
@@ -1722,17 +1206,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Voltstack Cluster Ar Accelerated Networking
 
-`disable` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable](#voltstack-cluster-ar-accelerated-networking-disable) below.
+`disable` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`enable` - (Optional) Empty. This can be used for messages where no values are needed. See [Enable](#voltstack-cluster-ar-accelerated-networking-enable) below.
-
-<a id="voltstack-cluster-ar-accelerated-networking-disable"></a>
-
-### Voltstack Cluster Ar Accelerated Networking Disable
-
-<a id="voltstack-cluster-ar-accelerated-networking-enable"></a>
-
-### Voltstack Cluster Ar Accelerated Networking Enable
+`enable` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="voltstack-cluster-ar-active-enhanced-firewall-policies"></a>
 
@@ -1792,14 +1268,6 @@ In addition to all arguments above, the following attributes are exported:
 
 `tenant` - (Optional) Tenant. When a configuration object(e.g. virtual_host) refers to another(e.g route) then tenant will hold the referred object's(e.g. route's) tenant (`String`).
 
-<a id="voltstack-cluster-ar-default-storage"></a>
-
-### Voltstack Cluster Ar Default Storage
-
-<a id="voltstack-cluster-ar-forward-proxy-allow-all"></a>
-
-### Voltstack Cluster Ar Forward Proxy Allow All
-
 <a id="voltstack-cluster-ar-global-network-list"></a>
 
 ### Voltstack Cluster Ar Global Network List
@@ -1810,17 +1278,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Voltstack Cluster Ar Global Network List Global Network Connections
 
-`sli_to_global_dr` - (Optional) Global Network. Global network reference for direct connection. See [Sli To Global DR](#voltstack-cluster-ar-global-network-list-global-network-connections-sli-to-global-dr) below.
+`sli_to_global_dr` - (Optional) Global Network. Global network reference for direct connection (`Block`).
 
-`slo_to_global_dr` - (Optional) Global Network. Global network reference for direct connection. See [Slo To Global DR](#voltstack-cluster-ar-global-network-list-global-network-connections-slo-to-global-dr) below.
-
-<a id="voltstack-cluster-ar-global-network-list-global-network-connections-sli-to-global-dr"></a>
-
-### Voltstack Cluster Ar Global Network List Global Network Connections Sli To Global DR
-
-<a id="voltstack-cluster-ar-global-network-list-global-network-connections-slo-to-global-dr"></a>
-
-### Voltstack Cluster Ar Global Network List Global Network Connections Slo To Global DR
+`slo_to_global_dr` - (Optional) Global Network. Global network reference for direct connection (`Block`).
 
 <a id="voltstack-cluster-ar-k8s-cluster"></a>
 
@@ -1831,30 +1291,6 @@ In addition to all arguments above, the following attributes are exported:
 `namespace` - (Optional) Namespace. When a configuration object(e.g. virtual_host) refers to another(e.g route) then namespace will hold the referred object's(e.g. route's) namespace (`String`).
 
 `tenant` - (Optional) Tenant. When a configuration object(e.g. virtual_host) refers to another(e.g route) then tenant will hold the referred object's(e.g. route's) tenant (`String`).
-
-<a id="voltstack-cluster-ar-no-dc-cluster-group"></a>
-
-### Voltstack Cluster Ar No Dc Cluster Group
-
-<a id="voltstack-cluster-ar-no-forward-proxy"></a>
-
-### Voltstack Cluster Ar No Forward Proxy
-
-<a id="voltstack-cluster-ar-no-global-network"></a>
-
-### Voltstack Cluster Ar No Global Network
-
-<a id="voltstack-cluster-ar-no-k8s-cluster"></a>
-
-### Voltstack Cluster Ar No K8s Cluster
-
-<a id="voltstack-cluster-ar-no-network-policy"></a>
-
-### Voltstack Cluster Ar No Network Policy
-
-<a id="voltstack-cluster-ar-no-outside-static-routes"></a>
-
-### Voltstack Cluster Ar No Outside Static Routes
 
 <a id="voltstack-cluster-ar-node"></a>
 
@@ -1872,17 +1308,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Voltstack Cluster Ar Node Local Subnet
 
-`subnet` - (Optional) Azure Subnet. Parameters for Azure subnet. See [Subnet](#voltstack-cluster-ar-node-local-subnet-subnet) below.
+`subnet` - (Optional) Azure Subnet. Parameters for Azure subnet (`Block`).
 
-`subnet_param` - (Optional) New Cloud Subnet Parameters. Parameters for creating a new cloud subnet. See [Subnet Param](#voltstack-cluster-ar-node-local-subnet-subnet-param) below.
-
-<a id="voltstack-cluster-ar-node-local-subnet-subnet"></a>
-
-### Voltstack Cluster Ar Node Local Subnet Subnet
-
-<a id="voltstack-cluster-ar-node-local-subnet-subnet-param"></a>
-
-### Voltstack Cluster Ar Node Local Subnet Subnet Param
+`subnet_param` - (Optional) New Cloud Subnet Parameters. Parameters for creating a new cloud subnet (`Block`).
 
 <a id="voltstack-cluster-ar-outside-static-routes"></a>
 
@@ -1894,21 +1322,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Voltstack Cluster Ar Outside Static Routes Static Route List
 
-`custom_static_route` - (Optional) Static Route. Defines a static route, configuring a list of prefixes and a next-hop to be used for them. See [Custom Static Route](#voltstack-cluster-ar-outside-static-routes-static-route-list-custom-static-route) below.
+`custom_static_route` - (Optional) Static Route. Defines a static route, configuring a list of prefixes and a next-hop to be used for them (`Block`).
 
 `simple_static_route` - (Optional) Simple Static Route. Use simple static route for prefix pointing to single interface in the network (`String`).
-
-<a id="voltstack-cluster-ar-outside-static-routes-static-route-list-custom-static-route"></a>
-
-### Voltstack Cluster Ar Outside Static Routes Static Route List Custom Static Route
-
-<a id="voltstack-cluster-ar-sm-connection-public-ip"></a>
-
-### Voltstack Cluster Ar Sm Connection Public IP
-
-<a id="voltstack-cluster-ar-sm-connection-pvt-ip"></a>
-
-### Voltstack Cluster Ar Sm Connection Pvt IP
 
 <a id="voltstack-cluster-ar-storage-class-list"></a>
 

--- a/docs/resources/bgp.md
+++ b/docs/resources/bgp.md
@@ -91,29 +91,21 @@ In addition to all arguments above, the following attributes are exported:
 
 `asn` - (Optional) ASN. Autonomous System Number (`Number`).
 
-`from_site` - (Optional) Empty. This can be used for messages where no values are needed. See [From Site](#bgp-parameters-from-site) below.
+`from_site` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `ip_address` - (Optional) IP Address. Use the configured IPv4 Address as Router ID (`String`).
 
-`local_address` - (Optional) Empty. This can be used for messages where no values are needed. See [Local Address](#bgp-parameters-local-address) below.
-
-<a id="bgp-parameters-from-site"></a>
-
-### BGP Parameters From Site
-
-<a id="bgp-parameters-local-address"></a>
-
-### BGP Parameters Local Address
+`local_address` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="peers"></a>
 
 ### Peers
 
-`bfd_disabled` - (Optional) Empty. This can be used for messages where no values are needed. See [Bfd Disabled](#peers-bfd-disabled) below.
+`bfd_disabled` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `bfd_enabled` - (Optional) BFD. BFD parameters. See [Bfd Enabled](#peers-bfd-enabled) below.
 
-`disable` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable](#peers-disable) below.
+`disable` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `external` - (Optional) External BGP Peer. External BGP Peer parameters. See [External](#peers-external) below.
 
@@ -121,15 +113,11 @@ In addition to all arguments above, the following attributes are exported:
 
 `metadata` - (Optional) Message Metadata. MessageMetaType is metadata (common attributes) of a message that only certain messages have. This information is propagated to the metadata of a child object that gets created from the containing message during view processing. The information in this type can be specified by user during create and replace APIs. See [Metadata](#peers-metadata) below.
 
-`passive_mode_disabled` - (Optional) Empty. This can be used for messages where no values are needed. See [Passive Mode Disabled](#peers-passive-mode-disabled) below.
+`passive_mode_disabled` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`passive_mode_enabled` - (Optional) Empty. This can be used for messages where no values are needed. See [Passive Mode Enabled](#peers-passive-mode-enabled) below.
+`passive_mode_enabled` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `routing_policies` - (Optional) BGP Routing Policy. List of rules which can be applied on all or particular nodes. See [Routing Policies](#peers-routing-policies) below.
-
-<a id="peers-bfd-disabled"></a>
-
-### Peers Bfd Disabled
 
 <a id="peers-bfd-enabled"></a>
 
@@ -141,10 +129,6 @@ In addition to all arguments above, the following attributes are exported:
 
 `transmit_interval_milliseconds` - (Optional) Transmit Interval. BFD transmit interval timer, in milliseconds (`Number`).
 
-<a id="peers-disable"></a>
-
-### Peers Disable
-
 <a id="peers-external"></a>
 
 ### Peers External
@@ -155,21 +139,21 @@ In addition to all arguments above, the following attributes are exported:
 
 `asn` - (Optional) ASN. Autonomous System Number for BGP peer (`Number`).
 
-`default_gateway` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Gateway](#peers-external-default-gateway) below.
+`default_gateway` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`default_gateway_v6` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Gateway V6](#peers-external-default-gateway-v6) below.
+`default_gateway_v6` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`disable` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable](#peers-external-disable) below.
+`disable` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`disable_v6` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable V6](#peers-external-disable-v6) below.
+`disable_v6` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`external_connector` - (Optional) Empty. This can be used for messages where no values are needed. See [External Connector](#peers-external-external-connector) below.
+`external_connector` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `family_inet` - (Optional) BGP Family Inet. Parameters for inet family. See [Family Inet](#peers-external-family-inet) below.
 
-`from_site` - (Optional) Empty. This can be used for messages where no values are needed. See [From Site](#peers-external-from-site) below.
+`from_site` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`from_site_v6` - (Optional) Empty. This can be used for messages where no values are needed. See [From Site V6](#peers-external-from-site-v6) below.
+`from_site_v6` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `interface` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Interface](#peers-external-interface) below.
 
@@ -177,7 +161,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `md5_auth_key` - (Optional) MD5 Authentication Key. MD5 key for protecting BGP Sessions (RFC 2385) (`String`).
 
-`no_authentication` - (Optional) Empty. This can be used for messages where no values are needed. See [No Authentication](#peers-external-no-authentication) below.
+`no_authentication` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `port` - (Optional) Peer Port. Peer TCP port number (`Number`).
 
@@ -189,49 +173,13 @@ In addition to all arguments above, the following attributes are exported:
 
 `subnet_end_offset_v6` - (Optional) Offset From End Of Subnet. Calculate peer address using offset from the end of the subnet (`Number`).
 
-<a id="peers-external-default-gateway"></a>
-
-### Peers External Default Gateway
-
-<a id="peers-external-default-gateway-v6"></a>
-
-### Peers External Default Gateway V6
-
-<a id="peers-external-disable"></a>
-
-### Peers External Disable
-
-<a id="peers-external-disable-v6"></a>
-
-### Peers External Disable V6
-
-<a id="peers-external-external-connector"></a>
-
-### Peers External External Connector
-
 <a id="peers-external-family-inet"></a>
 
 ### Peers External Family Inet
 
-`disable` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable](#peers-external-family-inet-disable) below.
+`disable` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`enable` - (Optional) Empty. This can be used for messages where no values are needed. See [Enable](#peers-external-family-inet-enable) below.
-
-<a id="peers-external-family-inet-disable"></a>
-
-### Peers External Family Inet Disable
-
-<a id="peers-external-family-inet-enable"></a>
-
-### Peers External Family Inet Enable
-
-<a id="peers-external-from-site"></a>
-
-### Peers External From Site
-
-<a id="peers-external-from-site-v6"></a>
-
-### Peers External From Site V6
+`enable` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="peers-external-interface"></a>
 
@@ -247,15 +195,7 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Peers External Interface List
 
-`interfaces` - (Optional) Interface List. List of network interfaces. See [Interfaces](#peers-external-interface-list-interfaces) below.
-
-<a id="peers-external-interface-list-interfaces"></a>
-
-### Peers External Interface List Interfaces
-
-<a id="peers-external-no-authentication"></a>
-
-### Peers External No Authentication
+`interfaces` - (Optional) Interface List. List of network interfaces (`Block`).
 
 <a id="peers-metadata"></a>
 
@@ -264,14 +204,6 @@ In addition to all arguments above, the following attributes are exported:
 `description` - (Optional) Description. Human readable description (`String`).
 
 `name` - (Optional) Name. This is the name of the message. The value of name has to follow DNS-1035 format (`String`).
-
-<a id="peers-passive-mode-disabled"></a>
-
-### Peers Passive Mode Disabled
-
-<a id="peers-passive-mode-enabled"></a>
-
-### Peers Passive Mode Enabled
 
 <a id="peers-routing-policies"></a>
 
@@ -283,35 +215,15 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Peers Routing Policies Route Policy
 
-`all_nodes` - (Optional) Empty. This can be used for messages where no values are needed. See [All Nodes](#peers-routing-policies-route-policy-all-nodes) below.
+`all_nodes` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`inbound` - (Optional) Empty. This can be used for messages where no values are needed. See [Inbound](#peers-routing-policies-route-policy-inbound) below.
+`inbound` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`node_name` - (Optional) Nodes. List of nodes on which BGP routing policy has to be applied. See [Node Name](#peers-routing-policies-route-policy-node-name) below.
+`node_name` - (Optional) Nodes. List of nodes on which BGP routing policy has to be applied (`Block`).
 
-`object_refs` - (Optional) BGP routing policy. Select route policy to apply. See [Object Refs](#peers-routing-policies-route-policy-object-refs) below.
+`object_refs` - (Optional) BGP routing policy. Select route policy to apply (`Block`).
 
-`outbound` - (Optional) Empty. This can be used for messages where no values are needed. See [Outbound](#peers-routing-policies-route-policy-outbound) below.
-
-<a id="peers-routing-policies-route-policy-all-nodes"></a>
-
-### Peers Routing Policies Route Policy All Nodes
-
-<a id="peers-routing-policies-route-policy-inbound"></a>
-
-### Peers Routing Policies Route Policy Inbound
-
-<a id="peers-routing-policies-route-policy-node-name"></a>
-
-### Peers Routing Policies Route Policy Node Name
-
-<a id="peers-routing-policies-route-policy-object-refs"></a>
-
-### Peers Routing Policies Route Policy Object Refs
-
-<a id="peers-routing-policies-route-policy-outbound"></a>
-
-### Peers Routing Policies Route Policy Outbound
+`outbound` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="timeouts"></a>
 
@@ -337,21 +249,13 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Where Site
 
-`disable_internet_vip` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Internet VIP](#where-site-disable-internet-vip) below.
+`disable_internet_vip` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`enable_internet_vip` - (Optional) Empty. This can be used for messages where no values are needed. See [Enable Internet VIP](#where-site-enable-internet-vip) below.
+`enable_internet_vip` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `network_type` - (Optional) Virtual Network Type. Different types of virtual networks understood by the system Virtual-network of type VIRTUAL_NETWORK_SITE_LOCAL provides connectivity to public (outside) network. This is an insecure network and is connected to public internet via NAT Gateways/firwalls Virtual-network of this type is local to every site. Two virtual networks of this type on different sites are neither related nor connected. Constraints: There can be atmost one virtual network of this type in a given site... Possible values include `VIRTUAL_NETWORK_SITE_LOCAL`, `VIRTUAL_NETWORK_SITE_LOCAL_INSIDE`, `VIRTUAL_NETWORK_PER_SITE`, `VIRTUAL_NETWORK_PUBLIC`, `VIRTUAL_NETWORK_GLOBAL`, `VIRTUAL_NETWORK_SITE_SERVICE`, `VIRTUAL_NETWORK_VER_INTERNAL`, `VIRTUAL_NETWORK_SITE_LOCAL_INSIDE_OUTSIDE`, `VIRTUAL_NETWORK_IP_AUTO`, `VIRTUAL_NETWORK_VOLTADN_PRIVATE_NETWORK`, and others. Defaults to `VIRTUAL_NETWORK_SITE_LOCAL` (`String`).
 
 `ref` - (Optional) Reference. A site direct reference. See [Ref](#where-site-ref) below.
-
-<a id="where-site-disable-internet-vip"></a>
-
-### Where Site Disable Internet VIP
-
-<a id="where-site-enable-internet-vip"></a>
-
-### Where Site Enable Internet VIP
 
 <a id="where-site-ref"></a>
 
@@ -371,21 +275,13 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Where Virtual Site
 
-`disable_internet_vip` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Internet VIP](#where-virtual-site-disable-internet-vip) below.
+`disable_internet_vip` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`enable_internet_vip` - (Optional) Empty. This can be used for messages where no values are needed. See [Enable Internet VIP](#where-virtual-site-enable-internet-vip) below.
+`enable_internet_vip` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `network_type` - (Optional) Virtual Network Type. Different types of virtual networks understood by the system Virtual-network of type VIRTUAL_NETWORK_SITE_LOCAL provides connectivity to public (outside) network. This is an insecure network and is connected to public internet via NAT Gateways/firwalls Virtual-network of this type is local to every site. Two virtual networks of this type on different sites are neither related nor connected. Constraints: There can be atmost one virtual network of this type in a given site... Possible values include `VIRTUAL_NETWORK_SITE_LOCAL`, `VIRTUAL_NETWORK_SITE_LOCAL_INSIDE`, `VIRTUAL_NETWORK_PER_SITE`, `VIRTUAL_NETWORK_PUBLIC`, `VIRTUAL_NETWORK_GLOBAL`, `VIRTUAL_NETWORK_SITE_SERVICE`, `VIRTUAL_NETWORK_VER_INTERNAL`, `VIRTUAL_NETWORK_SITE_LOCAL_INSIDE_OUTSIDE`, `VIRTUAL_NETWORK_IP_AUTO`, `VIRTUAL_NETWORK_VOLTADN_PRIVATE_NETWORK`, and others. Defaults to `VIRTUAL_NETWORK_SITE_LOCAL` (`String`).
 
 `ref` - (Optional) Reference. A virtual_site direct reference. See [Ref](#where-virtual-site-ref) below.
-
-<a id="where-virtual-site-disable-internet-vip"></a>
-
-### Where Virtual Site Disable Internet VIP
-
-<a id="where-virtual-site-enable-internet-vip"></a>
-
-### Where Virtual Site Enable Internet VIP
 
 <a id="where-virtual-site-ref"></a>
 

--- a/docs/resources/bgp_routing_policy.md
+++ b/docs/resources/bgp_routing_policy.md
@@ -86,37 +86,25 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Rules Action
 
-`aggregate` - (Optional) Empty. This can be used for messages where no values are needed. See [Aggregate](#rules-action-aggregate) below.
+`aggregate` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`allow` - (Optional) Empty. This can be used for messages where no values are needed. See [Allow](#rules-action-allow) below.
+`allow` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `as_path` - (Optional) AS-path to prepend. AS-Path Prepending is generally used to influence incoming traffic (`String`).
 
 `community` - (Optional) BGP Community list. List of BGP communities. See [Community](#rules-action-community) below.
 
-`deny` - (Optional) Empty. This can be used for messages where no values are needed. See [Deny](#rules-action-deny) below.
+`deny` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `local_preference` - (Optional) Local preference. BGP Local Preference is generally used to influence outgoing traffic (`Number`).
 
 `metric` - (Optional) MED/Metric. The Multi-Exit Discriminator metric to indicate the preferred path to AS (`Number`).
-
-<a id="rules-action-aggregate"></a>
-
-### Rules Action Aggregate
-
-<a id="rules-action-allow"></a>
-
-### Rules Action Allow
 
 <a id="rules-action-community"></a>
 
 ### Rules Action Community
 
 `community` - (Optional) BGP community. An unordered set of RFC 1997 defined 4-byte community, first 16 bits being ASN and lower 16 bits being value (`List`).
-
-<a id="rules-action-deny"></a>
-
-### Rules Action Deny
 
 <a id="rules-match"></a>
 
@@ -138,11 +126,7 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Rules Match IP Prefixes
 
-`prefixes` - (Optional) Prefix list. List of IP prefix. See [Prefixes](#rules-match-ip-prefixes-prefixes) below.
-
-<a id="rules-match-ip-prefixes-prefixes"></a>
-
-### Rules Match IP Prefixes Prefixes
+`prefixes` - (Optional) Prefix list. List of IP prefix (`Block`).
 
 <a id="timeouts"></a>
 

--- a/docs/resources/cdn_cache_rule.md
+++ b/docs/resources/cdn_cache_rule.md
@@ -78,17 +78,13 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Cache Rules
 
-`cache_bypass` - (Optional) Empty. This can be used for messages where no values are needed. See [Cache Bypass](#cache-rules-cache-bypass) below.
+`cache_bypass` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `eligible_for_cache` - (Optional) Cache Action Options. List of options for Cache Action. See [Eligible For Cache](#cache-rules-eligible-for-cache) below.
 
 `rule_expression_list` - (Optional) Expressions. Expressions are evaluated in the order in which they are specified. The evaluation stops when the first rule match occurs. See [Rule Expression List](#cache-rules-rule-expression-list) below.
 
 `rule_name` - (Optional) Rule Name. Name of the Cache Rule (`String`).
-
-<a id="cache-rules-cache-bypass"></a>
-
-### Cache Rules Cache Bypass
 
 <a id="cache-rules-eligible-for-cache"></a>
 
@@ -130,29 +126,13 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Cache Rules Rule Expression List Cache Rule Expression
 
-`cache_headers` - (Optional) Cache Headers. Configure cache rule headers to match the criteria. See [Cache Headers](#cache-rules-rule-expression-list-cache-rule-expression-cache-headers) below.
+`cache_headers` - (Optional) Cache Headers. Configure cache rule headers to match the criteria (`Block`).
 
-`cookie_matcher` - (Optional) Cookie Matchers. A list of predicates for all cookies that need to be matched. The criteria for matching each cookie is described in individual instances of CookieMatcherType. The actual cookie values are extracted from the request API as a list of strings for each cookie name. Note that all specified cookie matcher predicates must evaluate to true. See [Cookie Matcher](#cache-rules-rule-expression-list-cache-rule-expression-cookie-matcher) below.
+`cookie_matcher` - (Optional) Cookie Matchers. A list of predicates for all cookies that need to be matched. The criteria for matching each cookie is described in individual instances of CookieMatcherType. The actual cookie values are extracted from the request API as a list of strings for each cookie name. Note that all specified cookie matcher predicates must evaluate to true (`Block`).
 
-`path_match` - (Optional) Path to Match. Path match of the URI can be either be, Prefix match or exact match or regular expression match. See [Path Match](#cache-rules-rule-expression-list-cache-rule-expression-path-match) below.
+`path_match` - (Optional) Path to Match. Path match of the URI can be either be, Prefix match or exact match or regular expression match (`Block`).
 
-`query_parameters` - (Optional) Query Parameters. List of (key, value) query parameters. See [Query Parameters](#cache-rules-rule-expression-list-cache-rule-expression-query-parameters) below.
-
-<a id="cache-rules-rule-expression-list-cache-rule-expression-cache-headers"></a>
-
-### Cache Rules Rule Expression List Cache Rule Expression Cache Headers
-
-<a id="cache-rules-rule-expression-list-cache-rule-expression-cookie-matcher"></a>
-
-### Cache Rules Rule Expression List Cache Rule Expression Cookie Matcher
-
-<a id="cache-rules-rule-expression-list-cache-rule-expression-path-match"></a>
-
-### Cache Rules Rule Expression List Cache Rule Expression Path Match
-
-<a id="cache-rules-rule-expression-list-cache-rule-expression-query-parameters"></a>
-
-### Cache Rules Rule Expression List Cache Rule Expression Query Parameters
+`query_parameters` - (Optional) Query Parameters. List of (key, value) query parameters (`Block`).
 
 <a id="timeouts"></a>
 

--- a/docs/resources/cdn_loadbalancer.md
+++ b/docs/resources/cdn_loadbalancer.md
@@ -77,15 +77,15 @@ resource "f5xc_cdn_loadbalancer" "example" {
 
 `active_service_policies` - (Optional) Service Policy List. List of service policies. See [Active Service Policies](#active-service-policies) below for details.
 
-`no_service_policies` - (Optional) Empty. This can be used for messages where no values are needed. See [No Service Policies](#no-service-policies) below for details.
+`no_service_policies` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`service_policies_from_namespace` - (Optional) Empty. This can be used for messages where no values are needed. See [Service Policies From Namespace](#service-policies-from-namespace) below for details.
+`service_policies_from_namespace` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 > **Note:** One of the arguments from this list "api_rate_limit, disable_rate_limit, rate_limit" must be set.
 
 `api_rate_limit` - (Optional) APIRateLimit. See [API Rate Limit](#api-rate-limit) below for details.
 
-`disable_rate_limit` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Rate Limit](#disable-rate-limit) below for details.
+`disable_rate_limit` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `rate_limit` - (Optional) RateLimitConfigType. See [Rate Limit](#rate-limit) below for details.
 
@@ -93,13 +93,13 @@ resource "f5xc_cdn_loadbalancer" "example" {
 
 `api_specification` - (Optional) API Specification and Validation. Settings for API specification (API definition, OpenAPI validation, etc.). See [API Specification](#api-specification) below for details.
 
-`disable_api_definition` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable API Definition](#disable-api-definition) below for details.
+`disable_api_definition` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 > **Note:** One of the arguments from this list "app_firewall, disable_waf" must be set.
 
 `app_firewall` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [App Firewall](#app-firewall) below for details.
 
-`disable_waf` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable WAF](#disable-waf) below for details.
+`disable_waf` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `blocked_clients` - (Optional) Client Blocking Rules. Define rules to block IP Prefixes or AS numbers. See [Blocked Clients](#blocked-clients) below for details.
 
@@ -113,7 +113,7 @@ resource "f5xc_cdn_loadbalancer" "example" {
 
 `js_challenge` - (Optional) Javascript Challenge Parameters. Enables loadbalancer to perform client browser compatibility test by redirecting to a page with Javascript. With this feature enabled, only clients that are capable of executing Javascript(mostly browsers) will be allowed to complete the HTTP request. When loadbalancer is configured to do Javascript Challenge, it will redirect the browser to an HTML page on every new HTTP request. This HTML page will have Javascript embedded in it. Loadbalancer chooses a set o. See [Js Challenge](#js-challenge) below for details.
 
-`no_challenge` - (Optional) Empty. This can be used for messages where no values are needed. See [No Challenge](#no-challenge) below for details.
+`no_challenge` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `policy_based_challenge` - (Optional) Policy Based Challenge. Specifies the settings for policy rule based challenge. See [Policy Based Challenge](#policy-based-challenge) below for details.
 
@@ -121,7 +121,7 @@ resource "f5xc_cdn_loadbalancer" "example" {
 
 `client_side_defense` - (Optional) Client-Side Defense. This defines various configuration options for Client-Side Defense Policy. See [Client Side Defense](#client-side-defense) below for details.
 
-`disable_client_side_defense` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Client Side Defense](#disable-client-side-defense) below for details.
+`disable_client_side_defense` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `cors_policy` - (Optional) CORS Policy. Cross-Origin Resource Sharing requests configuration specified at Virtual-host or Route level. Route level configuration takes precedence. An example of an Cross origin HTTP request GET /resources/public-data/ HTTP/1.1 Host: bar.other User-Agent: Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.5; en-US; rv:1.9.1b3pre) Gecko/20081130 Minefield/3.1b3pre Accept: text/HTML,application/xhtml+XML,application/XML;q=0.9,*/*;q=0.8 Accept-Language: en-us,en;q=0.5 Accept-Encoding: gzip,deflate. See [CORS Policy](#cors-policy) below for details.
 
@@ -137,33 +137,33 @@ resource "f5xc_cdn_loadbalancer" "example" {
 
 > **Note:** One of the arguments from this list "default_sensitive_data_policy, sensitive_data_policy" must be set.
 
-`default_sensitive_data_policy` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Sensitive Data Policy](#default-sensitive-data-policy) below for details.
+`default_sensitive_data_policy` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `sensitive_data_policy` - (Optional) Sensitive Data Discovery. Settings for data type policy. See [Sensitive Data Policy](#sensitive-data-policy) below for details.
 
 > **Note:** One of the arguments from this list "disable_api_discovery, enable_api_discovery" must be set.
 
-`disable_api_discovery` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable API Discovery](#disable-api-discovery) below for details.
+`disable_api_discovery` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `enable_api_discovery` - (Optional) API Discovery Setting. Specifies the settings used for API discovery. See [Enable API Discovery](#enable-api-discovery) below for details.
 
 > **Note:** One of the arguments from this list "disable_ip_reputation, enable_ip_reputation" must be set.
 
-`disable_ip_reputation` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable IP Reputation](#disable-ip-reputation) below for details.
+`disable_ip_reputation` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `enable_ip_reputation` - (Optional) IP Threat Category List. List of IP threat categories. See [Enable IP Reputation](#enable-ip-reputation) below for details.
 
 > **Note:** One of the arguments from this list "disable_malicious_user_detection, enable_malicious_user_detection" must be set.
 
-`disable_malicious_user_detection` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Malicious User Detection](#disable-malicious-user-detection) below for details.
+`disable_malicious_user_detection` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`enable_malicious_user_detection` - (Optional) Empty. This can be used for messages where no values are needed. See [Enable Malicious User Detection](#enable-malicious-user-detection) below for details.
+`enable_malicious_user_detection` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 > **Note:** One of the arguments from this list "disable_threat_mesh, enable_threat_mesh" must be set.
 
-`disable_threat_mesh` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Threat Mesh](#disable-threat-mesh) below for details.
+`disable_threat_mesh` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`enable_threat_mesh` - (Optional) Empty. This can be used for messages where no values are needed. See [Enable Threat Mesh](#enable-threat-mesh) below for details.
+`enable_threat_mesh` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `domains` - (Optional) Domains. A list of fully qualified domain names. The CDN Distribution will be setup for these FQDN name(s). [This can be a domain or a sub-domain] (`List`).
 
@@ -181,9 +181,9 @@ resource "f5xc_cdn_loadbalancer" "example" {
 
 > **Note:** One of the arguments from this list "l7_ddos_action_block, l7_ddos_action_default, l7_ddos_action_js_challenge" must be set.
 
-`l7_ddos_action_block` - (Optional) Empty. This can be used for messages where no values are needed. See [L7 DDOS Action Block](#l7-ddos-action-block) below for details.
+`l7_ddos_action_block` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`l7_ddos_action_default` - (Optional) Empty. This can be used for messages where no values are needed. See [L7 DDOS Action Default](#l7-ddos-action-default) below for details.
+`l7_ddos_action_default` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `l7_ddos_action_js_challenge` - (Optional) Javascript Challenge Parameters. Enables loadbalancer to perform client browser compatibility test by redirecting to a page with Javascript. With this feature enabled, only clients that are capable of executing Javascript(mostly browsers) will be allowed to complete the HTTP request. When loadbalancer is configured to do Javascript Challenge, it will redirect the browser to an HTML page on every new HTTP request. This HTML page will have Javascript embedded in it. Loadbalancer chooses a set o. See [L7 DDOS Action Js Challenge](#l7-ddos-action-js-challenge) below for details.
 
@@ -197,7 +197,7 @@ resource "f5xc_cdn_loadbalancer" "example" {
 
 `slow_ddos_mitigation` - (Optional) Slow DDOS Mitigation. 'Slow and low' attacks tie up server resources, leaving none available for servicing requests from actual users. See [Slow DDOS Mitigation](#slow-ddos-mitigation) below for details.
 
-`system_default_timeouts` - (Optional) Empty. This can be used for messages where no values are needed. See [System Default Timeouts](#system-default-timeouts) below for details.
+`system_default_timeouts` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `timeouts` - (Optional) See [Timeouts](#timeouts) below for details.
 
@@ -205,7 +205,7 @@ resource "f5xc_cdn_loadbalancer" "example" {
 
 > **Note:** One of the arguments from this list "user_id_client_ip, user_identification" must be set.
 
-`user_id_client_ip` - (Optional) Empty. This can be used for messages where no values are needed. See [User Id Client IP](#user-id-client-ip) below for details.
+`user_id_client_ip` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `user_identification` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [User Identification](#user-identification) below for details.
 
@@ -247,7 +247,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `ip_allowed_list` - (Optional) IPv4 Prefix List. x-example: '192.168.20.0/24' List of IPv4 prefixes that represent an endpoint. See [IP Allowed List](#api-rate-limit-ip-allowed-list) below.
 
-`no_ip_allowed_list` - (Optional) Empty. This can be used for messages where no values are needed. See [No IP Allowed List](#api-rate-limit-no-ip-allowed-list) below.
+`no_ip_allowed_list` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `server_url_rules` - (Optional) Server URLs. Set of rules for entire domain or base path that contain multiple endpoints. Order is matter as it uses first match policy. For matching also specific endpoints you can use the API endpoint rules set bellow. See [Server URL Rules](#api-rate-limit-server-url-rules) below.
 
@@ -255,7 +255,7 @@ In addition to all arguments above, the following attributes are exported:
 
 ### API Rate Limit API Endpoint Rules
 
-`any_domain` - (Optional) Empty. This can be used for messages where no values are needed. See [Any Domain](#api-rate-limit-api-endpoint-rules-any-domain) below.
+`any_domain` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `api_endpoint_method` - (Optional) HTTP Method Matcher. A HTTP method matcher specifies a list of methods to match an input HTTP method. The match is considered successful if the input method is a member of the list. The result of the match based on the method list is inverted if invert_matcher is true. See [API Endpoint Method](#api-rate-limit-api-endpoint-rules-api-endpoint-method) below.
 
@@ -271,10 +271,6 @@ In addition to all arguments above, the following attributes are exported:
 
 `specific_domain` - (Optional) Specific Domain. The rule will apply for a specific domain (`String`).
 
-<a id="api-rate-limit-api-endpoint-rules-any-domain"></a>
-
-### API Rate Limit API Endpoint Rules Any Domain
-
 <a id="api-rate-limit-api-endpoint-rules-api-endpoint-method"></a>
 
 ### API Rate Limit API Endpoint Rules API Endpoint Method
@@ -287,79 +283,35 @@ In addition to all arguments above, the following attributes are exported:
 
 ### API Rate Limit API Endpoint Rules Client Matcher
 
-`any_client` - (Optional) Empty. This can be used for messages where no values are needed. See [Any Client](#api-rate-limit-api-endpoint-rules-client-matcher-any-client) below.
+`any_client` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`any_ip` - (Optional) Empty. This can be used for messages where no values are needed. See [Any IP](#api-rate-limit-api-endpoint-rules-client-matcher-any-ip) below.
+`any_ip` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`asn_list` - (Optional) ASN Match List. An unordered set of RFC 6793 defined 4-byte AS numbers that can be used to create allow or deny lists for use in network policy or service policy. It can be used to create the allow list only for DNS Load Balancer. See [Asn List](#api-rate-limit-api-endpoint-rules-client-matcher-asn-list) below.
+`asn_list` - (Optional) ASN Match List. An unordered set of RFC 6793 defined 4-byte AS numbers that can be used to create allow or deny lists for use in network policy or service policy. It can be used to create the allow list only for DNS Load Balancer (`Block`).
 
-`asn_matcher` - (Optional) ASN Matcher. Match any AS number contained in the list of bgp_asn_sets. See [Asn Matcher](#api-rate-limit-api-endpoint-rules-client-matcher-asn-matcher) below.
+`asn_matcher` - (Optional) ASN Matcher. Match any AS number contained in the list of bgp_asn_sets (`Block`).
 
-`client_selector` - (Optional) Label Selector. This type can be used to establish a 'selector reference' from one object(called selector) to a set of other objects(called selectees) based on the value of expresssions. A label selector is a label query over a set of resources. An empty label selector matches all objects. A null label selector matches no objects. Label selector is immutable. expressions is a list of strings of label selection expression. Each string has ',' separated values which are 'AND' and all strings ar. See [Client Selector](#api-rate-limit-api-endpoint-rules-client-matcher-client-selector) below.
+`client_selector` - (Optional) Label Selector. This type can be used to establish a 'selector reference' from one object(called selector) to a set of other objects(called selectees) based on the value of expresssions. A label selector is a label query over a set of resources. An empty label selector matches all objects. A null label selector matches no objects. Label selector is immutable. expressions is a list of strings of label selection expression. Each string has ',' separated values which are 'AND' and all strings ar (`Block`).
 
-`ip_matcher` - (Optional) IP Prefix Matcher. Match any IP prefix contained in the list of ip_prefix_sets. The result of the match is inverted if invert_matcher is true. See [IP Matcher](#api-rate-limit-api-endpoint-rules-client-matcher-ip-matcher) below.
+`ip_matcher` - (Optional) IP Prefix Matcher. Match any IP prefix contained in the list of ip_prefix_sets. The result of the match is inverted if invert_matcher is true (`Block`).
 
-`ip_prefix_list` - (Optional) IP Prefix Match List. List of IP Prefix strings to match against. See [IP Prefix List](#api-rate-limit-api-endpoint-rules-client-matcher-ip-prefix-list) below.
+`ip_prefix_list` - (Optional) IP Prefix Match List. List of IP Prefix strings to match against (`Block`).
 
-`ip_threat_category_list` - (Optional) IP Threat Category List Type. List of IP threat categories. See [IP Threat Category List](#api-rate-limit-api-endpoint-rules-client-matcher-ip-threat-category-list) below.
+`ip_threat_category_list` - (Optional) IP Threat Category List Type. List of IP threat categories (`Block`).
 
-`tls_fingerprint_matcher` - (Optional) TLS Fingerprint Matcher. A TLS fingerprint matcher specifies multiple criteria for matching a TLS fingerprint. The set of supported positve match criteria includes a list of known classes of TLS fingerprints and a list of exact values. The match is considered successful if either of these positive criteria are satisfied and the input fingerprint is not one of the excluded values. See [TLS Fingerprint Matcher](#api-rate-limit-api-endpoint-rules-client-matcher-tls-fingerprint-matcher) below.
-
-<a id="api-rate-limit-api-endpoint-rules-client-matcher-any-client"></a>
-
-### API Rate Limit API Endpoint Rules Client Matcher Any Client
-
-<a id="api-rate-limit-api-endpoint-rules-client-matcher-any-ip"></a>
-
-### API Rate Limit API Endpoint Rules Client Matcher Any IP
-
-<a id="api-rate-limit-api-endpoint-rules-client-matcher-asn-list"></a>
-
-### API Rate Limit API Endpoint Rules Client Matcher Asn List
-
-<a id="api-rate-limit-api-endpoint-rules-client-matcher-asn-matcher"></a>
-
-### API Rate Limit API Endpoint Rules Client Matcher Asn Matcher
-
-<a id="api-rate-limit-api-endpoint-rules-client-matcher-client-selector"></a>
-
-### API Rate Limit API Endpoint Rules Client Matcher Client Selector
-
-<a id="api-rate-limit-api-endpoint-rules-client-matcher-ip-matcher"></a>
-
-### API Rate Limit API Endpoint Rules Client Matcher IP Matcher
-
-<a id="api-rate-limit-api-endpoint-rules-client-matcher-ip-prefix-list"></a>
-
-### API Rate Limit API Endpoint Rules Client Matcher IP Prefix List
-
-<a id="api-rate-limit-api-endpoint-rules-client-matcher-ip-threat-category-list"></a>
-
-### API Rate Limit API Endpoint Rules Client Matcher IP Threat Category List
-
-<a id="api-rate-limit-api-endpoint-rules-client-matcher-tls-fingerprint-matcher"></a>
-
-### API Rate Limit API Endpoint Rules Client Matcher TLS Fingerprint Matcher
+`tls_fingerprint_matcher` - (Optional) TLS Fingerprint Matcher. A TLS fingerprint matcher specifies multiple criteria for matching a TLS fingerprint. The set of supported positve match criteria includes a list of known classes of TLS fingerprints and a list of exact values. The match is considered successful if either of these positive criteria are satisfied and the input fingerprint is not one of the excluded values (`Block`).
 
 <a id="api-rate-limit-api-endpoint-rules-inline-rate-limiter"></a>
 
 ### API Rate Limit API Endpoint Rules Inline Rate Limiter
 
-`ref_user_id` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Ref User Id](#api-rate-limit-api-endpoint-rules-inline-rate-limiter-ref-user-id) below.
+`ref_user_id` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name (`Block`).
 
 `threshold` - (Optional) Threshold. The total number of allowed requests for 1 unit (e.g. SECOND/MINUTE/HOUR etc.) of the specified period (`Number`).
 
 `unit` - (Optional) Rate Limit Period Unit. Unit for the period per which the rate limit is applied. - SECOND: Second Rate limit period unit is seconds - MINUTE: Minute Rate limit period unit is minutes - HOUR: Hour Rate limit period unit is hours - DAY: Day Rate limit period unit is days. Possible values are `SECOND`, `MINUTE`, `HOUR`. Defaults to `SECOND` (`String`).
 
-`use_http_lb_user_id` - (Optional) Empty. This can be used for messages where no values are needed. See [Use HTTP LB User Id](#api-rate-limit-api-endpoint-rules-inline-rate-limiter-use-http-lb-user-id) below.
-
-<a id="api-rate-limit-api-endpoint-rules-inline-rate-limiter-ref-user-id"></a>
-
-### API Rate Limit API Endpoint Rules Inline Rate Limiter Ref User Id
-
-<a id="api-rate-limit-api-endpoint-rules-inline-rate-limiter-use-http-lb-user-id"></a>
-
-### API Rate Limit API Endpoint Rules Inline Rate Limiter Use HTTP LB User Id
+`use_http_lb_user_id` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="api-rate-limit-api-endpoint-rules-ref-rate-limiter"></a>
 
@@ -375,29 +327,13 @@ In addition to all arguments above, the following attributes are exported:
 
 ### API Rate Limit API Endpoint Rules Request Matcher
 
-`cookie_matchers` - (Optional) Cookie Matchers. A list of predicates for all cookies that need to be matched. The criteria for matching each cookie is described in individual instances of CookieMatcherType. The actual cookie values are extracted from the request API as a list of strings for each cookie name. Note that all specified cookie matcher predicates must evaluate to true. See [Cookie Matchers](#api-rate-limit-api-endpoint-rules-request-matcher-cookie-matchers) below.
+`cookie_matchers` - (Optional) Cookie Matchers. A list of predicates for all cookies that need to be matched. The criteria for matching each cookie is described in individual instances of CookieMatcherType. The actual cookie values are extracted from the request API as a list of strings for each cookie name. Note that all specified cookie matcher predicates must evaluate to true (`Block`).
 
-`headers` - (Optional) HTTP Headers. A list of predicates for various HTTP headers that need to match. The criteria for matching each HTTP header are described in individual HeaderMatcherType instances. The actual HTTP header values are extracted from the request API as a list of strings for each HTTP header type. Note that all specified header predicates must evaluate to true. See [Headers](#api-rate-limit-api-endpoint-rules-request-matcher-headers) below.
+`headers` - (Optional) HTTP Headers. A list of predicates for various HTTP headers that need to match. The criteria for matching each HTTP header are described in individual HeaderMatcherType instances. The actual HTTP header values are extracted from the request API as a list of strings for each HTTP header type. Note that all specified header predicates must evaluate to true (`Block`).
 
-`jwt_claims` - (Optional) JWT Claims. A list of predicates for various JWT claims that need to match. The criteria for matching each JWT claim are described in individual JWTClaimMatcherType instances. The actual JWT claims values are extracted from the JWT payload as a list of strings. Note that all specified JWT claim predicates must evaluate to true. Note that this feature only works on LBs with JWT Validation feature enabled. See [JWT Claims](#api-rate-limit-api-endpoint-rules-request-matcher-jwt-claims) below.
+`jwt_claims` - (Optional) JWT Claims. A list of predicates for various JWT claims that need to match. The criteria for matching each JWT claim are described in individual JWTClaimMatcherType instances. The actual JWT claims values are extracted from the JWT payload as a list of strings. Note that all specified JWT claim predicates must evaluate to true. Note that this feature only works on LBs with JWT Validation feature enabled (`Block`).
 
-`query_params` - (Optional) HTTP Query Parameters. A list of predicates for all query parameters that need to be matched. The criteria for matching each query parameter are described in individual instances of QueryParameterMatcherType. The actual query parameter values are extracted from the request API as a list of strings for each query parameter name. Note that all specified query parameter predicates must evaluate to true. See [Query Params](#api-rate-limit-api-endpoint-rules-request-matcher-query-params) below.
-
-<a id="api-rate-limit-api-endpoint-rules-request-matcher-cookie-matchers"></a>
-
-### API Rate Limit API Endpoint Rules Request Matcher Cookie Matchers
-
-<a id="api-rate-limit-api-endpoint-rules-request-matcher-headers"></a>
-
-### API Rate Limit API Endpoint Rules Request Matcher Headers
-
-<a id="api-rate-limit-api-endpoint-rules-request-matcher-jwt-claims"></a>
-
-### API Rate Limit API Endpoint Rules Request Matcher JWT Claims
-
-<a id="api-rate-limit-api-endpoint-rules-request-matcher-query-params"></a>
-
-### API Rate Limit API Endpoint Rules Request Matcher Query Params
+`query_params` - (Optional) HTTP Query Parameters. A list of predicates for all query parameters that need to be matched. The criteria for matching each query parameter are described in individual instances of QueryParameterMatcherType. The actual query parameter values are extracted from the request API as a list of strings for each query parameter name. Note that all specified query parameter predicates must evaluate to true (`Block`).
 
 <a id="api-rate-limit-bypass-rate-limiting-rules"></a>
 
@@ -409,45 +345,21 @@ In addition to all arguments above, the following attributes are exported:
 
 ### API Rate Limit Bypass Rate Limiting Rules Bypass Rate Limiting Rules
 
-`any_domain` - (Optional) Empty. This can be used for messages where no values are needed. See [Any Domain](#api-rate-limit-bypass-rate-limiting-rules-bypass-rate-limiting-rules-any-domain) below.
+`any_domain` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`any_url` - (Optional) Empty. This can be used for messages where no values are needed. See [Any URL](#api-rate-limit-bypass-rate-limiting-rules-bypass-rate-limiting-rules-any-url) below.
+`any_url` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`api_endpoint` - (Optional) API Endpoint. This defines API endpoint. See [API Endpoint](#api-rate-limit-bypass-rate-limiting-rules-bypass-rate-limiting-rules-api-endpoint) below.
+`api_endpoint` - (Optional) API Endpoint. This defines API endpoint (`Block`).
 
-`api_groups` - (Optional) API Groups. See [API Groups](#api-rate-limit-bypass-rate-limiting-rules-bypass-rate-limiting-rules-api-groups) below.
+`api_groups` - (Optional) API Groups (`Block`).
 
 `base_path` - (Optional) Base Path. The base path which this validation applies to (`String`).
 
-`client_matcher` - (Optional) Client Matcher. Client conditions for matching a rule. See [Client Matcher](#api-rate-limit-bypass-rate-limiting-rules-bypass-rate-limiting-rules-client-matcher) below.
+`client_matcher` - (Optional) Client Matcher. Client conditions for matching a rule (`Block`).
 
-`request_matcher` - (Optional) Request Matcher. Request conditions for matching a rule. See [Request Matcher](#api-rate-limit-bypass-rate-limiting-rules-bypass-rate-limiting-rules-request-matcher) below.
+`request_matcher` - (Optional) Request Matcher. Request conditions for matching a rule (`Block`).
 
 `specific_domain` - (Optional) Specific Domain. The rule will apply for a specific domain. For example: API.example.com (`String`).
-
-<a id="api-rate-limit-bypass-rate-limiting-rules-bypass-rate-limiting-rules-any-domain"></a>
-
-### API Rate Limit Bypass Rate Limiting Rules Bypass Rate Limiting Rules Any Domain
-
-<a id="api-rate-limit-bypass-rate-limiting-rules-bypass-rate-limiting-rules-any-url"></a>
-
-### API Rate Limit Bypass Rate Limiting Rules Bypass Rate Limiting Rules Any URL
-
-<a id="api-rate-limit-bypass-rate-limiting-rules-bypass-rate-limiting-rules-api-endpoint"></a>
-
-### API Rate Limit Bypass Rate Limiting Rules Bypass Rate Limiting Rules API Endpoint
-
-<a id="api-rate-limit-bypass-rate-limiting-rules-bypass-rate-limiting-rules-api-groups"></a>
-
-### API Rate Limit Bypass Rate Limiting Rules Bypass Rate Limiting Rules API Groups
-
-<a id="api-rate-limit-bypass-rate-limiting-rules-bypass-rate-limiting-rules-client-matcher"></a>
-
-### API Rate Limit Bypass Rate Limiting Rules Bypass Rate Limiting Rules Client Matcher
-
-<a id="api-rate-limit-bypass-rate-limiting-rules-bypass-rate-limiting-rules-request-matcher"></a>
-
-### API Rate Limit Bypass Rate Limiting Rules Bypass Rate Limiting Rules Request Matcher
 
 <a id="api-rate-limit-custom-ip-allowed-list"></a>
 
@@ -471,15 +383,11 @@ In addition to all arguments above, the following attributes are exported:
 
 `prefixes` - (Optional) IPv4 Prefix List. List of IPv4 prefixes that represent an endpoint (`List`).
 
-<a id="api-rate-limit-no-ip-allowed-list"></a>
-
-### API Rate Limit No IP Allowed List
-
 <a id="api-rate-limit-server-url-rules"></a>
 
 ### API Rate Limit Server URL Rules
 
-`any_domain` - (Optional) Empty. This can be used for messages where no values are needed. See [Any Domain](#api-rate-limit-server-url-rules-any-domain) below.
+`any_domain` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `api_group` - (Optional) API Group. API groups derived from API Definition swaggers. For example oas-all-operations including all paths and methods from the swaggers, oas-base-urls covering all requests under base-paths from the swaggers. Custom groups can be created if user tags paths or operations with 'x-volterra-API-group' extensions inside swaggers (`String`).
 
@@ -495,87 +403,39 @@ In addition to all arguments above, the following attributes are exported:
 
 `specific_domain` - (Optional) Specific Domain. The rule will apply for a specific domain (`String`).
 
-<a id="api-rate-limit-server-url-rules-any-domain"></a>
-
-### API Rate Limit Server URL Rules Any Domain
-
 <a id="api-rate-limit-server-url-rules-client-matcher"></a>
 
 ### API Rate Limit Server URL Rules Client Matcher
 
-`any_client` - (Optional) Empty. This can be used for messages where no values are needed. See [Any Client](#api-rate-limit-server-url-rules-client-matcher-any-client) below.
+`any_client` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`any_ip` - (Optional) Empty. This can be used for messages where no values are needed. See [Any IP](#api-rate-limit-server-url-rules-client-matcher-any-ip) below.
+`any_ip` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`asn_list` - (Optional) ASN Match List. An unordered set of RFC 6793 defined 4-byte AS numbers that can be used to create allow or deny lists for use in network policy or service policy. It can be used to create the allow list only for DNS Load Balancer. See [Asn List](#api-rate-limit-server-url-rules-client-matcher-asn-list) below.
+`asn_list` - (Optional) ASN Match List. An unordered set of RFC 6793 defined 4-byte AS numbers that can be used to create allow or deny lists for use in network policy or service policy. It can be used to create the allow list only for DNS Load Balancer (`Block`).
 
-`asn_matcher` - (Optional) ASN Matcher. Match any AS number contained in the list of bgp_asn_sets. See [Asn Matcher](#api-rate-limit-server-url-rules-client-matcher-asn-matcher) below.
+`asn_matcher` - (Optional) ASN Matcher. Match any AS number contained in the list of bgp_asn_sets (`Block`).
 
-`client_selector` - (Optional) Label Selector. This type can be used to establish a 'selector reference' from one object(called selector) to a set of other objects(called selectees) based on the value of expresssions. A label selector is a label query over a set of resources. An empty label selector matches all objects. A null label selector matches no objects. Label selector is immutable. expressions is a list of strings of label selection expression. Each string has ',' separated values which are 'AND' and all strings ar. See [Client Selector](#api-rate-limit-server-url-rules-client-matcher-client-selector) below.
+`client_selector` - (Optional) Label Selector. This type can be used to establish a 'selector reference' from one object(called selector) to a set of other objects(called selectees) based on the value of expresssions. A label selector is a label query over a set of resources. An empty label selector matches all objects. A null label selector matches no objects. Label selector is immutable. expressions is a list of strings of label selection expression. Each string has ',' separated values which are 'AND' and all strings ar (`Block`).
 
-`ip_matcher` - (Optional) IP Prefix Matcher. Match any IP prefix contained in the list of ip_prefix_sets. The result of the match is inverted if invert_matcher is true. See [IP Matcher](#api-rate-limit-server-url-rules-client-matcher-ip-matcher) below.
+`ip_matcher` - (Optional) IP Prefix Matcher. Match any IP prefix contained in the list of ip_prefix_sets. The result of the match is inverted if invert_matcher is true (`Block`).
 
-`ip_prefix_list` - (Optional) IP Prefix Match List. List of IP Prefix strings to match against. See [IP Prefix List](#api-rate-limit-server-url-rules-client-matcher-ip-prefix-list) below.
+`ip_prefix_list` - (Optional) IP Prefix Match List. List of IP Prefix strings to match against (`Block`).
 
-`ip_threat_category_list` - (Optional) IP Threat Category List Type. List of IP threat categories. See [IP Threat Category List](#api-rate-limit-server-url-rules-client-matcher-ip-threat-category-list) below.
+`ip_threat_category_list` - (Optional) IP Threat Category List Type. List of IP threat categories (`Block`).
 
-`tls_fingerprint_matcher` - (Optional) TLS Fingerprint Matcher. A TLS fingerprint matcher specifies multiple criteria for matching a TLS fingerprint. The set of supported positve match criteria includes a list of known classes of TLS fingerprints and a list of exact values. The match is considered successful if either of these positive criteria are satisfied and the input fingerprint is not one of the excluded values. See [TLS Fingerprint Matcher](#api-rate-limit-server-url-rules-client-matcher-tls-fingerprint-matcher) below.
-
-<a id="api-rate-limit-server-url-rules-client-matcher-any-client"></a>
-
-### API Rate Limit Server URL Rules Client Matcher Any Client
-
-<a id="api-rate-limit-server-url-rules-client-matcher-any-ip"></a>
-
-### API Rate Limit Server URL Rules Client Matcher Any IP
-
-<a id="api-rate-limit-server-url-rules-client-matcher-asn-list"></a>
-
-### API Rate Limit Server URL Rules Client Matcher Asn List
-
-<a id="api-rate-limit-server-url-rules-client-matcher-asn-matcher"></a>
-
-### API Rate Limit Server URL Rules Client Matcher Asn Matcher
-
-<a id="api-rate-limit-server-url-rules-client-matcher-client-selector"></a>
-
-### API Rate Limit Server URL Rules Client Matcher Client Selector
-
-<a id="api-rate-limit-server-url-rules-client-matcher-ip-matcher"></a>
-
-### API Rate Limit Server URL Rules Client Matcher IP Matcher
-
-<a id="api-rate-limit-server-url-rules-client-matcher-ip-prefix-list"></a>
-
-### API Rate Limit Server URL Rules Client Matcher IP Prefix List
-
-<a id="api-rate-limit-server-url-rules-client-matcher-ip-threat-category-list"></a>
-
-### API Rate Limit Server URL Rules Client Matcher IP Threat Category List
-
-<a id="api-rate-limit-server-url-rules-client-matcher-tls-fingerprint-matcher"></a>
-
-### API Rate Limit Server URL Rules Client Matcher TLS Fingerprint Matcher
+`tls_fingerprint_matcher` - (Optional) TLS Fingerprint Matcher. A TLS fingerprint matcher specifies multiple criteria for matching a TLS fingerprint. The set of supported positve match criteria includes a list of known classes of TLS fingerprints and a list of exact values. The match is considered successful if either of these positive criteria are satisfied and the input fingerprint is not one of the excluded values (`Block`).
 
 <a id="api-rate-limit-server-url-rules-inline-rate-limiter"></a>
 
 ### API Rate Limit Server URL Rules Inline Rate Limiter
 
-`ref_user_id` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Ref User Id](#api-rate-limit-server-url-rules-inline-rate-limiter-ref-user-id) below.
+`ref_user_id` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name (`Block`).
 
 `threshold` - (Optional) Threshold. The total number of allowed requests for 1 unit (e.g. SECOND/MINUTE/HOUR etc.) of the specified period (`Number`).
 
 `unit` - (Optional) Rate Limit Period Unit. Unit for the period per which the rate limit is applied. - SECOND: Second Rate limit period unit is seconds - MINUTE: Minute Rate limit period unit is minutes - HOUR: Hour Rate limit period unit is hours - DAY: Day Rate limit period unit is days. Possible values are `SECOND`, `MINUTE`, `HOUR`. Defaults to `SECOND` (`String`).
 
-`use_http_lb_user_id` - (Optional) Empty. This can be used for messages where no values are needed. See [Use HTTP LB User Id](#api-rate-limit-server-url-rules-inline-rate-limiter-use-http-lb-user-id) below.
-
-<a id="api-rate-limit-server-url-rules-inline-rate-limiter-ref-user-id"></a>
-
-### API Rate Limit Server URL Rules Inline Rate Limiter Ref User Id
-
-<a id="api-rate-limit-server-url-rules-inline-rate-limiter-use-http-lb-user-id"></a>
-
-### API Rate Limit Server URL Rules Inline Rate Limiter Use HTTP LB User Id
+`use_http_lb_user_id` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="api-rate-limit-server-url-rules-ref-rate-limiter"></a>
 
@@ -591,29 +451,13 @@ In addition to all arguments above, the following attributes are exported:
 
 ### API Rate Limit Server URL Rules Request Matcher
 
-`cookie_matchers` - (Optional) Cookie Matchers. A list of predicates for all cookies that need to be matched. The criteria for matching each cookie is described in individual instances of CookieMatcherType. The actual cookie values are extracted from the request API as a list of strings for each cookie name. Note that all specified cookie matcher predicates must evaluate to true. See [Cookie Matchers](#api-rate-limit-server-url-rules-request-matcher-cookie-matchers) below.
+`cookie_matchers` - (Optional) Cookie Matchers. A list of predicates for all cookies that need to be matched. The criteria for matching each cookie is described in individual instances of CookieMatcherType. The actual cookie values are extracted from the request API as a list of strings for each cookie name. Note that all specified cookie matcher predicates must evaluate to true (`Block`).
 
-`headers` - (Optional) HTTP Headers. A list of predicates for various HTTP headers that need to match. The criteria for matching each HTTP header are described in individual HeaderMatcherType instances. The actual HTTP header values are extracted from the request API as a list of strings for each HTTP header type. Note that all specified header predicates must evaluate to true. See [Headers](#api-rate-limit-server-url-rules-request-matcher-headers) below.
+`headers` - (Optional) HTTP Headers. A list of predicates for various HTTP headers that need to match. The criteria for matching each HTTP header are described in individual HeaderMatcherType instances. The actual HTTP header values are extracted from the request API as a list of strings for each HTTP header type. Note that all specified header predicates must evaluate to true (`Block`).
 
-`jwt_claims` - (Optional) JWT Claims. A list of predicates for various JWT claims that need to match. The criteria for matching each JWT claim are described in individual JWTClaimMatcherType instances. The actual JWT claims values are extracted from the JWT payload as a list of strings. Note that all specified JWT claim predicates must evaluate to true. Note that this feature only works on LBs with JWT Validation feature enabled. See [JWT Claims](#api-rate-limit-server-url-rules-request-matcher-jwt-claims) below.
+`jwt_claims` - (Optional) JWT Claims. A list of predicates for various JWT claims that need to match. The criteria for matching each JWT claim are described in individual JWTClaimMatcherType instances. The actual JWT claims values are extracted from the JWT payload as a list of strings. Note that all specified JWT claim predicates must evaluate to true. Note that this feature only works on LBs with JWT Validation feature enabled (`Block`).
 
-`query_params` - (Optional) HTTP Query Parameters. A list of predicates for all query parameters that need to be matched. The criteria for matching each query parameter are described in individual instances of QueryParameterMatcherType. The actual query parameter values are extracted from the request API as a list of strings for each query parameter name. Note that all specified query parameter predicates must evaluate to true. See [Query Params](#api-rate-limit-server-url-rules-request-matcher-query-params) below.
-
-<a id="api-rate-limit-server-url-rules-request-matcher-cookie-matchers"></a>
-
-### API Rate Limit Server URL Rules Request Matcher Cookie Matchers
-
-<a id="api-rate-limit-server-url-rules-request-matcher-headers"></a>
-
-### API Rate Limit Server URL Rules Request Matcher Headers
-
-<a id="api-rate-limit-server-url-rules-request-matcher-jwt-claims"></a>
-
-### API Rate Limit Server URL Rules Request Matcher JWT Claims
-
-<a id="api-rate-limit-server-url-rules-request-matcher-query-params"></a>
-
-### API Rate Limit Server URL Rules Request Matcher Query Params
+`query_params` - (Optional) HTTP Query Parameters. A list of predicates for all query parameters that need to be matched. The criteria for matching each query parameter are described in individual instances of QueryParameterMatcherType. The actual query parameter values are extracted from the request API as a list of strings for each query parameter name. Note that all specified query parameter predicates must evaluate to true (`Block`).
 
 <a id="api-specification"></a>
 
@@ -625,7 +469,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `validation_custom_list` - (Optional) Custom List. Define API groups, base paths, or API endpoints and their OpenAPI validation modes. Any other API-endpoint not listed will act according to 'Fall Through Mode'. See [Validation Custom List](#api-specification-validation-custom-list) below.
 
-`validation_disabled` - (Optional) Empty. This can be used for messages where no values are needed. See [Validation Disabled](#api-specification-validation-disabled) below.
+`validation_disabled` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="api-specification-api-definition"></a>
 
@@ -651,73 +495,33 @@ In addition to all arguments above, the following attributes are exported:
 
 ### API Specification Validation All Spec Endpoints Fall Through Mode
 
-`fall_through_mode_allow` - (Optional) Empty. This can be used for messages where no values are needed. See [Fall Through Mode Allow](#api-specification-validation-all-spec-endpoints-fall-through-mode-fall-through-mode-allow) below.
+`fall_through_mode_allow` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`fall_through_mode_custom` - (Optional) Custom Fall Through Mode. Define the fall through settings. See [Fall Through Mode Custom](#api-specification-validation-all-spec-endpoints-fall-through-mode-fall-through-mode-custom) below.
-
-<a id="api-specification-validation-all-spec-endpoints-fall-through-mode-fall-through-mode-allow"></a>
-
-### API Specification Validation All Spec Endpoints Fall Through Mode Fall Through Mode Allow
-
-<a id="api-specification-validation-all-spec-endpoints-fall-through-mode-fall-through-mode-custom"></a>
-
-### API Specification Validation All Spec Endpoints Fall Through Mode Fall Through Mode Custom
+`fall_through_mode_custom` - (Optional) Custom Fall Through Mode. Define the fall through settings (`Block`).
 
 <a id="api-specification-validation-all-spec-endpoints-settings"></a>
 
 ### API Specification Validation All Spec Endpoints Settings
 
-`oversized_body_fail_validation` - (Optional) Empty. This can be used for messages where no values are needed. See [Oversized Body Fail Validation](#api-specification-validation-all-spec-endpoints-settings-oversized-body-fail-validation) below.
+`oversized_body_fail_validation` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`oversized_body_skip_validation` - (Optional) Empty. This can be used for messages where no values are needed. See [Oversized Body Skip Validation](#api-specification-validation-all-spec-endpoints-settings-oversized-body-skip-validation) below.
+`oversized_body_skip_validation` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`property_validation_settings_custom` - (Optional) Validation Property Settings. Custom property validation settings. See [Property Validation Settings Custom](#api-specification-validation-all-spec-endpoints-settings-property-validation-settings-custom) below.
+`property_validation_settings_custom` - (Optional) Validation Property Settings. Custom property validation settings (`Block`).
 
-`property_validation_settings_default` - (Optional) Empty. This can be used for messages where no values are needed. See [Property Validation Settings Default](#api-specification-validation-all-spec-endpoints-settings-property-validation-settings-default) below.
-
-<a id="api-specification-validation-all-spec-endpoints-settings-oversized-body-fail-validation"></a>
-
-### API Specification Validation All Spec Endpoints Settings Oversized Body Fail Validation
-
-<a id="api-specification-validation-all-spec-endpoints-settings-oversized-body-skip-validation"></a>
-
-### API Specification Validation All Spec Endpoints Settings Oversized Body Skip Validation
-
-<a id="api-specification-validation-all-spec-endpoints-settings-property-validation-settings-custom"></a>
-
-### API Specification Validation All Spec Endpoints Settings Property Validation Settings Custom
-
-<a id="api-specification-validation-all-spec-endpoints-settings-property-validation-settings-default"></a>
-
-### API Specification Validation All Spec Endpoints Settings Property Validation Settings Default
+`property_validation_settings_default` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="api-specification-validation-all-spec-endpoints-validation-mode"></a>
 
 ### API Specification Validation All Spec Endpoints Validation Mode
 
-`response_validation_mode_active` - (Optional) Open API Validation Mode Active. Validation mode properties of response. See [Response Validation Mode Active](#api-specification-validation-all-spec-endpoints-validation-mode-response-validation-mode-active) below.
+`response_validation_mode_active` - (Optional) Open API Validation Mode Active. Validation mode properties of response (`Block`).
 
-`skip_response_validation` - (Optional) Empty. This can be used for messages where no values are needed. See [Skip Response Validation](#api-specification-validation-all-spec-endpoints-validation-mode-skip-response-validation) below.
+`skip_response_validation` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`skip_validation` - (Optional) Empty. This can be used for messages where no values are needed. See [Skip Validation](#api-specification-validation-all-spec-endpoints-validation-mode-skip-validation) below.
+`skip_validation` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`validation_mode_active` - (Optional) Open API Validation Mode Active. Validation mode properties of request. See [Validation Mode Active](#api-specification-validation-all-spec-endpoints-validation-mode-validation-mode-active) below.
-
-<a id="api-specification-validation-all-spec-endpoints-validation-mode-response-validation-mode-active"></a>
-
-### API Specification Validation All Spec Endpoints Validation Mode Response Validation Mode Active
-
-<a id="api-specification-validation-all-spec-endpoints-validation-mode-skip-response-validation"></a>
-
-### API Specification Validation All Spec Endpoints Validation Mode Skip Response Validation
-
-<a id="api-specification-validation-all-spec-endpoints-validation-mode-skip-validation"></a>
-
-### API Specification Validation All Spec Endpoints Validation Mode Skip Validation
-
-<a id="api-specification-validation-all-spec-endpoints-validation-mode-validation-mode-active"></a>
-
-### API Specification Validation All Spec Endpoints Validation Mode Validation Mode Active
+`validation_mode_active` - (Optional) Open API Validation Mode Active. Validation mode properties of request (`Block`).
 
 <a id="api-specification-validation-custom-list"></a>
 
@@ -733,83 +537,39 @@ In addition to all arguments above, the following attributes are exported:
 
 ### API Specification Validation Custom List Fall Through Mode
 
-`fall_through_mode_allow` - (Optional) Empty. This can be used for messages where no values are needed. See [Fall Through Mode Allow](#api-specification-validation-custom-list-fall-through-mode-fall-through-mode-allow) below.
+`fall_through_mode_allow` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`fall_through_mode_custom` - (Optional) Custom Fall Through Mode. Define the fall through settings. See [Fall Through Mode Custom](#api-specification-validation-custom-list-fall-through-mode-fall-through-mode-custom) below.
-
-<a id="api-specification-validation-custom-list-fall-through-mode-fall-through-mode-allow"></a>
-
-### API Specification Validation Custom List Fall Through Mode Fall Through Mode Allow
-
-<a id="api-specification-validation-custom-list-fall-through-mode-fall-through-mode-custom"></a>
-
-### API Specification Validation Custom List Fall Through Mode Fall Through Mode Custom
+`fall_through_mode_custom` - (Optional) Custom Fall Through Mode. Define the fall through settings (`Block`).
 
 <a id="api-specification-validation-custom-list-open-api-validation-rules"></a>
 
 ### API Specification Validation Custom List Open API Validation Rules
 
-`any_domain` - (Optional) Empty. This can be used for messages where no values are needed. See [Any Domain](#api-specification-validation-custom-list-open-api-validation-rules-any-domain) below.
+`any_domain` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`api_endpoint` - (Optional) API Endpoint. This defines API endpoint. See [API Endpoint](#api-specification-validation-custom-list-open-api-validation-rules-api-endpoint) below.
+`api_endpoint` - (Optional) API Endpoint. This defines API endpoint (`Block`).
 
 `api_group` - (Optional) API Group. The API group which this validation applies to (`String`).
 
 `base_path` - (Optional) Base Path. The base path which this validation applies to (`String`).
 
-`metadata` - (Optional) Message Metadata. MessageMetaType is metadata (common attributes) of a message that only certain messages have. This information is propagated to the metadata of a child object that gets created from the containing message during view processing. The information in this type can be specified by user during create and replace APIs. See [Metadata](#api-specification-validation-custom-list-open-api-validation-rules-metadata) below.
+`metadata` - (Optional) Message Metadata. MessageMetaType is metadata (common attributes) of a message that only certain messages have. This information is propagated to the metadata of a child object that gets created from the containing message during view processing. The information in this type can be specified by user during create and replace APIs (`Block`).
 
 `specific_domain` - (Optional) Specific Domain. The rule will apply for a specific domain (`String`).
 
-`validation_mode` - (Optional) Validation Mode. x-required Validation mode of OpenAPI specification. When a validation mismatch occurs on a request to one of the endpoints listed on the OpenAPI specification file (a.k.a. swagger). See [Validation Mode](#api-specification-validation-custom-list-open-api-validation-rules-validation-mode) below.
-
-<a id="api-specification-validation-custom-list-open-api-validation-rules-any-domain"></a>
-
-### API Specification Validation Custom List Open API Validation Rules Any Domain
-
-<a id="api-specification-validation-custom-list-open-api-validation-rules-api-endpoint"></a>
-
-### API Specification Validation Custom List Open API Validation Rules API Endpoint
-
-<a id="api-specification-validation-custom-list-open-api-validation-rules-metadata"></a>
-
-### API Specification Validation Custom List Open API Validation Rules Metadata
-
-<a id="api-specification-validation-custom-list-open-api-validation-rules-validation-mode"></a>
-
-### API Specification Validation Custom List Open API Validation Rules Validation Mode
+`validation_mode` - (Optional) Validation Mode. x-required Validation mode of OpenAPI specification. When a validation mismatch occurs on a request to one of the endpoints listed on the OpenAPI specification file (a.k.a. swagger) (`Block`).
 
 <a id="api-specification-validation-custom-list-settings"></a>
 
 ### API Specification Validation Custom List Settings
 
-`oversized_body_fail_validation` - (Optional) Empty. This can be used for messages where no values are needed. See [Oversized Body Fail Validation](#api-specification-validation-custom-list-settings-oversized-body-fail-validation) below.
+`oversized_body_fail_validation` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`oversized_body_skip_validation` - (Optional) Empty. This can be used for messages where no values are needed. See [Oversized Body Skip Validation](#api-specification-validation-custom-list-settings-oversized-body-skip-validation) below.
+`oversized_body_skip_validation` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`property_validation_settings_custom` - (Optional) Validation Property Settings. Custom property validation settings. See [Property Validation Settings Custom](#api-specification-validation-custom-list-settings-property-validation-settings-custom) below.
+`property_validation_settings_custom` - (Optional) Validation Property Settings. Custom property validation settings (`Block`).
 
-`property_validation_settings_default` - (Optional) Empty. This can be used for messages where no values are needed. See [Property Validation Settings Default](#api-specification-validation-custom-list-settings-property-validation-settings-default) below.
-
-<a id="api-specification-validation-custom-list-settings-oversized-body-fail-validation"></a>
-
-### API Specification Validation Custom List Settings Oversized Body Fail Validation
-
-<a id="api-specification-validation-custom-list-settings-oversized-body-skip-validation"></a>
-
-### API Specification Validation Custom List Settings Oversized Body Skip Validation
-
-<a id="api-specification-validation-custom-list-settings-property-validation-settings-custom"></a>
-
-### API Specification Validation Custom List Settings Property Validation Settings Custom
-
-<a id="api-specification-validation-custom-list-settings-property-validation-settings-default"></a>
-
-### API Specification Validation Custom List Settings Property Validation Settings Default
-
-<a id="api-specification-validation-disabled"></a>
-
-### API Specification Validation Disabled
+`property_validation_settings_default` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="app-firewall"></a>
 
@@ -829,7 +589,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `as_number` - (Optional) AS Number. RFC 6793 defined 4-byte AS number (`Number`).
 
-`bot_skip_processing` - (Optional) Empty. This can be used for messages where no values are needed. See [Bot Skip Processing](#blocked-clients-bot-skip-processing) below.
+`bot_skip_processing` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `expiration_timestamp` - (Optional) Expiration Timestamp. The expiration_timestamp is the RFC 3339 format timestamp at which the containing rule is considered to be logically expired. The rule continues to exist in the configuration but is not applied anymore (`String`).
 
@@ -841,15 +601,11 @@ In addition to all arguments above, the following attributes are exported:
 
 `metadata` - (Optional) Message Metadata. MessageMetaType is metadata (common attributes) of a message that only certain messages have. This information is propagated to the metadata of a child object that gets created from the containing message during view processing. The information in this type can be specified by user during create and replace APIs. See [Metadata](#blocked-clients-metadata) below.
 
-`skip_processing` - (Optional) Empty. This can be used for messages where no values are needed. See [Skip Processing](#blocked-clients-skip-processing) below.
+`skip_processing` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `user_identifier` - (Optional) User Identifier. Identify user based on user identifier. User identifier value needs to be copied from security event (`String`).
 
-`waf_skip_processing` - (Optional) Empty. This can be used for messages where no values are needed. See [WAF Skip Processing](#blocked-clients-waf-skip-processing) below.
-
-<a id="blocked-clients-bot-skip-processing"></a>
-
-### Blocked Clients Bot Skip Processing
+`waf_skip_processing` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="blocked-clients-http-header"></a>
 
@@ -879,21 +635,13 @@ In addition to all arguments above, the following attributes are exported:
 
 `name` - (Optional) Name. This is the name of the message. The value of name has to follow DNS-1035 format (`String`).
 
-<a id="blocked-clients-skip-processing"></a>
-
-### Blocked Clients Skip Processing
-
-<a id="blocked-clients-waf-skip-processing"></a>
-
-### Blocked Clients WAF Skip Processing
-
 <a id="bot-defense"></a>
 
 ### Bot Defense
 
-`disable_cors_support` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable CORS Support](#bot-defense-disable-cors-support) below.
+`disable_cors_support` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`enable_cors_support` - (Optional) Empty. This can be used for messages where no values are needed. See [Enable CORS Support](#bot-defense-enable-cors-support) below.
+`enable_cors_support` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `policy` - (Optional) Bot Defense Policy. This defines various configuration options for Bot Defense policy. See [Policy](#bot-defense-policy) below.
 
@@ -901,21 +649,13 @@ In addition to all arguments above, the following attributes are exported:
 
 `timeout` - (Optional) Timeout. The timeout for the inference check, in milliseconds (`Number`).
 
-<a id="bot-defense-disable-cors-support"></a>
-
-### Bot Defense Disable CORS Support
-
-<a id="bot-defense-enable-cors-support"></a>
-
-### Bot Defense Enable CORS Support
-
 <a id="bot-defense-policy"></a>
 
 ### Bot Defense Policy
 
-`disable_js_insert` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Js Insert](#bot-defense-policy-disable-js-insert) below.
+`disable_js_insert` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`disable_mobile_sdk` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Mobile Sdk](#bot-defense-policy-disable-mobile-sdk) below.
+`disable_mobile_sdk` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `javascript_mode` - (Optional) Web Client JavaScript Mode. Web Client JavaScript Mode. Bot Defense JavaScript for telemetry collection is requested asynchronously, and it is non-cacheable Bot Defense JavaScript for telemetry collection is requested asynchronously, and it is cacheable Bot Defense JavaScript for telemetry collection is requested synchronously, and it is non-cacheable Bot Defense JavaScript for telemetry collection is requested synchronously, and it is cacheable. Possible values are `ASYNC_JS_NO_CACHING`, `ASYNC_JS_CACHING`, `SYNC_JS_NO_CACHING`, `SYNC_JS_CACHING`. Defaults to `ASYNC_JS_NO_CACHING` (`String`).
 
@@ -931,14 +671,6 @@ In addition to all arguments above, the following attributes are exported:
 
 `protected_app_endpoints` - (Optional) App Endpoint Type. List of protected endpoints. Limit: Approx '128 endpoints per Load Balancer (LB)' upto 4 LBs, '32 endpoints per LB' after 4 LBs. See [Protected App Endpoints](#bot-defense-policy-protected-app-endpoints) below.
 
-<a id="bot-defense-policy-disable-js-insert"></a>
-
-### Bot Defense Policy Disable Js Insert
-
-<a id="bot-defense-policy-disable-mobile-sdk"></a>
-
-### Bot Defense Policy Disable Mobile Sdk
-
 <a id="bot-defense-policy-js-insert-all-pages"></a>
 
 ### Bot Defense Policy Js Insert All Pages
@@ -949,131 +681,59 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Bot Defense Policy Js Insert All Pages Except
 
-`exclude_list` - (Optional) Exclude Pages. Optional JavaScript insertions exclude list of domain and path matchers. See [Exclude List](#bot-defense-policy-js-insert-all-pages-except-exclude-list) below.
+`exclude_list` - (Optional) Exclude Pages. Optional JavaScript insertions exclude list of domain and path matchers (`Block`).
 
 `javascript_location` - (Optional) JavaScript Location. All inside networks. Insert JavaScript after <head> tag Insert JavaScript after </title> tag. Insert JavaScript before first <script> tag. Possible values are `AFTER_HEAD`, `AFTER_TITLE_END`, `BEFORE_SCRIPT`. Defaults to `AFTER_HEAD` (`String`).
-
-<a id="bot-defense-policy-js-insert-all-pages-except-exclude-list"></a>
-
-### Bot Defense Policy Js Insert All Pages Except Exclude List
 
 <a id="bot-defense-policy-js-insertion-rules"></a>
 
 ### Bot Defense Policy Js Insertion Rules
 
-`exclude_list` - (Optional) Exclude Paths. Optional JavaScript insertions exclude list of domain and path matchers. See [Exclude List](#bot-defense-policy-js-insertion-rules-exclude-list) below.
+`exclude_list` - (Optional) Exclude Paths. Optional JavaScript insertions exclude list of domain and path matchers (`Block`).
 
-`rules` - (Optional) JavaScript Insertions. Required list of pages to insert Bot Defense client JavaScript. See [Rules](#bot-defense-policy-js-insertion-rules-rules) below.
-
-<a id="bot-defense-policy-js-insertion-rules-exclude-list"></a>
-
-### Bot Defense Policy Js Insertion Rules Exclude List
-
-<a id="bot-defense-policy-js-insertion-rules-rules"></a>
-
-### Bot Defense Policy Js Insertion Rules Rules
+`rules` - (Optional) JavaScript Insertions. Required list of pages to insert Bot Defense client JavaScript (`Block`).
 
 <a id="bot-defense-policy-mobile-sdk-config"></a>
 
 ### Bot Defense Policy Mobile Sdk Config
 
-`mobile_identifier` - (Optional) Mobile Traffic Identifier. Mobile traffic identifier type. See [Mobile Identifier](#bot-defense-policy-mobile-sdk-config-mobile-identifier) below.
-
-<a id="bot-defense-policy-mobile-sdk-config-mobile-identifier"></a>
-
-### Bot Defense Policy Mobile Sdk Config Mobile Identifier
+`mobile_identifier` - (Optional) Mobile Traffic Identifier. Mobile traffic identifier type (`Block`).
 
 <a id="bot-defense-policy-protected-app-endpoints"></a>
 
 ### Bot Defense Policy Protected App Endpoints
 
-`allow_good_bots` - (Optional) Empty. This can be used for messages where no values are needed. See [Allow Good Bots](#bot-defense-policy-protected-app-endpoints-allow-good-bots) below.
+`allow_good_bots` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`any_domain` - (Optional) Empty. This can be used for messages where no values are needed. See [Any Domain](#bot-defense-policy-protected-app-endpoints-any-domain) below.
+`any_domain` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`domain` - (Optional) Configuration for domain. See [Domain](#bot-defense-policy-protected-app-endpoints-domain) below.
+`domain` - (Optional) Configuration for domain (`Block`).
 
-`flow_label` - (Optional) Bot Defense Flow Label Category. Bot Defense Flow Label Category allows to associate traffic with selected category. See [Flow Label](#bot-defense-policy-protected-app-endpoints-flow-label) below.
+`flow_label` - (Optional) Bot Defense Flow Label Category. Bot Defense Flow Label Category allows to associate traffic with selected category (`Block`).
 
-`headers` - (Optional) HTTP Headers. A list of predicates for various HTTP headers that need to match. The criteria for matching each HTTP header are described in individual HeaderMatcherType instances. The actual HTTP header values are extracted from the request API as a list of strings for each HTTP header type. Note that all specified header predicates must evaluate to true. See [Headers](#bot-defense-policy-protected-app-endpoints-headers) below.
+`headers` - (Optional) HTTP Headers. A list of predicates for various HTTP headers that need to match. The criteria for matching each HTTP header are described in individual HeaderMatcherType instances. The actual HTTP header values are extracted from the request API as a list of strings for each HTTP header type. Note that all specified header predicates must evaluate to true (`Block`).
 
 `http_methods` - (Optional) HTTP Methods. List of HTTP methods (`List`).
 
-`metadata` - (Optional) Message Metadata. MessageMetaType is metadata (common attributes) of a message that only certain messages have. This information is propagated to the metadata of a child object that gets created from the containing message during view processing. The information in this type can be specified by user during create and replace APIs. See [Metadata](#bot-defense-policy-protected-app-endpoints-metadata) below.
+`metadata` - (Optional) Message Metadata. MessageMetaType is metadata (common attributes) of a message that only certain messages have. This information is propagated to the metadata of a child object that gets created from the containing message during view processing. The information in this type can be specified by user during create and replace APIs (`Block`).
 
-`mitigate_good_bots` - (Optional) Empty. This can be used for messages where no values are needed. See [Mitigate Good Bots](#bot-defense-policy-protected-app-endpoints-mitigate-good-bots) below.
+`mitigate_good_bots` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`mitigation` - (Optional) Bot Mitigation Action. Modify Bot Defense behavior for a matching request. See [Mitigation](#bot-defense-policy-protected-app-endpoints-mitigation) below.
+`mitigation` - (Optional) Bot Mitigation Action. Modify Bot Defense behavior for a matching request (`Block`).
 
-`mobile` - (Optional) Empty. This can be used for messages where no values are needed. See [Mobile](#bot-defense-policy-protected-app-endpoints-mobile) below.
+`mobile` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`path` - (Optional) Path to Match. Path match of the URI can be either be, Prefix match or exact match or regular expression match. See [Path](#bot-defense-policy-protected-app-endpoints-path) below.
+`path` - (Optional) Path to Match. Path match of the URI can be either be, Prefix match or exact match or regular expression match (`Block`).
 
 `protocol` - (Optional) URL Scheme. SchemeType is used to indicate URL scheme. - BOTH: BOTH URL scheme for HTTPS:// or `HTTP://.` - HTTP: HTTP URL scheme HTTP:// only. - HTTPS: HTTPS URL scheme HTTPS:// only. Possible values are `BOTH`, `HTTP`, `HTTPS`. Defaults to `BOTH` (`String`).
 
-`query_params` - (Optional) HTTP Query Parameters. A list of predicates for all query parameters that need to be matched. The criteria for matching each query parameter are described in individual instances of QueryParameterMatcherType. The actual query parameter values are extracted from the request API as a list of strings for each query parameter name. Note that all specified query parameter predicates must evaluate to true. See [Query Params](#bot-defense-policy-protected-app-endpoints-query-params) below.
+`query_params` - (Optional) HTTP Query Parameters. A list of predicates for all query parameters that need to be matched. The criteria for matching each query parameter are described in individual instances of QueryParameterMatcherType. The actual query parameter values are extracted from the request API as a list of strings for each query parameter name. Note that all specified query parameter predicates must evaluate to true (`Block`).
 
-`undefined_flow_label` - (Optional) Empty. This can be used for messages where no values are needed. See [Undefined Flow Label](#bot-defense-policy-protected-app-endpoints-undefined-flow-label) below.
+`undefined_flow_label` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`web` - (Optional) Empty. This can be used for messages where no values are needed. See [Web](#bot-defense-policy-protected-app-endpoints-web) below.
+`web` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`web_mobile` - (Optional) Web and Mobile traffic type. Web and Mobile traffic type. See [Web Mobile](#bot-defense-policy-protected-app-endpoints-web-mobile) below.
-
-<a id="bot-defense-policy-protected-app-endpoints-allow-good-bots"></a>
-
-### Bot Defense Policy Protected App Endpoints Allow Good Bots
-
-<a id="bot-defense-policy-protected-app-endpoints-any-domain"></a>
-
-### Bot Defense Policy Protected App Endpoints Any Domain
-
-<a id="bot-defense-policy-protected-app-endpoints-domain"></a>
-
-### Bot Defense Policy Protected App Endpoints Domain
-
-<a id="bot-defense-policy-protected-app-endpoints-flow-label"></a>
-
-### Bot Defense Policy Protected App Endpoints Flow Label
-
-<a id="bot-defense-policy-protected-app-endpoints-headers"></a>
-
-### Bot Defense Policy Protected App Endpoints Headers
-
-<a id="bot-defense-policy-protected-app-endpoints-metadata"></a>
-
-### Bot Defense Policy Protected App Endpoints Metadata
-
-<a id="bot-defense-policy-protected-app-endpoints-mitigate-good-bots"></a>
-
-### Bot Defense Policy Protected App Endpoints Mitigate Good Bots
-
-<a id="bot-defense-policy-protected-app-endpoints-mitigation"></a>
-
-### Bot Defense Policy Protected App Endpoints Mitigation
-
-<a id="bot-defense-policy-protected-app-endpoints-mobile"></a>
-
-### Bot Defense Policy Protected App Endpoints Mobile
-
-<a id="bot-defense-policy-protected-app-endpoints-path"></a>
-
-### Bot Defense Policy Protected App Endpoints Path
-
-<a id="bot-defense-policy-protected-app-endpoints-query-params"></a>
-
-### Bot Defense Policy Protected App Endpoints Query Params
-
-<a id="bot-defense-policy-protected-app-endpoints-undefined-flow-label"></a>
-
-### Bot Defense Policy Protected App Endpoints Undefined Flow Label
-
-<a id="bot-defense-policy-protected-app-endpoints-web"></a>
-
-### Bot Defense Policy Protected App Endpoints Web
-
-<a id="bot-defense-policy-protected-app-endpoints-web-mobile"></a>
-
-### Bot Defense Policy Protected App Endpoints Web Mobile
+`web_mobile` - (Optional) Web and Mobile traffic type. Web and Mobile traffic type (`Block`).
 
 <a id="captcha-challenge"></a>
 
@@ -1093,47 +753,27 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Client Side Defense Policy
 
-`disable_js_insert` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Js Insert](#client-side-defense-policy-disable-js-insert) below.
+`disable_js_insert` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`js_insert_all_pages` - (Optional) Empty. This can be used for messages where no values are needed. See [Js Insert All Pages](#client-side-defense-policy-js-insert-all-pages) below.
+`js_insert_all_pages` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `js_insert_all_pages_except` - (Optional) Insert JavaScript in All Pages with the Exceptions. Insert Client-Side Defense JavaScript in all pages with the exceptions. See [Js Insert All Pages Except](#client-side-defense-policy-js-insert-all-pages-except) below.
 
 `js_insertion_rules` - (Optional) JavaScript Custom Insertion Rules. This defines custom JavaScript insertion rules for Client-Side Defense Policy. See [Js Insertion Rules](#client-side-defense-policy-js-insertion-rules) below.
 
-<a id="client-side-defense-policy-disable-js-insert"></a>
-
-### Client Side Defense Policy Disable Js Insert
-
-<a id="client-side-defense-policy-js-insert-all-pages"></a>
-
-### Client Side Defense Policy Js Insert All Pages
-
 <a id="client-side-defense-policy-js-insert-all-pages-except"></a>
 
 ### Client Side Defense Policy Js Insert All Pages Except
 
-`exclude_list` - (Optional) Exclude Pages. Optional JavaScript insertions exclude list of domain and path matchers. See [Exclude List](#client-side-defense-policy-js-insert-all-pages-except-exclude-list) below.
-
-<a id="client-side-defense-policy-js-insert-all-pages-except-exclude-list"></a>
-
-### Client Side Defense Policy Js Insert All Pages Except Exclude List
+`exclude_list` - (Optional) Exclude Pages. Optional JavaScript insertions exclude list of domain and path matchers (`Block`).
 
 <a id="client-side-defense-policy-js-insertion-rules"></a>
 
 ### Client Side Defense Policy Js Insertion Rules
 
-`exclude_list` - (Optional) Exclude Paths. Optional JavaScript insertions exclude list of domain and path matchers. See [Exclude List](#client-side-defense-policy-js-insertion-rules-exclude-list) below.
+`exclude_list` - (Optional) Exclude Paths. Optional JavaScript insertions exclude list of domain and path matchers (`Block`).
 
-`rules` - (Optional) JavaScript Insertions. Required list of pages to insert Client-Side Defense client JavaScript. See [Rules](#client-side-defense-policy-js-insertion-rules-rules) below.
-
-<a id="client-side-defense-policy-js-insertion-rules-exclude-list"></a>
-
-### Client Side Defense Policy Js Insertion Rules Exclude List
-
-<a id="client-side-defense-policy-js-insertion-rules-rules"></a>
-
-### Client Side Defense Policy Js Insertion Rules Rules
+`rules` - (Optional) JavaScript Insertions. Required list of pages to insert Client-Side Defense client JavaScript (`Block`).
 
 <a id="cors-policy"></a>
 
@@ -1159,25 +799,17 @@ In addition to all arguments above, the following attributes are exported:
 
 ### CSRF Policy
 
-`all_load_balancer_domains` - (Optional) Empty. This can be used for messages where no values are needed. See [All Load Balancer Domains](#csrf-policy-all-load-balancer-domains) below.
+`all_load_balancer_domains` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `custom_domain_list` - (Optional) Domain name list. List of domain names used for Host header matching. See [Custom Domain List](#csrf-policy-custom-domain-list) below.
 
-`disabled` - (Optional) Empty. This can be used for messages where no values are needed. See [Disabled](#csrf-policy-disabled) below.
-
-<a id="csrf-policy-all-load-balancer-domains"></a>
-
-### CSRF Policy All Load Balancer Domains
+`disabled` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="csrf-policy-custom-domain-list"></a>
 
 ### CSRF Policy Custom Domain List
 
 `domains` - (Optional) Domain names. A list of domain names that will be matched to loadbalancer. These domains are not used for SNI match. Wildcard names are supported in the suffix or prefix form (`List`).
-
-<a id="csrf-policy-disabled"></a>
-
-### CSRF Policy Disabled
 
 <a id="custom-cache-rule"></a>
 
@@ -1199,9 +831,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Data Guard Rules
 
-`any_domain` - (Optional) Empty. This can be used for messages where no values are needed. See [Any Domain](#data-guard-rules-any-domain) below.
+`any_domain` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`apply_data_guard` - (Optional) Empty. This can be used for messages where no values are needed. See [Apply Data Guard](#data-guard-rules-apply-data-guard) below.
+`apply_data_guard` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `exact_value` - (Optional) Exact Value. Exact domain name (`String`).
 
@@ -1209,17 +841,9 @@ In addition to all arguments above, the following attributes are exported:
 
 `path` - (Optional) Path to Match. Path match of the URI can be either be, Prefix match or exact match or regular expression match. See [Path](#data-guard-rules-path) below.
 
-`skip_data_guard` - (Optional) Empty. This can be used for messages where no values are needed. See [Skip Data Guard](#data-guard-rules-skip-data-guard) below.
+`skip_data_guard` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `suffix_value` - (Optional) Suffix Value. Suffix of domain name e.g 'xyz.com' will match '*.xyz.com' and 'xyz.com' (`String`).
-
-<a id="data-guard-rules-any-domain"></a>
-
-### Data Guard Rules Any Domain
-
-<a id="data-guard-rules-apply-data-guard"></a>
-
-### Data Guard Rules Apply Data Guard
 
 <a id="data-guard-rules-metadata"></a>
 
@@ -1239,15 +863,11 @@ In addition to all arguments above, the following attributes are exported:
 
 `regex` - (Optional) Regex. Regular expression of path match (e.g. the value .* will match on all paths) (`String`).
 
-<a id="data-guard-rules-skip-data-guard"></a>
-
-### Data Guard Rules Skip Data Guard
-
 <a id="ddos-mitigation-rules"></a>
 
 ### DDOS Mitigation Rules
 
-`block` - (Optional) Empty. This can be used for messages where no values are needed. See [Block](#ddos-mitigation-rules-block) below.
+`block` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `ddos_client_source` - (Optional) DDOS Client Source Choice. DDOS Mitigation sources to be blocked. See [DDOS Client Source](#ddos-mitigation-rules-ddos-client-source) below.
 
@@ -1256,10 +876,6 @@ In addition to all arguments above, the following attributes are exported:
 `ip_prefix_list` - (Optional) IP Prefix Match List. List of IP Prefix strings to match against. See [IP Prefix List](#ddos-mitigation-rules-ip-prefix-list) below.
 
 `metadata` - (Optional) Message Metadata. MessageMetaType is metadata (common attributes) of a message that only certain messages have. This information is propagated to the metadata of a child object that gets created from the containing message during view processing. The information in this type can be specified by user during create and replace APIs. See [Metadata](#ddos-mitigation-rules-metadata) below.
-
-<a id="ddos-mitigation-rules-block"></a>
-
-### DDOS Mitigation Rules Block
 
 <a id="ddos-mitigation-rules-ddos-client-source"></a>
 
@@ -1315,51 +931,11 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Default Cache Action
 
-`cache_disabled` - (Optional) Empty. This can be used for messages where no values are needed. See [Cache Disabled](#default-cache-action-cache-disabled) below.
+`cache_disabled` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `cache_ttl_default` - (Optional) Fallback Cache TTL (d/ h/ m). Use Cache TTL Provided by Origin, and set a contigency TTL value in case one is not provided (`String`).
 
 `cache_ttl_override` - (Optional) Override Cache TTL (d/ h/ m/ s). Always override the Cahce TTL provided by Origin (`String`).
-
-<a id="default-cache-action-cache-disabled"></a>
-
-### Default Cache Action Cache Disabled
-
-<a id="default-sensitive-data-policy"></a>
-
-### Default Sensitive Data Policy
-
-<a id="disable-api-definition"></a>
-
-### Disable API Definition
-
-<a id="disable-api-discovery"></a>
-
-### Disable API Discovery
-
-<a id="disable-client-side-defense"></a>
-
-### Disable Client Side Defense
-
-<a id="disable-ip-reputation"></a>
-
-### Disable IP Reputation
-
-<a id="disable-malicious-user-detection"></a>
-
-### Disable Malicious User Detection
-
-<a id="disable-rate-limit"></a>
-
-### Disable Rate Limit
-
-<a id="disable-threat-mesh"></a>
-
-### Disable Threat Mesh
-
-<a id="disable-waf"></a>
-
-### Disable WAF
 
 <a id="enable-api-discovery"></a>
 
@@ -1371,13 +947,13 @@ In addition to all arguments above, the following attributes are exported:
 
 `custom_api_auth_discovery` - (Optional) API Discovery Advanced Settings. API Discovery Advanced settings. See [Custom API Auth Discovery](#enable-api-discovery-custom-api-auth-discovery) below.
 
-`default_api_auth_discovery` - (Optional) Empty. This can be used for messages where no values are needed. See [Default API Auth Discovery](#enable-api-discovery-default-api-auth-discovery) below.
+`default_api_auth_discovery` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`disable_learn_from_redirect_traffic` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Learn From Redirect Traffic](#enable-api-discovery-disable-learn-from-redirect-traffic) below.
+`disable_learn_from_redirect_traffic` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `discovered_api_settings` - (Optional) Discovered API Settings. x-example: '2' Configure Discovered API Settings. See [Discovered API Settings](#enable-api-discovery-discovered-api-settings) below.
 
-`enable_learn_from_redirect_traffic` - (Optional) Empty. This can be used for messages where no values are needed. See [Enable Learn From Redirect Traffic](#enable-api-discovery-enable-learn-from-redirect-traffic) below.
+`enable_learn_from_redirect_traffic` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="enable-api-discovery-api-crawler"></a>
 
@@ -1385,21 +961,13 @@ In addition to all arguments above, the following attributes are exported:
 
 `api_crawler_config` - (Optional) Crawler Configure. See [API Crawler Config](#enable-api-discovery-api-crawler-api-crawler-config) below.
 
-`disable_api_crawler` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable API Crawler](#enable-api-discovery-api-crawler-disable-api-crawler) below.
+`disable_api_crawler` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="enable-api-discovery-api-crawler-api-crawler-config"></a>
 
 ### Enable API Discovery API Crawler API Crawler Config
 
-`domains` - (Optional) Domains to Crawl. Enter domains and their credentials to allow authenticated API crawling. You can only include domains you own that are associated with this Load Balancer. See [Domains](#enable-api-discovery-api-crawler-api-crawler-config-domains) below.
-
-<a id="enable-api-discovery-api-crawler-api-crawler-config-domains"></a>
-
-### Enable API Discovery API Crawler API Crawler Config Domains
-
-<a id="enable-api-discovery-api-crawler-disable-api-crawler"></a>
-
-### Enable API Discovery API Crawler Disable API Crawler
+`domains` - (Optional) Domains to Crawl. Enter domains and their credentials to allow authenticated API crawling. You can only include domains you own that are associated with this Load Balancer (`Block`).
 
 <a id="enable-api-discovery-api-discovery-from-code-scan"></a>
 
@@ -1411,23 +979,11 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Enable API Discovery API Discovery From Code Scan Code Base Integrations
 
-`all_repos` - (Optional) Empty. This can be used for messages where no values are needed. See [All Repos](#enable-api-discovery-api-discovery-from-code-scan-code-base-integrations-all-repos) below.
+`all_repos` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`code_base_integration` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Code Base Integration](#enable-api-discovery-api-discovery-from-code-scan-code-base-integrations-code-base-integration) below.
+`code_base_integration` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name (`Block`).
 
-`selected_repos` - (Optional) API Code Repositories. Select which API repositories represent the LB applications. See [Selected Repos](#enable-api-discovery-api-discovery-from-code-scan-code-base-integrations-selected-repos) below.
-
-<a id="enable-api-discovery-api-discovery-from-code-scan-code-base-integrations-all-repos"></a>
-
-### Enable API Discovery API Discovery From Code Scan Code Base Integrations All Repos
-
-<a id="enable-api-discovery-api-discovery-from-code-scan-code-base-integrations-code-base-integration"></a>
-
-### Enable API Discovery API Discovery From Code Scan Code Base Integrations Code Base Integration
-
-<a id="enable-api-discovery-api-discovery-from-code-scan-code-base-integrations-selected-repos"></a>
-
-### Enable API Discovery API Discovery From Code Scan Code Base Integrations Selected Repos
+`selected_repos` - (Optional) API Code Repositories. Select which API repositories represent the LB applications (`Block`).
 
 <a id="enable-api-discovery-custom-api-auth-discovery"></a>
 
@@ -1445,23 +1001,11 @@ In addition to all arguments above, the following attributes are exported:
 
 `tenant` - (Optional) Tenant. When a configuration object(e.g. virtual_host) refers to another(e.g route) then tenant will hold the referred object's(e.g. route's) tenant (`String`).
 
-<a id="enable-api-discovery-default-api-auth-discovery"></a>
-
-### Enable API Discovery Default API Auth Discovery
-
-<a id="enable-api-discovery-disable-learn-from-redirect-traffic"></a>
-
-### Enable API Discovery Disable Learn From Redirect Traffic
-
 <a id="enable-api-discovery-discovered-api-settings"></a>
 
 ### Enable API Discovery Discovered API Settings
 
 `purge_duration_for_inactive_discovered_apis` - (Optional) Purge Duration for Inactive Discovered APIs from Traffic. Inactive discovered API will be deleted after configured duration (`Number`).
-
-<a id="enable-api-discovery-enable-learn-from-redirect-traffic"></a>
-
-### Enable API Discovery Enable Learn From Redirect Traffic
 
 <a id="enable-challenge"></a>
 
@@ -1469,11 +1013,11 @@ In addition to all arguments above, the following attributes are exported:
 
 `captcha_challenge_parameters` - (Optional) Captcha Challenge Parameters. Enables loadbalancer to perform captcha challenge Captcha challenge will be based on Google Recaptcha. With this feature enabled, only clients that pass the captcha challenge will be allowed to complete the HTTP request. When loadbalancer is configured to do Captcha Challenge, it will redirect the browser to an HTML page on every new HTTP request. This HTML page will have captcha challenge embedded in it. Client will be allowed to make the request only if the cap. See [Captcha Challenge Parameters](#enable-challenge-captcha-challenge-parameters) below.
 
-`default_captcha_challenge_parameters` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Captcha Challenge Parameters](#enable-challenge-default-captcha-challenge-parameters) below.
+`default_captcha_challenge_parameters` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`default_js_challenge_parameters` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Js Challenge Parameters](#enable-challenge-default-js-challenge-parameters) below.
+`default_js_challenge_parameters` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`default_mitigation_settings` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Mitigation Settings](#enable-challenge-default-mitigation-settings) below.
+`default_mitigation_settings` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `js_challenge_parameters` - (Optional) Javascript Challenge Parameters. Enables loadbalancer to perform client browser compatibility test by redirecting to a page with Javascript. With this feature enabled, only clients that are capable of executing Javascript(mostly browsers) will be allowed to complete the HTTP request. When loadbalancer is configured to do Javascript Challenge, it will redirect the browser to an HTML page on every new HTTP request. This HTML page will have Javascript embedded in it. Loadbalancer chooses a set o. See [Js Challenge Parameters](#enable-challenge-js-challenge-parameters) below.
 
@@ -1486,18 +1030,6 @@ In addition to all arguments above, the following attributes are exported:
 `cookie_expiry` - (Optional) Cookie Expiration Period. Cookie expiration period, in seconds. An expired cookie causes the loadbalancer to issue a new challenge (`Number`).
 
 `custom_page` - (Optional) Custom message for Captcha Challenge. Custom message is of type uri_ref. Currently supported URL schemes is string:///. For string:/// scheme, message needs to be encoded in Base64 format. You can specify this message as base64 encoded plain text message e.g. 'Please Wait.' or it can be HTML paragraph or a body string encoded as base64 string E.g. '<p> Please Wait </p>'. Base64 encoded string for this HTML is 'PHA+IFBsZWFzZSBXYWl0IDwvcD4=' (`String`).
-
-<a id="enable-challenge-default-captcha-challenge-parameters"></a>
-
-### Enable Challenge Default Captcha Challenge Parameters
-
-<a id="enable-challenge-default-js-challenge-parameters"></a>
-
-### Enable Challenge Default Js Challenge Parameters
-
-<a id="enable-challenge-default-mitigation-settings"></a>
-
-### Enable Challenge Default Mitigation Settings
 
 <a id="enable-challenge-js-challenge-parameters"></a>
 
@@ -1525,19 +1057,11 @@ In addition to all arguments above, the following attributes are exported:
 
 `ip_threat_categories` - (Optional) List of IP Threat Categories to choose. If the source IP matches on atleast one of the enabled IP threat categories, the request will be denied (`List`).
 
-<a id="enable-malicious-user-detection"></a>
-
-### Enable Malicious User Detection
-
-<a id="enable-threat-mesh"></a>
-
-### Enable Threat Mesh
-
 <a id="graphql-rules"></a>
 
 ### GraphQL Rules
 
-`any_domain` - (Optional) Empty. This can be used for messages where no values are needed. See [Any Domain](#graphql-rules-any-domain) below.
+`any_domain` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `exact_path` - (Optional) Path. Specifies the exact path to GraphQL endpoint. Default value is /GraphQL (`String`).
 
@@ -1547,37 +1071,25 @@ In addition to all arguments above, the following attributes are exported:
 
 `metadata` - (Optional) Message Metadata. MessageMetaType is metadata (common attributes) of a message that only certain messages have. This information is propagated to the metadata of a child object that gets created from the containing message during view processing. The information in this type can be specified by user during create and replace APIs. See [Metadata](#graphql-rules-metadata) below.
 
-`method_get` - (Optional) Empty. This can be used for messages where no values are needed. See [Method Get](#graphql-rules-method-get) below.
+`method_get` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`method_post` - (Optional) Empty. This can be used for messages where no values are needed. See [Method Post](#graphql-rules-method-post) below.
+`method_post` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `suffix_value` - (Optional) Suffix Value. Suffix of domain name e.g 'xyz.com' will match '*.xyz.com' and 'xyz.com' (`String`).
-
-<a id="graphql-rules-any-domain"></a>
-
-### GraphQL Rules Any Domain
 
 <a id="graphql-rules-graphql-settings"></a>
 
 ### GraphQL Rules GraphQL Settings
 
-`disable_introspection` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Introspection](#graphql-rules-graphql-settings-disable-introspection) below.
+`disable_introspection` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`enable_introspection` - (Optional) Empty. This can be used for messages where no values are needed. See [Enable Introspection](#graphql-rules-graphql-settings-enable-introspection) below.
+`enable_introspection` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `max_batched_queries` - (Optional) Maximum Batched Queries. Specify maximum number of queries in a single batched request (`Number`).
 
 `max_depth` - (Optional) Maximum Structure Depth. Specify maximum depth for the GraphQL query (`Number`).
 
 `max_total_length` - (Optional) Maximum Total Length. Specify maximum length in bytes for the GraphQL query (`Number`).
-
-<a id="graphql-rules-graphql-settings-disable-introspection"></a>
-
-### GraphQL Rules GraphQL Settings Disable Introspection
-
-<a id="graphql-rules-graphql-settings-enable-introspection"></a>
-
-### GraphQL Rules GraphQL Settings Enable Introspection
 
 <a id="graphql-rules-metadata"></a>
 
@@ -1586,14 +1098,6 @@ In addition to all arguments above, the following attributes are exported:
 `description` - (Optional) Description. Human readable description (`String`).
 
 `name` - (Optional) Name. This is the name of the message. The value of name has to follow DNS-1035 format (`String`).
-
-<a id="graphql-rules-method-get"></a>
-
-### GraphQL Rules Method Get
-
-<a id="graphql-rules-method-post"></a>
-
-### GraphQL Rules Method Post
 
 <a id="http"></a>
 
@@ -1627,57 +1131,25 @@ In addition to all arguments above, the following attributes are exported:
 
 ### HTTPS TLS Cert Options TLS Cert Params
 
-`certificates` - (Optional) Certificates. Select one or more certificates with any domain names. See [Certificates](#https-tls-cert-options-tls-cert-params-certificates) below.
+`certificates` - (Optional) Certificates. Select one or more certificates with any domain names (`Block`).
 
-`no_mtls` - (Optional) Empty. This can be used for messages where no values are needed. See [No mTLS](#https-tls-cert-options-tls-cert-params-no-mtls) below.
+`no_mtls` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`tls_config` - (Optional) TLS Config. This defines various options to configure TLS configuration parameters. See [TLS Config](#https-tls-cert-options-tls-cert-params-tls-config) below.
+`tls_config` - (Optional) TLS Config. This defines various options to configure TLS configuration parameters (`Block`).
 
-`use_mtls` - (Optional) Clients TLS validation context. Validation context for downstream client TLS connections. See [Use mTLS](#https-tls-cert-options-tls-cert-params-use-mtls) below.
-
-<a id="https-tls-cert-options-tls-cert-params-certificates"></a>
-
-### HTTPS TLS Cert Options TLS Cert Params Certificates
-
-<a id="https-tls-cert-options-tls-cert-params-no-mtls"></a>
-
-### HTTPS TLS Cert Options TLS Cert Params No mTLS
-
-<a id="https-tls-cert-options-tls-cert-params-tls-config"></a>
-
-### HTTPS TLS Cert Options TLS Cert Params TLS Config
-
-<a id="https-tls-cert-options-tls-cert-params-use-mtls"></a>
-
-### HTTPS TLS Cert Options TLS Cert Params Use mTLS
+`use_mtls` - (Optional) Clients TLS validation context. Validation context for downstream client TLS connections (`Block`).
 
 <a id="https-tls-cert-options-tls-inline-params"></a>
 
 ### HTTPS TLS Cert Options TLS Inline Params
 
-`no_mtls` - (Optional) Empty. This can be used for messages where no values are needed. See [No mTLS](#https-tls-cert-options-tls-inline-params-no-mtls) below.
+`no_mtls` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`tls_certificates` - (Optional) TLS Certificates. Users can add one or more certificates that share the same set of domains. for example, domain.com and *.domain.com - but use different signature algorithms. See [TLS Certificates](#https-tls-cert-options-tls-inline-params-tls-certificates) below.
+`tls_certificates` - (Optional) TLS Certificates. Users can add one or more certificates that share the same set of domains. for example, domain.com and *.domain.com - but use different signature algorithms (`Block`).
 
-`tls_config` - (Optional) TLS Config. This defines various options to configure TLS configuration parameters. See [TLS Config](#https-tls-cert-options-tls-inline-params-tls-config) below.
+`tls_config` - (Optional) TLS Config. This defines various options to configure TLS configuration parameters (`Block`).
 
-`use_mtls` - (Optional) Clients TLS validation context. Validation context for downstream client TLS connections. See [Use mTLS](#https-tls-cert-options-tls-inline-params-use-mtls) below.
-
-<a id="https-tls-cert-options-tls-inline-params-no-mtls"></a>
-
-### HTTPS TLS Cert Options TLS Inline Params No mTLS
-
-<a id="https-tls-cert-options-tls-inline-params-tls-certificates"></a>
-
-### HTTPS TLS Cert Options TLS Inline Params TLS Certificates
-
-<a id="https-tls-cert-options-tls-inline-params-tls-config"></a>
-
-### HTTPS TLS Cert Options TLS Inline Params TLS Config
-
-<a id="https-tls-cert-options-tls-inline-params-use-mtls"></a>
-
-### HTTPS TLS Cert Options TLS Inline Params Use mTLS
+`use_mtls` - (Optional) Clients TLS validation context. Validation context for downstream client TLS connections (`Block`).
 
 <a id="https-auto-cert"></a>
 
@@ -1693,17 +1165,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ### HTTPS Auto Cert TLS Config
 
-`tls_11_plus` - (Optional) Empty. This can be used for messages where no values are needed. See [TLS 11 Plus](#https-auto-cert-tls-config-tls-11-plus) below.
+`tls_11_plus` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`tls_12_plus` - (Optional) Empty. This can be used for messages where no values are needed. See [TLS 12 Plus](#https-auto-cert-tls-config-tls-12-plus) below.
-
-<a id="https-auto-cert-tls-config-tls-11-plus"></a>
-
-### HTTPS Auto Cert TLS Config TLS 11 Plus
-
-<a id="https-auto-cert-tls-config-tls-12-plus"></a>
-
-### HTTPS Auto Cert TLS Config TLS 12 Plus
+`tls_12_plus` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="js-challenge"></a>
 
@@ -1735,17 +1199,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ### JWT Validation Action
 
-`block` - (Optional) Empty. This can be used for messages where no values are needed. See [Block](#jwt-validation-action-block) below.
+`block` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`report` - (Optional) Empty. This can be used for messages where no values are needed. See [Report](#jwt-validation-action-report) below.
-
-<a id="jwt-validation-action-block"></a>
-
-### JWT Validation Action Block
-
-<a id="jwt-validation-action-report"></a>
-
-### JWT Validation Action Report
+`report` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="jwt-validation-jwks-config"></a>
 
@@ -1765,15 +1221,15 @@ In addition to all arguments above, the following attributes are exported:
 
 `audience` - (Optional) Audiences. See [Audience](#jwt-validation-reserved-claims-audience) below.
 
-`audience_disable` - (Optional) Empty. This can be used for messages where no values are needed. See [Audience Disable](#jwt-validation-reserved-claims-audience-disable) below.
+`audience_disable` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `issuer` - (Optional) Exact Match (`String`).
 
-`issuer_disable` - (Optional) Empty. This can be used for messages where no values are needed. See [Issuer Disable](#jwt-validation-reserved-claims-issuer-disable) below.
+`issuer_disable` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`validate_period_disable` - (Optional) Empty. This can be used for messages where no values are needed. See [Validate Period Disable](#jwt-validation-reserved-claims-validate-period-disable) below.
+`validate_period_disable` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`validate_period_enable` - (Optional) Empty. This can be used for messages where no values are needed. See [Validate Period Enable](#jwt-validation-reserved-claims-validate-period-enable) below.
+`validate_period_enable` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="jwt-validation-reserved-claims-audience"></a>
 
@@ -1781,35 +1237,15 @@ In addition to all arguments above, the following attributes are exported:
 
 `audiences` - (Optional) Values (`List`).
 
-<a id="jwt-validation-reserved-claims-audience-disable"></a>
-
-### JWT Validation Reserved Claims Audience Disable
-
-<a id="jwt-validation-reserved-claims-issuer-disable"></a>
-
-### JWT Validation Reserved Claims Issuer Disable
-
-<a id="jwt-validation-reserved-claims-validate-period-disable"></a>
-
-### JWT Validation Reserved Claims Validate Period Disable
-
-<a id="jwt-validation-reserved-claims-validate-period-enable"></a>
-
-### JWT Validation Reserved Claims Validate Period Enable
-
 <a id="jwt-validation-target"></a>
 
 ### JWT Validation Target
 
-`all_endpoint` - (Optional) Empty. This can be used for messages where no values are needed. See [All Endpoint](#jwt-validation-target-all-endpoint) below.
+`all_endpoint` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `api_groups` - (Optional) API Groups. See [API Groups](#jwt-validation-target-api-groups) below.
 
 `base_paths` - (Optional) Base Paths. See [Base Paths](#jwt-validation-target-base-paths) below.
-
-<a id="jwt-validation-target-all-endpoint"></a>
-
-### JWT Validation Target All Endpoint
 
 <a id="jwt-validation-target-api-groups"></a>
 
@@ -1827,19 +1263,7 @@ In addition to all arguments above, the following attributes are exported:
 
 ### JWT Validation Token Location
 
-`bearer_token` - (Optional) Empty. This can be used for messages where no values are needed. See [Bearer Token](#jwt-validation-token-location-bearer-token) below.
-
-<a id="jwt-validation-token-location-bearer-token"></a>
-
-### JWT Validation Token Location Bearer Token
-
-<a id="l7-ddos-action-block"></a>
-
-### L7 DDOS Action Block
-
-<a id="l7-ddos-action-default"></a>
-
-### L7 DDOS Action Default
+`bearer_token` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="l7-ddos-action-js-challenge"></a>
 
@@ -1851,21 +1275,13 @@ In addition to all arguments above, the following attributes are exported:
 
 `js_script_delay` - (Optional) Javascript Delay. Delay introduced by Javascript, in milliseconds (`Number`).
 
-<a id="no-challenge"></a>
-
-### No Challenge
-
-<a id="no-service-policies"></a>
-
-### No Service Policies
-
 <a id="origin-pool"></a>
 
 ### Origin Pool
 
 `more_origin_options` - (Optional) Origin Byte Range Request Config. See [More Origin Options](#origin-pool-more-origin-options) below.
 
-`no_tls` - (Optional) Empty. This can be used for messages where no values are needed. See [No TLS](#origin-pool-no-tls) below.
+`no_tls` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `origin_request_timeout` - (Optional) Origin Request Timeout Duration. Configures the time after which a request to the origin will time out waiting for a response (`String`).
 
@@ -1882,10 +1298,6 @@ In addition to all arguments above, the following attributes are exported:
 `enable_byte_range_request` - (Optional) Enable Origin Byte Range Requests. Choice to enable/disable byte range requests towards origin (`Bool`).
 
 `websocket_proxy` - (Optional) Enable WebSocket proxy to the origin. Option to enable proxying of WebSocket connections to the origin server (`Bool`).
-
-<a id="origin-pool-no-tls"></a>
-
-### Origin Pool No TLS
 
 <a id="origin-pool-origin-servers"></a>
 
@@ -1923,23 +1335,23 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Origin Pool Use TLS
 
-`default_session_key_caching` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Session Key Caching](#origin-pool-use-tls-default-session-key-caching) below.
+`default_session_key_caching` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`disable_session_key_caching` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Session Key Caching](#origin-pool-use-tls-disable-session-key-caching) below.
+`disable_session_key_caching` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`disable_sni` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Sni](#origin-pool-use-tls-disable-sni) below.
+`disable_sni` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `max_session_keys` - (Optional) Max Session Keys Cached. x-example:'25' Number of session keys that are cached (`Number`).
 
-`no_mtls` - (Optional) Empty. This can be used for messages where no values are needed. See [No mTLS](#origin-pool-use-tls-no-mtls) below.
+`no_mtls` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`skip_server_verification` - (Optional) Empty. This can be used for messages where no values are needed. See [Skip Server Verification](#origin-pool-use-tls-skip-server-verification) below.
+`skip_server_verification` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `sni` - (Optional) SNI Value. SNI value to be used (`String`).
 
 `tls_config` - (Optional) TLS Config. This defines various options to configure TLS configuration parameters. See [TLS Config](#origin-pool-use-tls-tls-config) below.
 
-`use_host_header_as_sni` - (Optional) Empty. This can be used for messages where no values are needed. See [Use Host Header As Sni](#origin-pool-use-tls-use-host-header-as-sni) below.
+`use_host_header_as_sni` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `use_mtls` - (Optional) mTLS Certificate. mTLS Client Certificate. See [Use mTLS](#origin-pool-use-tls-use-mtls) below.
 
@@ -1947,69 +1359,25 @@ In addition to all arguments above, the following attributes are exported:
 
 `use_server_verification` - (Optional) TLS Validation Context for Origin Servers. Upstream TLS Validation Context. See [Use Server Verification](#origin-pool-use-tls-use-server-verification) below.
 
-`volterra_trusted_ca` - (Optional) Empty. This can be used for messages where no values are needed. See [Volterra Trusted CA](#origin-pool-use-tls-volterra-trusted-ca) below.
-
-<a id="origin-pool-use-tls-default-session-key-caching"></a>
-
-### Origin Pool Use TLS Default Session Key Caching
-
-<a id="origin-pool-use-tls-disable-session-key-caching"></a>
-
-### Origin Pool Use TLS Disable Session Key Caching
-
-<a id="origin-pool-use-tls-disable-sni"></a>
-
-### Origin Pool Use TLS Disable Sni
-
-<a id="origin-pool-use-tls-no-mtls"></a>
-
-### Origin Pool Use TLS No mTLS
-
-<a id="origin-pool-use-tls-skip-server-verification"></a>
-
-### Origin Pool Use TLS Skip Server Verification
+`volterra_trusted_ca` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="origin-pool-use-tls-tls-config"></a>
 
 ### Origin Pool Use TLS TLS Config
 
-`custom_security` - (Optional) Custom Ciphers. This defines TLS protocol config including min/max versions and allowed ciphers. See [Custom Security](#origin-pool-use-tls-tls-config-custom-security) below.
+`custom_security` - (Optional) Custom Ciphers. This defines TLS protocol config including min/max versions and allowed ciphers (`Block`).
 
-`default_security` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Security](#origin-pool-use-tls-tls-config-default-security) below.
+`default_security` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`low_security` - (Optional) Empty. This can be used for messages where no values are needed. See [Low Security](#origin-pool-use-tls-tls-config-low-security) below.
+`low_security` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`medium_security` - (Optional) Empty. This can be used for messages where no values are needed. See [Medium Security](#origin-pool-use-tls-tls-config-medium-security) below.
-
-<a id="origin-pool-use-tls-tls-config-custom-security"></a>
-
-### Origin Pool Use TLS TLS Config Custom Security
-
-<a id="origin-pool-use-tls-tls-config-default-security"></a>
-
-### Origin Pool Use TLS TLS Config Default Security
-
-<a id="origin-pool-use-tls-tls-config-low-security"></a>
-
-### Origin Pool Use TLS TLS Config Low Security
-
-<a id="origin-pool-use-tls-tls-config-medium-security"></a>
-
-### Origin Pool Use TLS TLS Config Medium Security
-
-<a id="origin-pool-use-tls-use-host-header-as-sni"></a>
-
-### Origin Pool Use TLS Use Host Header As Sni
+`medium_security` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="origin-pool-use-tls-use-mtls"></a>
 
 ### Origin Pool Use TLS Use mTLS
 
-`tls_certificates` - (Optional) mTLS Client Certificate. mTLS Client Certificate. See [TLS Certificates](#origin-pool-use-tls-use-mtls-tls-certificates) below.
-
-<a id="origin-pool-use-tls-use-mtls-tls-certificates"></a>
-
-### Origin Pool Use TLS Use mTLS TLS Certificates
+`tls_certificates` - (Optional) mTLS Client Certificate. mTLS Client Certificate (`Block`).
 
 <a id="origin-pool-use-tls-use-mtls-obj"></a>
 
@@ -2025,17 +1393,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Origin Pool Use TLS Use Server Verification
 
-`trusted_ca` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Trusted CA](#origin-pool-use-tls-use-server-verification-trusted-ca) below.
+`trusted_ca` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name (`Block`).
 
 `trusted_ca_url` - (Optional) Inline Root CA Certificate (legacy). Upload a Root CA Certificate specifically for this Origin Pool for verification of server's certificate (`String`).
-
-<a id="origin-pool-use-tls-use-server-verification-trusted-ca"></a>
-
-### Origin Pool Use TLS Use Server Verification Trusted CA
-
-<a id="origin-pool-use-tls-volterra-trusted-ca"></a>
-
-### Origin Pool Use TLS Volterra Trusted CA
 
 <a id="other-settings"></a>
 
@@ -2067,13 +1427,9 @@ In addition to all arguments above, the following attributes are exported:
 
 `name` - (Optional) Name. Name of the HTTP header (`String`).
 
-`secret_value` - (Optional) Secret. SecretType is used in an object to indicate a sensitive/confidential field. See [Secret Value](#other-settings-header-options-request-headers-to-add-secret-value) below.
+`secret_value` - (Optional) Secret. SecretType is used in an object to indicate a sensitive/confidential field (`Block`).
 
 `value` - (Optional) Value. Value of the HTTP header (`String`).
-
-<a id="other-settings-header-options-request-headers-to-add-secret-value"></a>
-
-### Other Settings Header Options Request Headers To Add Secret Value
 
 <a id="other-settings-header-options-response-headers-to-add"></a>
 
@@ -2083,13 +1439,9 @@ In addition to all arguments above, the following attributes are exported:
 
 `name` - (Optional) Name. Name of the HTTP header (`String`).
 
-`secret_value` - (Optional) Secret. SecretType is used in an object to indicate a sensitive/confidential field. See [Secret Value](#other-settings-header-options-response-headers-to-add-secret-value) below.
+`secret_value` - (Optional) Secret. SecretType is used in an object to indicate a sensitive/confidential field (`Block`).
 
 `value` - (Optional) Value. Value of the HTTP header (`String`).
-
-<a id="other-settings-header-options-response-headers-to-add-secret-value"></a>
-
-### Other Settings Header Options Response Headers To Add Secret Value
 
 <a id="other-settings-logging-options"></a>
 
@@ -2115,37 +1467,29 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Policy Based Challenge
 
-`always_enable_captcha_challenge` - (Optional) Empty. This can be used for messages where no values are needed. See [Always Enable Captcha Challenge](#policy-based-challenge-always-enable-captcha-challenge) below.
+`always_enable_captcha_challenge` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`always_enable_js_challenge` - (Optional) Empty. This can be used for messages where no values are needed. See [Always Enable Js Challenge](#policy-based-challenge-always-enable-js-challenge) below.
+`always_enable_js_challenge` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `captcha_challenge_parameters` - (Optional) Captcha Challenge Parameters. Enables loadbalancer to perform captcha challenge Captcha challenge will be based on Google Recaptcha. With this feature enabled, only clients that pass the captcha challenge will be allowed to complete the HTTP request. When loadbalancer is configured to do Captcha Challenge, it will redirect the browser to an HTML page on every new HTTP request. This HTML page will have captcha challenge embedded in it. Client will be allowed to make the request only if the cap. See [Captcha Challenge Parameters](#policy-based-challenge-captcha-challenge-parameters) below.
 
-`default_captcha_challenge_parameters` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Captcha Challenge Parameters](#policy-based-challenge-default-captcha-challenge-parameters) below.
+`default_captcha_challenge_parameters` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`default_js_challenge_parameters` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Js Challenge Parameters](#policy-based-challenge-default-js-challenge-parameters) below.
+`default_js_challenge_parameters` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`default_mitigation_settings` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Mitigation Settings](#policy-based-challenge-default-mitigation-settings) below.
+`default_mitigation_settings` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`default_temporary_blocking_parameters` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Temporary Blocking Parameters](#policy-based-challenge-default-temporary-blocking-parameters) below.
+`default_temporary_blocking_parameters` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `js_challenge_parameters` - (Optional) Javascript Challenge Parameters. Enables loadbalancer to perform client browser compatibility test by redirecting to a page with Javascript. With this feature enabled, only clients that are capable of executing Javascript(mostly browsers) will be allowed to complete the HTTP request. When loadbalancer is configured to do Javascript Challenge, it will redirect the browser to an HTML page on every new HTTP request. This HTML page will have Javascript embedded in it. Loadbalancer chooses a set o. See [Js Challenge Parameters](#policy-based-challenge-js-challenge-parameters) below.
 
 `malicious_user_mitigation` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Malicious User Mitigation](#policy-based-challenge-malicious-user-mitigation) below.
 
-`no_challenge` - (Optional) Empty. This can be used for messages where no values are needed. See [No Challenge](#policy-based-challenge-no-challenge) below.
+`no_challenge` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `rule_list` - (Optional) Challenge Rule List. List of challenge rules to be used in policy based challenge. See [Rule List](#policy-based-challenge-rule-list) below.
 
 `temporary_user_blocking` - (Optional) Temporary User Blocking. Specifies configuration for temporary user blocking resulting from user behavior analysis. When Malicious User Mitigation is enabled from service policy rules, users' accessing the application will be analyzed for malicious activity and the configured mitigation actions will be taken on identified malicious users. These mitigation actions include setting up temporary blocking on that user. This configuration specifies settings on how that blocking should be done by th. See [Temporary User Blocking](#policy-based-challenge-temporary-user-blocking) below.
-
-<a id="policy-based-challenge-always-enable-captcha-challenge"></a>
-
-### Policy Based Challenge Always Enable Captcha Challenge
-
-<a id="policy-based-challenge-always-enable-js-challenge"></a>
-
-### Policy Based Challenge Always Enable Js Challenge
 
 <a id="policy-based-challenge-captcha-challenge-parameters"></a>
 
@@ -2154,22 +1498,6 @@ In addition to all arguments above, the following attributes are exported:
 `cookie_expiry` - (Optional) Cookie Expiration Period. Cookie expiration period, in seconds. An expired cookie causes the loadbalancer to issue a new challenge (`Number`).
 
 `custom_page` - (Optional) Custom message for Captcha Challenge. Custom message is of type uri_ref. Currently supported URL schemes is string:///. For string:/// scheme, message needs to be encoded in Base64 format. You can specify this message as base64 encoded plain text message e.g. 'Please Wait.' or it can be HTML paragraph or a body string encoded as base64 string E.g. '<p> Please Wait </p>'. Base64 encoded string for this HTML is 'PHA+IFBsZWFzZSBXYWl0IDwvcD4=' (`String`).
-
-<a id="policy-based-challenge-default-captcha-challenge-parameters"></a>
-
-### Policy Based Challenge Default Captcha Challenge Parameters
-
-<a id="policy-based-challenge-default-js-challenge-parameters"></a>
-
-### Policy Based Challenge Default Js Challenge Parameters
-
-<a id="policy-based-challenge-default-mitigation-settings"></a>
-
-### Policy Based Challenge Default Mitigation Settings
-
-<a id="policy-based-challenge-default-temporary-blocking-parameters"></a>
-
-### Policy Based Challenge Default Temporary Blocking Parameters
 
 <a id="policy-based-challenge-js-challenge-parameters"></a>
 
@@ -2191,10 +1519,6 @@ In addition to all arguments above, the following attributes are exported:
 
 `tenant` - (Optional) Tenant. When a configuration object(e.g. virtual_host) refers to another(e.g route) then tenant will hold the referred object's(e.g. route's) tenant (`String`).
 
-<a id="policy-based-challenge-no-challenge"></a>
-
-### Policy Based Challenge No Challenge
-
 <a id="policy-based-challenge-rule-list"></a>
 
 ### Policy Based Challenge Rule List
@@ -2205,17 +1529,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Policy Based Challenge Rule List Rules
 
-`metadata` - (Optional) Message Metadata. MessageMetaType is metadata (common attributes) of a message that only certain messages have. This information is propagated to the metadata of a child object that gets created from the containing message during view processing. The information in this type can be specified by user during create and replace APIs. See [Metadata](#policy-based-challenge-rule-list-rules-metadata) below.
+`metadata` - (Optional) Message Metadata. MessageMetaType is metadata (common attributes) of a message that only certain messages have. This information is propagated to the metadata of a child object that gets created from the containing message during view processing. The information in this type can be specified by user during create and replace APIs (`Block`).
 
-`spec` - (Optional) Challenge Rule Specification. A Challenge Rule consists of an unordered list of predicates and an action. The predicates are evaluated against a set of input fields that are extracted from or derived from an L7 request API. A request API is considered to match the rule if all predicates in the rule evaluate to true for that request. Any predicates that are not specified in a rule are implicitly considered to be true. If a request API matches a challenge rule, the configured challenge is enfor. See [Spec](#policy-based-challenge-rule-list-rules-spec) below.
-
-<a id="policy-based-challenge-rule-list-rules-metadata"></a>
-
-### Policy Based Challenge Rule List Rules Metadata
-
-<a id="policy-based-challenge-rule-list-rules-spec"></a>
-
-### Policy Based Challenge Rule List Rules Spec
+`spec` - (Optional) Challenge Rule Specification. A Challenge Rule consists of an unordered list of predicates and an action. The predicates are evaluated against a set of input fields that are extracted from or derived from an L7 request API. A request API is considered to match the rule if all predicates in the rule evaluate to true for that request. Any predicates that are not specified in a rule are implicitly considered to be true. If a request API matches a challenge rule, the configured challenge is enfor (`Block`).
 
 <a id="policy-based-challenge-temporary-user-blocking"></a>
 
@@ -2227,75 +1543,31 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Protected Cookies
 
-`add_httponly` - (Optional) Empty. This can be used for messages where no values are needed. See [Add Httponly](#protected-cookies-add-httponly) below.
+`add_httponly` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`add_secure` - (Optional) Empty. This can be used for messages where no values are needed. See [Add Secure](#protected-cookies-add-secure) below.
+`add_secure` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`disable_tampering_protection` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Tampering Protection](#protected-cookies-disable-tampering-protection) below.
+`disable_tampering_protection` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`enable_tampering_protection` - (Optional) Empty. This can be used for messages where no values are needed. See [Enable Tampering Protection](#protected-cookies-enable-tampering-protection) below.
+`enable_tampering_protection` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`ignore_httponly` - (Optional) Empty. This can be used for messages where no values are needed. See [Ignore Httponly](#protected-cookies-ignore-httponly) below.
+`ignore_httponly` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`ignore_max_age` - (Optional) Empty. This can be used for messages where no values are needed. See [Ignore Max Age](#protected-cookies-ignore-max-age) below.
+`ignore_max_age` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`ignore_samesite` - (Optional) Empty. This can be used for messages where no values are needed. See [Ignore Samesite](#protected-cookies-ignore-samesite) below.
+`ignore_samesite` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`ignore_secure` - (Optional) Empty. This can be used for messages where no values are needed. See [Ignore Secure](#protected-cookies-ignore-secure) below.
+`ignore_secure` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `max_age_value` - (Optional) Add Max Age. Add max age attribute (`Number`).
 
 `name` - (Optional) Cookie Name. Name of the Cookie (`String`).
 
-`samesite_lax` - (Optional) Empty. This can be used for messages where no values are needed. See [Samesite Lax](#protected-cookies-samesite-lax) below.
+`samesite_lax` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`samesite_none` - (Optional) Empty. This can be used for messages where no values are needed. See [Samesite None](#protected-cookies-samesite-none) below.
+`samesite_none` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`samesite_strict` - (Optional) Empty. This can be used for messages where no values are needed. See [Samesite Strict](#protected-cookies-samesite-strict) below.
-
-<a id="protected-cookies-add-httponly"></a>
-
-### Protected Cookies Add Httponly
-
-<a id="protected-cookies-add-secure"></a>
-
-### Protected Cookies Add Secure
-
-<a id="protected-cookies-disable-tampering-protection"></a>
-
-### Protected Cookies Disable Tampering Protection
-
-<a id="protected-cookies-enable-tampering-protection"></a>
-
-### Protected Cookies Enable Tampering Protection
-
-<a id="protected-cookies-ignore-httponly"></a>
-
-### Protected Cookies Ignore Httponly
-
-<a id="protected-cookies-ignore-max-age"></a>
-
-### Protected Cookies Ignore Max Age
-
-<a id="protected-cookies-ignore-samesite"></a>
-
-### Protected Cookies Ignore Samesite
-
-<a id="protected-cookies-ignore-secure"></a>
-
-### Protected Cookies Ignore Secure
-
-<a id="protected-cookies-samesite-lax"></a>
-
-### Protected Cookies Samesite Lax
-
-<a id="protected-cookies-samesite-none"></a>
-
-### Protected Cookies Samesite None
-
-<a id="protected-cookies-samesite-strict"></a>
-
-### Protected Cookies Samesite Strict
+`samesite_strict` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="rate-limit"></a>
 
@@ -2305,9 +1577,9 @@ In addition to all arguments above, the following attributes are exported:
 
 `ip_allowed_list` - (Optional) IPv4 Prefix List. x-example: '192.168.20.0/24' List of IPv4 prefixes that represent an endpoint. See [IP Allowed List](#rate-limit-ip-allowed-list) below.
 
-`no_ip_allowed_list` - (Optional) Empty. This can be used for messages where no values are needed. See [No IP Allowed List](#rate-limit-no-ip-allowed-list) below.
+`no_ip_allowed_list` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_policies` - (Optional) Empty. This can be used for messages where no values are needed. See [No Policies](#rate-limit-no-policies) below.
+`no_policies` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `policies` - (Optional) Rate Limiter Policy List. List of rate limiter policies to be applied. See [Policies](#rate-limit-policies) below.
 
@@ -2335,14 +1607,6 @@ In addition to all arguments above, the following attributes are exported:
 
 `prefixes` - (Optional) IPv4 Prefix List. List of IPv4 prefixes that represent an endpoint (`List`).
 
-<a id="rate-limit-no-ip-allowed-list"></a>
-
-### Rate Limit No IP Allowed List
-
-<a id="rate-limit-no-policies"></a>
-
-### Rate Limit No Policies
-
 <a id="rate-limit-policies"></a>
 
 ### Rate Limit Policies
@@ -2367,13 +1631,13 @@ In addition to all arguments above, the following attributes are exported:
 
 `burst_multiplier` - (Optional) Burst Multiplier. The maximum burst of requests to accommodate, expressed as a multiple of the rate (`Number`).
 
-`disabled` - (Optional) Empty. This can be used for messages where no values are needed. See [Disabled](#rate-limit-rate-limiter-disabled) below.
+`disabled` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`leaky_bucket` - (Optional) Leaky Bucket Rate Limiter. Leaky-Bucket is the default rate limiter algorithm for F5. See [Leaky Bucket](#rate-limit-rate-limiter-leaky-bucket) below.
+`leaky_bucket` - (Optional) Leaky Bucket Rate Limiter. Leaky-Bucket is the default rate limiter algorithm for F5 (`Block`).
 
 `period_multiplier` - (Optional) Periods. This setting, combined with Per Period units, provides a duration (`Number`).
 
-`token_bucket` - (Optional) Token Bucket Rate Limiter. Token-Bucket is a rate limiter algorithm that is stricter with enforcing limits. See [Token Bucket](#rate-limit-rate-limiter-token-bucket) below.
+`token_bucket` - (Optional) Token Bucket Rate Limiter. Token-Bucket is a rate limiter algorithm that is stricter with enforcing limits (`Block`).
 
 `total_number` - (Optional) Number Of Requests. The total number of allowed requests per rate-limiting period (`Number`).
 
@@ -2383,35 +1647,11 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Rate Limit Rate Limiter Action Block
 
-`hours` - (Optional) Hours. Input Duration Hours. See [Hours](#rate-limit-rate-limiter-action-block-hours) below.
+`hours` - (Optional) Hours. Input Duration Hours (`Block`).
 
-`minutes` - (Optional) Minutes. Input Duration Minutes. See [Minutes](#rate-limit-rate-limiter-action-block-minutes) below.
+`minutes` - (Optional) Minutes. Input Duration Minutes (`Block`).
 
-`seconds` - (Optional) Seconds. Input Duration Seconds. See [Seconds](#rate-limit-rate-limiter-action-block-seconds) below.
-
-<a id="rate-limit-rate-limiter-action-block-hours"></a>
-
-### Rate Limit Rate Limiter Action Block Hours
-
-<a id="rate-limit-rate-limiter-action-block-minutes"></a>
-
-### Rate Limit Rate Limiter Action Block Minutes
-
-<a id="rate-limit-rate-limiter-action-block-seconds"></a>
-
-### Rate Limit Rate Limiter Action Block Seconds
-
-<a id="rate-limit-rate-limiter-disabled"></a>
-
-### Rate Limit Rate Limiter Disabled
-
-<a id="rate-limit-rate-limiter-leaky-bucket"></a>
-
-### Rate Limit Rate Limiter Leaky Bucket
-
-<a id="rate-limit-rate-limiter-token-bucket"></a>
-
-### Rate Limit Rate Limiter Token Bucket
+`seconds` - (Optional) Seconds. Input Duration Seconds (`Block`).
 
 <a id="sensitive-data-policy"></a>
 
@@ -2429,27 +1669,15 @@ In addition to all arguments above, the following attributes are exported:
 
 `tenant` - (Optional) Tenant. When a configuration object(e.g. virtual_host) refers to another(e.g route) then tenant will hold the referred object's(e.g. route's) tenant (`String`).
 
-<a id="service-policies-from-namespace"></a>
-
-### Service Policies From Namespace
-
 <a id="slow-ddos-mitigation"></a>
 
 ### Slow DDOS Mitigation
 
-`disable_request_timeout` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Request Timeout](#slow-ddos-mitigation-disable-request-timeout) below.
+`disable_request_timeout` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `request_headers_timeout` - (Optional) Request Headers Timeout. The amount of time the client has to send only the headers on the request stream before the stream is cancelled. The default value is 10000 milliseconds. This setting provides protection against Slowloris attacks (`Number`).
 
 `request_timeout` - (Optional) Custom Timeout (`Number`).
-
-<a id="slow-ddos-mitigation-disable-request-timeout"></a>
-
-### Slow DDOS Mitigation Disable Request Timeout
-
-<a id="system-default-timeouts"></a>
-
-### System Default Timeouts
 
 <a id="timeouts"></a>
 
@@ -2471,7 +1699,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `as_number` - (Optional) AS Number. RFC 6793 defined 4-byte AS number (`Number`).
 
-`bot_skip_processing` - (Optional) Empty. This can be used for messages where no values are needed. See [Bot Skip Processing](#trusted-clients-bot-skip-processing) below.
+`bot_skip_processing` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `expiration_timestamp` - (Optional) Expiration Timestamp. The expiration_timestamp is the RFC 3339 format timestamp at which the containing rule is considered to be logically expired. The rule continues to exist in the configuration but is not applied anymore (`String`).
 
@@ -2483,15 +1711,11 @@ In addition to all arguments above, the following attributes are exported:
 
 `metadata` - (Optional) Message Metadata. MessageMetaType is metadata (common attributes) of a message that only certain messages have. This information is propagated to the metadata of a child object that gets created from the containing message during view processing. The information in this type can be specified by user during create and replace APIs. See [Metadata](#trusted-clients-metadata) below.
 
-`skip_processing` - (Optional) Empty. This can be used for messages where no values are needed. See [Skip Processing](#trusted-clients-skip-processing) below.
+`skip_processing` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `user_identifier` - (Optional) User Identifier. Identify user based on user identifier. User identifier value needs to be copied from security event (`String`).
 
-`waf_skip_processing` - (Optional) Empty. This can be used for messages where no values are needed. See [WAF Skip Processing](#trusted-clients-waf-skip-processing) below.
-
-<a id="trusted-clients-bot-skip-processing"></a>
-
-### Trusted Clients Bot Skip Processing
+`waf_skip_processing` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="trusted-clients-http-header"></a>
 
@@ -2521,18 +1745,6 @@ In addition to all arguments above, the following attributes are exported:
 
 `name` - (Optional) Name. This is the name of the message. The value of name has to follow DNS-1035 format (`String`).
 
-<a id="trusted-clients-skip-processing"></a>
-
-### Trusted Clients Skip Processing
-
-<a id="trusted-clients-waf-skip-processing"></a>
-
-### Trusted Clients WAF Skip Processing
-
-<a id="user-id-client-ip"></a>
-
-### User Id Client IP
-
 <a id="user-identification"></a>
 
 ### User Identification
@@ -2561,17 +1773,17 @@ In addition to all arguments above, the following attributes are exported:
 
 ### WAF Exclusion WAF Exclusion Inline Rules Rules
 
-`any_domain` - (Optional) Empty. This can be used for messages where no values are needed. See [Any Domain](#waf-exclusion-waf-exclusion-inline-rules-rules-any-domain) below.
+`any_domain` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`any_path` - (Optional) Empty. This can be used for messages where no values are needed. See [Any Path](#waf-exclusion-waf-exclusion-inline-rules-rules-any-path) below.
+`any_path` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`app_firewall_detection_control` - (Optional) App Firewall Detection Control. Define the list of Signature IDs, Violations, Attack Types and Bot Names that should be excluded from triggering on the defined match criteria. See [App Firewall Detection Control](#waf-exclusion-waf-exclusion-inline-rules-rules-app-firewall-detection-control) below.
+`app_firewall_detection_control` - (Optional) App Firewall Detection Control. Define the list of Signature IDs, Violations, Attack Types and Bot Names that should be excluded from triggering on the defined match criteria (`Block`).
 
 `exact_value` - (Optional) Exact Value. Exact domain name (`String`).
 
 `expiration_timestamp` - (Optional) Expiration Timestamp. The expiration_timestamp is the RFC 3339 format timestamp at which the containing rule is considered to be logically expired. The rule continues to exist in the configuration but is not applied anymore (`String`).
 
-`metadata` - (Optional) Message Metadata. MessageMetaType is metadata (common attributes) of a message that only certain messages have. This information is propagated to the metadata of a child object that gets created from the containing message during view processing. The information in this type can be specified by user during create and replace APIs. See [Metadata](#waf-exclusion-waf-exclusion-inline-rules-rules-metadata) below.
+`metadata` - (Optional) Message Metadata. MessageMetaType is metadata (common attributes) of a message that only certain messages have. This information is propagated to the metadata of a child object that gets created from the containing message during view processing. The information in this type can be specified by user during create and replace APIs (`Block`).
 
 `methods` - (Optional) Methods. methods to be matched (`List`).
 
@@ -2581,27 +1793,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `suffix_value` - (Optional) Suffix Value. Suffix of domain name e.g 'xyz.com' will match '*.xyz.com' and 'xyz.com' (`String`).
 
-`waf_skip_processing` - (Optional) Empty. This can be used for messages where no values are needed. See [WAF Skip Processing](#waf-exclusion-waf-exclusion-inline-rules-rules-waf-skip-processing) below.
-
-<a id="waf-exclusion-waf-exclusion-inline-rules-rules-any-domain"></a>
-
-### WAF Exclusion WAF Exclusion Inline Rules Rules Any Domain
-
-<a id="waf-exclusion-waf-exclusion-inline-rules-rules-any-path"></a>
-
-### WAF Exclusion WAF Exclusion Inline Rules Rules Any Path
-
-<a id="waf-exclusion-waf-exclusion-inline-rules-rules-app-firewall-detection-control"></a>
-
-### WAF Exclusion WAF Exclusion Inline Rules Rules App Firewall Detection Control
-
-<a id="waf-exclusion-waf-exclusion-inline-rules-rules-metadata"></a>
-
-### WAF Exclusion WAF Exclusion Inline Rules Rules Metadata
-
-<a id="waf-exclusion-waf-exclusion-inline-rules-rules-waf-skip-processing"></a>
-
-### WAF Exclusion WAF Exclusion Inline Rules Rules WAF Skip Processing
+`waf_skip_processing` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="waf-exclusion-waf-exclusion-policy"></a>
 

--- a/docs/resources/certificate.md
+++ b/docs/resources/certificate.md
@@ -64,9 +64,9 @@ resource "f5xc_certificate" "example" {
 
 `custom_hash_algorithms` - (Optional) Hash Algorithms. Specifies the hash algorithms to be used. See [Custom Hash Algorithms](#custom-hash-algorithms) below for details.
 
-`disable_ocsp_stapling` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable OCSP Stapling](#disable-ocsp-stapling) below for details.
+`disable_ocsp_stapling` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`use_system_defaults` - (Optional) Empty. This can be used for messages where no values are needed. See [Use System Defaults](#use-system-defaults) below for details.
+`use_system_defaults` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `private_key` - (Optional) Secret. SecretType is used in an object to indicate a sensitive/confidential field. See [Private Key](#private-key) below for details.
 
@@ -95,10 +95,6 @@ In addition to all arguments above, the following attributes are exported:
 ### Custom Hash Algorithms
 
 `hash_algorithms` - (Optional) Hash Algorithms. Ordered list of hash algorithms to be used (`List`).
-
-<a id="disable-ocsp-stapling"></a>
-
-### Disable OCSP Stapling
 
 <a id="private-key"></a>
 
@@ -137,10 +133,6 @@ In addition to all arguments above, the following attributes are exported:
 `read` - (Optional) A string that can be [parsed as a duration](`HTTPS://pkg.go.dev/time#ParseDuration`) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Read operations occur during any refresh or planning operation when refresh is enabled (`String`).
 
 `update` - (Optional) A string that can be [parsed as a duration](`HTTPS://pkg.go.dev/time#ParseDuration`) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours) (`String`).
-
-<a id="use-system-defaults"></a>
-
-### Use System Defaults
 
 ## Import
 

--- a/docs/resources/cloud_connect.md
+++ b/docs/resources/cloud_connect.md
@@ -120,31 +120,15 @@ In addition to all arguments above, the following attributes are exported:
 
 ### AWS Tgw Site Vpc Attachments Vpc List
 
-`custom_routing` - (Optional) AWS Route Table List. AWS Route Table List. See [Custom Routing](#aws-tgw-site-vpc-attachments-vpc-list-custom-routing) below.
+`custom_routing` - (Optional) AWS Route Table List. AWS Route Table List (`Block`).
 
-`default_route` - (Optional) Override Default Route Choice. Select Override Default Route Choice. See [Default Route](#aws-tgw-site-vpc-attachments-vpc-list-default-route) below.
+`default_route` - (Optional) Override Default Route Choice. Select Override Default Route Choice (`Block`).
 
-`labels` - (Optional) Labels. Add labels for the VPC attachment. These labels can then be used in policies such as enhanced firewall. See [Labels](#aws-tgw-site-vpc-attachments-vpc-list-labels) below.
+`labels` - (Optional) Labels. Add labels for the VPC attachment. These labels can then be used in policies such as enhanced firewall (`Block`).
 
-`manual_routing` - (Optional) Empty. This can be used for messages where no values are needed. See [Manual Routing](#aws-tgw-site-vpc-attachments-vpc-list-manual-routing) below.
+`manual_routing` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `vpc_id` - (Optional) VPC ID. Enter the VPC ID of the VPC to be attached (`String`).
-
-<a id="aws-tgw-site-vpc-attachments-vpc-list-custom-routing"></a>
-
-### AWS Tgw Site Vpc Attachments Vpc List Custom Routing
-
-<a id="aws-tgw-site-vpc-attachments-vpc-list-default-route"></a>
-
-### AWS Tgw Site Vpc Attachments Vpc List Default Route
-
-<a id="aws-tgw-site-vpc-attachments-vpc-list-labels"></a>
-
-### AWS Tgw Site Vpc Attachments Vpc List Labels
-
-<a id="aws-tgw-site-vpc-attachments-vpc-list-manual-routing"></a>
-
-### AWS Tgw Site Vpc Attachments Vpc List Manual Routing
 
 <a id="azure-vnet-site"></a>
 
@@ -174,33 +158,17 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Azure Vnet Site Vnet Attachments Vnet List
 
-`custom_routing` - (Optional) List Azure Route Table with Static Route. List Azure Route Table with Static Route. See [Custom Routing](#azure-vnet-site-vnet-attachments-vnet-list-custom-routing) below.
+`custom_routing` - (Optional) List Azure Route Table with Static Route. List Azure Route Table with Static Route (`Block`).
 
-`default_route` - (Optional) Override Default Route Choice. Select Override Default Route Choice. See [Default Route](#azure-vnet-site-vnet-attachments-vnet-list-default-route) below.
+`default_route` - (Optional) Override Default Route Choice. Select Override Default Route Choice (`Block`).
 
-`labels` - (Optional) Labels. Add labels for the VNET attachments. These labels can then be used in policies such as enhanced firewall policies. See [Labels](#azure-vnet-site-vnet-attachments-vnet-list-labels) below.
+`labels` - (Optional) Labels. Add labels for the VNET attachments. These labels can then be used in policies such as enhanced firewall policies (`Block`).
 
-`manual_routing` - (Optional) Empty. This can be used for messages where no values are needed. See [Manual Routing](#azure-vnet-site-vnet-attachments-vnet-list-manual-routing) below.
+`manual_routing` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `subscription_id` - (Optional) Subscription ID. Enter the Subscription ID of the VNET to be attached (`String`).
 
 `vnet_id` - (Optional) VNET ID. Enter the vnet ID of the VNET to be attached in format /<resource-group-name>/<vnet-name> (`String`).
-
-<a id="azure-vnet-site-vnet-attachments-vnet-list-custom-routing"></a>
-
-### Azure Vnet Site Vnet Attachments Vnet List Custom Routing
-
-<a id="azure-vnet-site-vnet-attachments-vnet-list-default-route"></a>
-
-### Azure Vnet Site Vnet Attachments Vnet List Default Route
-
-<a id="azure-vnet-site-vnet-attachments-vnet-list-labels"></a>
-
-### Azure Vnet Site Vnet Attachments Vnet List Labels
-
-<a id="azure-vnet-site-vnet-attachments-vnet-list-manual-routing"></a>
-
-### Azure Vnet Site Vnet Attachments Vnet List Manual Routing
 
 <a id="segment"></a>
 

--- a/docs/resources/cloud_credentials.md
+++ b/docs/resources/cloud_credentials.md
@@ -89,27 +89,15 @@ In addition to all arguments above, the following attributes are exported:
 
 `duration_seconds` - (Optional) Role Session Duration Seconds. The duration, in seconds of the role session (`Number`).
 
-`external_id_is_optional` - (Optional) Empty. This can be used for messages where no values are needed. See [External Id Is Optional](#aws-assume-role-external-id-is-optional) below.
+`external_id_is_optional` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`external_id_is_tenant_id` - (Optional) Empty. This can be used for messages where no values are needed. See [External Id Is Tenant Id](#aws-assume-role-external-id-is-tenant-id) below.
+`external_id_is_tenant_id` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `role_arn` - (Optional) IAM Role ARN. IAM Role ARN to assume the role (`String`).
 
 `session_name` - (Optional) Role Session Name. Use the role session name to uniquely identify a session, which will be used for deploy, monitor from F5XC console (`String`).
 
-`session_tags` - (Optional) Role Session Tags. Session tags are key-value pair attributes that you pass when you assume an IAM role. See [Session Tags](#aws-assume-role-session-tags) below.
-
-<a id="aws-assume-role-external-id-is-optional"></a>
-
-### AWS Assume Role External Id Is Optional
-
-<a id="aws-assume-role-external-id-is-tenant-id"></a>
-
-### AWS Assume Role External Id Is Tenant Id
-
-<a id="aws-assume-role-session-tags"></a>
-
-### AWS Assume Role Session Tags
+`session_tags` - (Optional) Role Session Tags. Session tags are key-value pair attributes that you pass when you assume an IAM role (`Block`).
 
 <a id="aws-secret-key"></a>
 

--- a/docs/resources/cloud_link.md
+++ b/docs/resources/cloud_link.md
@@ -70,7 +70,7 @@ resource "f5xc_cloud_link" "example" {
 
 > **Note:** One of the arguments from this list "disabled, enabled" must be set.
 
-`disabled` - (Optional) Empty. This can be used for messages where no values are needed. See [Disabled](#disabled) below for details.
+`disabled` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `enabled` - (Optional) CloudLink ADN Network Config. See [Enabled](#enabled) below for details.
 
@@ -114,51 +114,27 @@ In addition to all arguments above, the following attributes are exported:
 
 ### AWS Byoc Connections
 
-`auth_key` - (Optional) Secret. SecretType is used in an object to indicate a sensitive/confidential field. See [Auth Key](#aws-byoc-connections-auth-key) below.
+`auth_key` - (Optional) Secret. SecretType is used in an object to indicate a sensitive/confidential field (`Block`).
 
 `bgp_asn` - (Optional) BGP ASN. The Border Gateway Protocol (BGP) Autonomous System Number (ASN) of your on-premises router for the new virtual interface to be configured on AWS (`Number`).
 
 `connection_id` - (Optional) Direct Connect Connection Id. Id of the existing AWS Direct Connect Connection (`String`).
 
-`ipv4` - (Optional) IPv4 Peering. Configure BGP IPv4 peering for endpoints. See [IPv4](#aws-byoc-connections-ipv4) below.
+`ipv4` - (Optional) IPv4 Peering. Configure BGP IPv4 peering for endpoints (`Block`).
 
-`metadata` - (Optional) Message Metadata. MessageMetaType is metadata (common attributes) of a message that only certain messages have. This information is propagated to the metadata of a child object that gets created from the containing message during view processing. The information in this type can be specified by user during create and replace APIs. See [Metadata](#aws-byoc-connections-metadata) below.
+`metadata` - (Optional) Message Metadata. MessageMetaType is metadata (common attributes) of a message that only certain messages have. This information is propagated to the metadata of a child object that gets created from the containing message during view processing. The information in this type can be specified by user during create and replace APIs (`Block`).
 
 `region` - (Optional) Region. Region where the connection is setup (`String`).
 
-`system_generated_name` - (Optional) Empty. This can be used for messages where no values are needed. See [System Generated Name](#aws-byoc-connections-system-generated-name) below.
+`system_generated_name` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`tags` - (Optional) AWS Tags. AWS Tags is a label consisting of a user-defined key and value. It helps to manage, identify, organize, search for, and filter resources in AWS console. Specified tags will be added to Virtual interface along with any F5XC specific tags. See [Tags](#aws-byoc-connections-tags) below.
+`tags` - (Optional) AWS Tags. AWS Tags is a label consisting of a user-defined key and value. It helps to manage, identify, organize, search for, and filter resources in AWS console. Specified tags will be added to Virtual interface along with any F5XC specific tags (`Block`).
 
 `user_assigned_name` - (Optional) User Assigned. User is managing the AWS resource name (`String`).
 
 `virtual_interface_type` - (Optional) Virtual Interface Type. Defines the type of virtual interface that needs to be configured on AWS - PRIVATE: Private A private virtual interface should be used to access an Amazon VPC using private IP addresses. - TRANSIT: Transit A transit virtual interface is a VLAN that transports traffic from a Direct Connect gateway to one or more transit gateways. The only possible value is `PRIVATE`. Defaults to `PRIVATE` (`String`).
 
 `vlan` - (Optional) Virtual Local Area Network (VLAN). Virtual Local Area Network number for the new virtual interface to be configured on the AWS. This tag is required for any traffic traversing the AWS Direct Connect connection (`Number`).
-
-<a id="aws-byoc-connections-auth-key"></a>
-
-### AWS Byoc Connections Auth Key
-
-<a id="aws-byoc-connections-ipv4"></a>
-
-### AWS Byoc Connections IPv4
-
-<a id="aws-byoc-connections-metadata"></a>
-
-### AWS Byoc Connections Metadata
-
-<a id="aws-byoc-connections-system-generated-name"></a>
-
-### AWS Byoc Connections System Generated Name
-
-<a id="aws-byoc-connections-tags"></a>
-
-### AWS Byoc Connections Tags
-
-<a id="disabled"></a>
-
-### Disabled
 
 <a id="enabled"></a>
 
@@ -186,21 +162,13 @@ In addition to all arguments above, the following attributes are exported:
 
 `interconnect_attachment_name` - (Optional) Interconnect Attachment Name. Name of already-existing GCP Cloud Interconnect Attachment (`String`).
 
-`metadata` - (Optional) Message Metadata. MessageMetaType is metadata (common attributes) of a message that only certain messages have. This information is propagated to the metadata of a child object that gets created from the containing message during view processing. The information in this type can be specified by user during create and replace APIs. See [Metadata](#gcp-byoc-connections-metadata) below.
+`metadata` - (Optional) Message Metadata. MessageMetaType is metadata (common attributes) of a message that only certain messages have. This information is propagated to the metadata of a child object that gets created from the containing message during view processing. The information in this type can be specified by user during create and replace APIs (`Block`).
 
 `project` - (Optional) Specified Project. Specify a GCP Project for the interconnect attachment (`String`).
 
 `region` - (Optional) Region. GCP Region in which the GCP Cloud Interconnect attachment is configured (`String`).
 
-`same_as_credential` - (Optional) Empty. This can be used for messages where no values are needed. See [Same As Credential](#gcp-byoc-connections-same-as-credential) below.
-
-<a id="gcp-byoc-connections-metadata"></a>
-
-### GCP Byoc Connections Metadata
-
-<a id="gcp-byoc-connections-same-as-credential"></a>
-
-### GCP Byoc Connections Same As Credential
+`same_as_credential` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="gcp-gcp-cred"></a>
 

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -64,7 +64,7 @@ resource "f5xc_cluster" "example" {
 
 > **Note:** One of the arguments from this list "auto_http_config, http1_config, http2_options" must be set.
 
-`auto_http_config` - (Optional) Empty. This can be used for messages where no values are needed. See [Auto HTTP Config](#auto-http-config) below for details.
+`auto_http_config` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `http1_config` - (Optional) HTTP/1.1 Protocol Options. HTTP/1.1 Protocol options for upstream connections. See [Http1 Config](#http1-config) below for details.
 
@@ -74,15 +74,15 @@ resource "f5xc_cluster" "example" {
 
 `connection_timeout` - (Optional) Connection Timeout. The timeout for new network connections to endpoints in the cluster. This is specified in milliseconds. The default value is 2 seconds (`Number`).
 
-`default_subset` - (Optional) Default Subset. List of key-value pairs that define default subset. This subset can be referred in fallback_policy which gets used when route specifies no metadata or no subset matching the metadata exists. See [Default Subset](#default-subset) below for details.
+`default_subset` - (Optional) Default Subset. List of key-value pairs that define default subset. This subset can be referred in fallback_policy which gets used when route specifies no metadata or no subset matching the metadata exists (`Block`).
 
 > **Note:** One of the arguments from this list "disable_proxy_protocol, proxy_protocol_v1, proxy_protocol_v2" must be set.
 
-`disable_proxy_protocol` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Proxy Protocol](#disable-proxy-protocol) below for details.
+`disable_proxy_protocol` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`proxy_protocol_v1` - (Optional) Empty. This can be used for messages where no values are needed. See [Proxy Protocol V1](#proxy-protocol-v1) below for details.
+`proxy_protocol_v1` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`proxy_protocol_v2` - (Optional) Empty. This can be used for messages where no values are needed. See [Proxy Protocol V2](#proxy-protocol-v2) below for details.
+`proxy_protocol_v2` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `endpoint_selection` - (Optional) Endpoint Selection Policy. Policy for selection of endpoints from local site/remote site/both Consider both remote and local endpoints for load balancing LOCAL_ONLY: Consider only local endpoints for load balancing Enable this policy to load balance ONLY among locally discovered endpoints Prefer the local endpoints for load balancing. If local endpoints are not present remote endpoints will be considered. Possible values are `DISTRIBUTED`, `LOCAL_ONLY`, `LOCAL_PREFERRED`. Defaults to `DISTRIBUTED` (`String`).
 
@@ -100,7 +100,7 @@ resource "f5xc_cluster" "example" {
 
 > **Note:** One of the arguments from this list "no_panic_threshold, panic_threshold" must be set.
 
-`no_panic_threshold` - (Optional) Empty. This can be used for messages where no values are needed. See [No Panic Threshold](#no-panic-threshold) below for details.
+`no_panic_threshold` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `panic_threshold` - (Optional) Panic threshold. Configure a threshold (percentage of unhealthy endpoints) below which all endpoints will be considered for loadbalancing ignoring its health status (`Number`).
 
@@ -120,10 +120,6 @@ In addition to all arguments above, the following attributes are exported:
 
 ---
 
-<a id="auto-http-config"></a>
-
-### Auto HTTP Config
-
 <a id="circuit-breaker"></a>
 
 ### Circuit Breaker
@@ -137,14 +133,6 @@ In addition to all arguments above, the following attributes are exported:
 `priority` - (Optional) Routing Priority. Priority routing for each request. Different connection pools are used based on the priority selected for the request. Also, circuit-breaker configuration at destination cluster is chosen based on selected priority. Default routing mechanism High-Priority routing mechanism. Possible values are `DEFAULT`, `HIGH`. Defaults to `DEFAULT` (`String`).
 
 `retries` - (Optional) Retry Count. The maximum number of retries that can be outstanding to all hosts in a cluster at any given time. Remove endpoint out of load balancing decision, if retries for request exceed this count (`Number`).
-
-<a id="default-subset"></a>
-
-### Default Subset
-
-<a id="disable-proxy-protocol"></a>
-
-### Disable Proxy Protocol
 
 <a id="endpoint-subsets"></a>
 
@@ -190,39 +178,19 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Http1 Config Header Transformation
 
-`default_header_transformation` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Header Transformation](#http1-config-header-transformation-default-header-transformation) below.
+`default_header_transformation` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`legacy_header_transformation` - (Optional) Empty. This can be used for messages where no values are needed. See [Legacy Header Transformation](#http1-config-header-transformation-legacy-header-transformation) below.
+`legacy_header_transformation` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`preserve_case_header_transformation` - (Optional) Empty. This can be used for messages where no values are needed. See [Preserve Case Header Transformation](#http1-config-header-transformation-preserve-case-header-transformation) below.
+`preserve_case_header_transformation` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`proper_case_header_transformation` - (Optional) Empty. This can be used for messages where no values are needed. See [Proper Case Header Transformation](#http1-config-header-transformation-proper-case-header-transformation) below.
-
-<a id="http1-config-header-transformation-default-header-transformation"></a>
-
-### Http1 Config Header Transformation Default Header Transformation
-
-<a id="http1-config-header-transformation-legacy-header-transformation"></a>
-
-### Http1 Config Header Transformation Legacy Header Transformation
-
-<a id="http1-config-header-transformation-preserve-case-header-transformation"></a>
-
-### Http1 Config Header Transformation Preserve Case Header Transformation
-
-<a id="http1-config-header-transformation-proper-case-header-transformation"></a>
-
-### Http1 Config Header Transformation Proper Case Header Transformation
+`proper_case_header_transformation` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="http2-options"></a>
 
 ### Http2 Options
 
 `enabled` - (Optional) HTTP2 Enabled. Enable/disable HTTP2 Protocol for upstream connections (`Bool`).
-
-<a id="no-panic-threshold"></a>
-
-### No Panic Threshold
 
 <a id="outlier-detection"></a>
 
@@ -237,14 +205,6 @@ In addition to all arguments above, the following attributes are exported:
 `interval` - (Optional) Interval. The time interval between ejection analysis sweeps. This can result in both new ejections as well as endpoints being returned to service. Defaults to 10000ms or 10s. Specified in milliseconds (`Number`).
 
 `max_ejection_percent` - (Optional) Max Ejection Percentage. The maximum % of an upstream cluster that can be ejected due to outlier detection. Defaults to 10% but will eject at least one host regardless of the value (`Number`).
-
-<a id="proxy-protocol-v1"></a>
-
-### Proxy Protocol V1
-
-<a id="proxy-protocol-v2"></a>
-
-### Proxy Protocol V2
 
 <a id="timeouts"></a>
 
@@ -266,17 +226,17 @@ In addition to all arguments above, the following attributes are exported:
 
 `common_params` - (Optional) TLS Parameters. Information of different aspects for TLS authentication related to ciphers, certificates and trust store. See [Common Params](#tls-parameters-common-params) below.
 
-`default_session_key_caching` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Session Key Caching](#tls-parameters-default-session-key-caching) below.
+`default_session_key_caching` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`disable_session_key_caching` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Session Key Caching](#tls-parameters-disable-session-key-caching) below.
+`disable_session_key_caching` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`disable_sni` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Sni](#tls-parameters-disable-sni) below.
+`disable_sni` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `max_session_keys` - (Optional) Max Session Keys Cached. x-example:'25' Number of session keys that are cached (`Number`).
 
 `sni` - (Optional) SNI Value. SNI value to be used (`String`).
 
-`use_host_header_as_sni` - (Optional) Empty. This can be used for messages where no values are needed. See [Use Host Header As Sni](#tls-parameters-use-host-header-as-sni) below.
+`use_host_header_as_sni` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="tls-parameters-cert-params"></a>
 
@@ -312,15 +272,11 @@ In addition to all arguments above, the following attributes are exported:
 
 `skip_hostname_verification` - (Optional) Skip verification of hostname. When True, skip verification of hostname i.e. CN/Subject Alt Name of certificate is not matched to the connecting hostname (`Bool`).
 
-`trusted_ca` - (Optional) Root CA Certificate Reference. Reference to Root CA Certificate. See [Trusted CA](#tls-parameters-cert-params-validation-params-trusted-ca) below.
+`trusted_ca` - (Optional) Root CA Certificate Reference. Reference to Root CA Certificate (`Block`).
 
 `trusted_ca_url` - (Optional) Inline Root CA Certificate (legacy). Inline Root CA Certificate (`String`).
 
 `verify_subject_alt_names` - (Optional) List of SANs for matching. List of acceptable Subject Alt Names/CN in the peer's certificate. When skip_hostname_verification is false and verify_subject_alt_names is empty, the hostname of the peer will be used for matching against SAN/CN of peer's certificate (`List`).
-
-<a id="tls-parameters-cert-params-validation-params-trusted-ca"></a>
-
-### TLS Parameters Cert Params Validation Params Trusted CA
 
 <a id="tls-parameters-common-params"></a>
 
@@ -342,31 +298,15 @@ In addition to all arguments above, the following attributes are exported:
 
 `certificate_url` - (Optional) Certificate. TLS certificate. Certificate or certificate chain in PEM format including the PEM headers (`String`).
 
-`custom_hash_algorithms` - (Optional) Hash Algorithms. Specifies the hash algorithms to be used. See [Custom Hash Algorithms](#tls-parameters-common-params-tls-certificates-custom-hash-algorithms) below.
+`custom_hash_algorithms` - (Optional) Hash Algorithms. Specifies the hash algorithms to be used (`Block`).
 
 `description` - (Optional) Configuration for description (`String`).
 
-`disable_ocsp_stapling` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable OCSP Stapling](#tls-parameters-common-params-tls-certificates-disable-ocsp-stapling) below.
+`disable_ocsp_stapling` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`private_key` - (Optional) Secret. SecretType is used in an object to indicate a sensitive/confidential field. See [Private Key](#tls-parameters-common-params-tls-certificates-private-key) below.
+`private_key` - (Optional) Secret. SecretType is used in an object to indicate a sensitive/confidential field (`Block`).
 
-`use_system_defaults` - (Optional) Empty. This can be used for messages where no values are needed. See [Use System Defaults](#tls-parameters-common-params-tls-certificates-use-system-defaults) below.
-
-<a id="tls-parameters-common-params-tls-certificates-custom-hash-algorithms"></a>
-
-### TLS Parameters Common Params TLS Certificates Custom Hash Algorithms
-
-<a id="tls-parameters-common-params-tls-certificates-disable-ocsp-stapling"></a>
-
-### TLS Parameters Common Params TLS Certificates Disable OCSP Stapling
-
-<a id="tls-parameters-common-params-tls-certificates-private-key"></a>
-
-### TLS Parameters Common Params TLS Certificates Private Key
-
-<a id="tls-parameters-common-params-tls-certificates-use-system-defaults"></a>
-
-### TLS Parameters Common Params TLS Certificates Use System Defaults
+`use_system_defaults` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="tls-parameters-common-params-validation-params"></a>
 
@@ -374,47 +314,19 @@ In addition to all arguments above, the following attributes are exported:
 
 `skip_hostname_verification` - (Optional) Skip verification of hostname. When True, skip verification of hostname i.e. CN/Subject Alt Name of certificate is not matched to the connecting hostname (`Bool`).
 
-`trusted_ca` - (Optional) Root CA Certificate Reference. Reference to Root CA Certificate. See [Trusted CA](#tls-parameters-common-params-validation-params-trusted-ca) below.
+`trusted_ca` - (Optional) Root CA Certificate Reference. Reference to Root CA Certificate (`Block`).
 
 `trusted_ca_url` - (Optional) Inline Root CA Certificate (legacy). Inline Root CA Certificate (`String`).
 
 `verify_subject_alt_names` - (Optional) List of SANs for matching. List of acceptable Subject Alt Names/CN in the peer's certificate. When skip_hostname_verification is false and verify_subject_alt_names is empty, the hostname of the peer will be used for matching against SAN/CN of peer's certificate (`List`).
 
-<a id="tls-parameters-common-params-validation-params-trusted-ca"></a>
-
-### TLS Parameters Common Params Validation Params Trusted CA
-
-<a id="tls-parameters-default-session-key-caching"></a>
-
-### TLS Parameters Default Session Key Caching
-
-<a id="tls-parameters-disable-session-key-caching"></a>
-
-### TLS Parameters Disable Session Key Caching
-
-<a id="tls-parameters-disable-sni"></a>
-
-### TLS Parameters Disable Sni
-
-<a id="tls-parameters-use-host-header-as-sni"></a>
-
-### TLS Parameters Use Host Header As Sni
-
 <a id="upstream-conn-pool-reuse-type"></a>
 
 ### Upstream Conn Pool Reuse Type
 
-`disable_conn_pool_reuse` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Conn Pool Reuse](#upstream-conn-pool-reuse-type-disable-conn-pool-reuse) below.
+`disable_conn_pool_reuse` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`enable_conn_pool_reuse` - (Optional) Empty. This can be used for messages where no values are needed. See [Enable Conn Pool Reuse](#upstream-conn-pool-reuse-type-enable-conn-pool-reuse) below.
-
-<a id="upstream-conn-pool-reuse-type-disable-conn-pool-reuse"></a>
-
-### Upstream Conn Pool Reuse Type Disable Conn Pool Reuse
-
-<a id="upstream-conn-pool-reuse-type-enable-conn-pool-reuse"></a>
-
-### Upstream Conn Pool Reuse Type Enable Conn Pool Reuse
+`enable_conn_pool_reuse` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 ## Import
 

--- a/docs/resources/code_base_integration.md
+++ b/docs/resources/code_base_integration.md
@@ -102,17 +102,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Code Base Integration Azure Repos Access Token
 
-`blindfold_secret_info` - (Optional) Blindfold Secret. BlindfoldSecretInfoType specifies information about the Secret managed by F5XC Secret Management. See [Blindfold Secret Info](#code-base-integration-azure-repos-access-token-blindfold-secret-info) below.
+`blindfold_secret_info` - (Optional) Blindfold Secret. BlindfoldSecretInfoType specifies information about the Secret managed by F5XC Secret Management (`Block`).
 
-`clear_secret_info` - (Optional) In-Clear Secret. ClearSecretInfoType specifies information about the Secret that is not encrypted. See [Clear Secret Info](#code-base-integration-azure-repos-access-token-clear-secret-info) below.
-
-<a id="code-base-integration-azure-repos-access-token-blindfold-secret-info"></a>
-
-### Code Base Integration Azure Repos Access Token Blindfold Secret Info
-
-<a id="code-base-integration-azure-repos-access-token-clear-secret-info"></a>
-
-### Code Base Integration Azure Repos Access Token Clear Secret Info
+`clear_secret_info` - (Optional) In-Clear Secret. ClearSecretInfoType specifies information about the Secret that is not encrypted (`Block`).
 
 <a id="code-base-integration-bitbucket"></a>
 
@@ -126,17 +118,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Code Base Integration Bitbucket Passwd
 
-`blindfold_secret_info` - (Optional) Blindfold Secret. BlindfoldSecretInfoType specifies information about the Secret managed by F5XC Secret Management. See [Blindfold Secret Info](#code-base-integration-bitbucket-passwd-blindfold-secret-info) below.
+`blindfold_secret_info` - (Optional) Blindfold Secret. BlindfoldSecretInfoType specifies information about the Secret managed by F5XC Secret Management (`Block`).
 
-`clear_secret_info` - (Optional) In-Clear Secret. ClearSecretInfoType specifies information about the Secret that is not encrypted. See [Clear Secret Info](#code-base-integration-bitbucket-passwd-clear-secret-info) below.
-
-<a id="code-base-integration-bitbucket-passwd-blindfold-secret-info"></a>
-
-### Code Base Integration Bitbucket Passwd Blindfold Secret Info
-
-<a id="code-base-integration-bitbucket-passwd-clear-secret-info"></a>
-
-### Code Base Integration Bitbucket Passwd Clear Secret Info
+`clear_secret_info` - (Optional) In-Clear Secret. ClearSecretInfoType specifies information about the Secret that is not encrypted (`Block`).
 
 <a id="code-base-integration-bitbucket-server"></a>
 
@@ -154,17 +138,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Code Base Integration Bitbucket Server Passwd
 
-`blindfold_secret_info` - (Optional) Blindfold Secret. BlindfoldSecretInfoType specifies information about the Secret managed by F5XC Secret Management. See [Blindfold Secret Info](#code-base-integration-bitbucket-server-passwd-blindfold-secret-info) below.
+`blindfold_secret_info` - (Optional) Blindfold Secret. BlindfoldSecretInfoType specifies information about the Secret managed by F5XC Secret Management (`Block`).
 
-`clear_secret_info` - (Optional) In-Clear Secret. ClearSecretInfoType specifies information about the Secret that is not encrypted. See [Clear Secret Info](#code-base-integration-bitbucket-server-passwd-clear-secret-info) below.
-
-<a id="code-base-integration-bitbucket-server-passwd-blindfold-secret-info"></a>
-
-### Code Base Integration Bitbucket Server Passwd Blindfold Secret Info
-
-<a id="code-base-integration-bitbucket-server-passwd-clear-secret-info"></a>
-
-### Code Base Integration Bitbucket Server Passwd Clear Secret Info
+`clear_secret_info` - (Optional) In-Clear Secret. ClearSecretInfoType specifies information about the Secret that is not encrypted (`Block`).
 
 <a id="code-base-integration-github"></a>
 
@@ -180,17 +156,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Code Base Integration Github Access Token
 
-`blindfold_secret_info` - (Optional) Blindfold Secret. BlindfoldSecretInfoType specifies information about the Secret managed by F5XC Secret Management. See [Blindfold Secret Info](#code-base-integration-github-access-token-blindfold-secret-info) below.
+`blindfold_secret_info` - (Optional) Blindfold Secret. BlindfoldSecretInfoType specifies information about the Secret managed by F5XC Secret Management (`Block`).
 
-`clear_secret_info` - (Optional) In-Clear Secret. ClearSecretInfoType specifies information about the Secret that is not encrypted. See [Clear Secret Info](#code-base-integration-github-access-token-clear-secret-info) below.
-
-<a id="code-base-integration-github-access-token-blindfold-secret-info"></a>
-
-### Code Base Integration Github Access Token Blindfold Secret Info
-
-<a id="code-base-integration-github-access-token-clear-secret-info"></a>
-
-### Code Base Integration Github Access Token Clear Secret Info
+`clear_secret_info` - (Optional) In-Clear Secret. ClearSecretInfoType specifies information about the Secret that is not encrypted (`Block`).
 
 <a id="code-base-integration-github-enterprise"></a>
 
@@ -206,17 +174,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Code Base Integration Github Enterprise Access Token
 
-`blindfold_secret_info` - (Optional) Blindfold Secret. BlindfoldSecretInfoType specifies information about the Secret managed by F5XC Secret Management. See [Blindfold Secret Info](#code-base-integration-github-enterprise-access-token-blindfold-secret-info) below.
+`blindfold_secret_info` - (Optional) Blindfold Secret. BlindfoldSecretInfoType specifies information about the Secret managed by F5XC Secret Management (`Block`).
 
-`clear_secret_info` - (Optional) In-Clear Secret. ClearSecretInfoType specifies information about the Secret that is not encrypted. See [Clear Secret Info](#code-base-integration-github-enterprise-access-token-clear-secret-info) below.
-
-<a id="code-base-integration-github-enterprise-access-token-blindfold-secret-info"></a>
-
-### Code Base Integration Github Enterprise Access Token Blindfold Secret Info
-
-<a id="code-base-integration-github-enterprise-access-token-clear-secret-info"></a>
-
-### Code Base Integration Github Enterprise Access Token Clear Secret Info
+`clear_secret_info` - (Optional) In-Clear Secret. ClearSecretInfoType specifies information about the Secret that is not encrypted (`Block`).
 
 <a id="code-base-integration-gitlab"></a>
 
@@ -228,17 +188,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Code Base Integration Gitlab Access Token
 
-`blindfold_secret_info` - (Optional) Blindfold Secret. BlindfoldSecretInfoType specifies information about the Secret managed by F5XC Secret Management. See [Blindfold Secret Info](#code-base-integration-gitlab-access-token-blindfold-secret-info) below.
+`blindfold_secret_info` - (Optional) Blindfold Secret. BlindfoldSecretInfoType specifies information about the Secret managed by F5XC Secret Management (`Block`).
 
-`clear_secret_info` - (Optional) In-Clear Secret. ClearSecretInfoType specifies information about the Secret that is not encrypted. See [Clear Secret Info](#code-base-integration-gitlab-access-token-clear-secret-info) below.
-
-<a id="code-base-integration-gitlab-access-token-blindfold-secret-info"></a>
-
-### Code Base Integration Gitlab Access Token Blindfold Secret Info
-
-<a id="code-base-integration-gitlab-access-token-clear-secret-info"></a>
-
-### Code Base Integration Gitlab Access Token Clear Secret Info
+`clear_secret_info` - (Optional) In-Clear Secret. ClearSecretInfoType specifies information about the Secret that is not encrypted (`Block`).
 
 <a id="code-base-integration-gitlab-enterprise"></a>
 
@@ -252,17 +204,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Code Base Integration Gitlab Enterprise Access Token
 
-`blindfold_secret_info` - (Optional) Blindfold Secret. BlindfoldSecretInfoType specifies information about the Secret managed by F5XC Secret Management. See [Blindfold Secret Info](#code-base-integration-gitlab-enterprise-access-token-blindfold-secret-info) below.
+`blindfold_secret_info` - (Optional) Blindfold Secret. BlindfoldSecretInfoType specifies information about the Secret managed by F5XC Secret Management (`Block`).
 
-`clear_secret_info` - (Optional) In-Clear Secret. ClearSecretInfoType specifies information about the Secret that is not encrypted. See [Clear Secret Info](#code-base-integration-gitlab-enterprise-access-token-clear-secret-info) below.
-
-<a id="code-base-integration-gitlab-enterprise-access-token-blindfold-secret-info"></a>
-
-### Code Base Integration Gitlab Enterprise Access Token Blindfold Secret Info
-
-<a id="code-base-integration-gitlab-enterprise-access-token-clear-secret-info"></a>
-
-### Code Base Integration Gitlab Enterprise Access Token Clear Secret Info
+`clear_secret_info` - (Optional) In-Clear Secret. ClearSecretInfoType specifies information about the Secret that is not encrypted (`Block`).
 
 <a id="timeouts"></a>
 

--- a/docs/resources/data_group.md
+++ b/docs/resources/data_group.md
@@ -84,31 +84,19 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Address Records
 
-`records` - (Optional) Address records. See [Records](#address-records-records) below.
-
-<a id="address-records-records"></a>
-
-### Address Records Records
+`records` - (Optional) Address records (`Block`).
 
 <a id="integer-records"></a>
 
 ### Integer Records
 
-`records` - (Optional) Integer records. See [Records](#integer-records-records) below.
-
-<a id="integer-records-records"></a>
-
-### Integer Records Records
+`records` - (Optional) Integer records (`Block`).
 
 <a id="string-records"></a>
 
 ### String Records
 
-`records` - (Optional) String records. See [Records](#string-records-records) below.
-
-<a id="string-records-records"></a>
-
-### String Records Records
+`records` - (Optional) String records (`Block`).
 
 <a id="timeouts"></a>
 

--- a/docs/resources/data_type.md
+++ b/docs/resources/data_type.md
@@ -118,29 +118,21 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Rules Key Value Pattern Key Pattern
 
-`exact_values` - (Optional) Exact Values. List of exact values to match. See [Exact Values](#rules-key-value-pattern-key-pattern-exact-values) below.
+`exact_values` - (Optional) Exact Values. List of exact values to match (`Block`).
 
 `regex_value` - (Optional) Regex Value. Search for values matching this regular expression (`String`).
 
 `substring_value` - (Optional) Substring Search. Search for values that include this substring (`String`).
-
-<a id="rules-key-value-pattern-key-pattern-exact-values"></a>
-
-### Rules Key Value Pattern Key Pattern Exact Values
 
 <a id="rules-key-value-pattern-value-pattern"></a>
 
 ### Rules Key Value Pattern Value Pattern
 
-`exact_values` - (Optional) Exact Values. List of exact values to match. See [Exact Values](#rules-key-value-pattern-value-pattern-exact-values) below.
+`exact_values` - (Optional) Exact Values. List of exact values to match (`Block`).
 
 `regex_value` - (Optional) Regex Value. Search for values matching this regular expression (`String`).
 
 `substring_value` - (Optional) Substring Search. Search for values that include this substring (`String`).
-
-<a id="rules-key-value-pattern-value-pattern-exact-values"></a>
-
-### Rules Key Value Pattern Value Pattern Exact Values
 
 <a id="rules-value-pattern"></a>
 

--- a/docs/resources/dc_cluster_group.md
+++ b/docs/resources/dc_cluster_group.md
@@ -90,17 +90,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Type
 
-`control_and_data_plane_mesh` - (Optional) Empty. This can be used for messages where no values are needed. See [Control And Data Plane Mesh](#type-control-and-data-plane-mesh) below.
+`control_and_data_plane_mesh` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`data_plane_mesh` - (Optional) Empty. This can be used for messages where no values are needed. See [Data Plane Mesh](#type-data-plane-mesh) below.
-
-<a id="type-control-and-data-plane-mesh"></a>
-
-### Type Control And Data Plane Mesh
-
-<a id="type-data-plane-mesh"></a>
-
-### Type Data Plane Mesh
+`data_plane_mesh` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 ## Import
 

--- a/docs/resources/discovery.md
+++ b/docs/resources/discovery.md
@@ -78,7 +78,7 @@ resource "f5xc_discovery" "example" {
 
 `cluster_id` - (Optional) Discovery cluster Identifier. Specify identifier for discovery cluster. This identifier can be specified in endpoint object to discover only from this discovery object (`String`).
 
-`no_cluster_id` - (Optional) Empty. This can be used for messages where no values are needed. See [No Cluster Id](#no-cluster-id) below for details.
+`no_cluster_id` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 > **Note:** One of the arguments from this list "discovery_consul, discovery_k8s" must be set.
 
@@ -120,39 +120,23 @@ In addition to all arguments above, the following attributes are exported:
 
 `api_server` - (Optional) API Server and Port. API server must be a fully qualified domain string and port specified as host:port pair (`String`).
 
-`tls_info` - (Optional) Client TLS Config. TLS config for client of discovery service. See [TLS Info](#discovery-consul-access-info-connection-info-tls-info) below.
-
-<a id="discovery-consul-access-info-connection-info-tls-info"></a>
-
-### Discovery Consul Access Info Connection Info TLS Info
+`tls_info` - (Optional) Client TLS Config. TLS config for client of discovery service (`Block`).
 
 <a id="discovery-consul-access-info-http-basic-auth-info"></a>
 
 ### Discovery Consul Access Info HTTP Basic Auth Info
 
-`passwd_url` - (Optional) Secret. SecretType is used in an object to indicate a sensitive/confidential field. See [Passwd URL](#discovery-consul-access-info-http-basic-auth-info-passwd-url) below.
+`passwd_url` - (Optional) Secret. SecretType is used in an object to indicate a sensitive/confidential field (`Block`).
 
 `user_name` - (Optional) User Name. username in consul (`String`).
-
-<a id="discovery-consul-access-info-http-basic-auth-info-passwd-url"></a>
-
-### Discovery Consul Access Info HTTP Basic Auth Info Passwd URL
 
 <a id="discovery-consul-publish-info"></a>
 
 ### Discovery Consul Publish Info
 
-`disable` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable](#discovery-consul-publish-info-disable) below.
+`disable` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`publish` - (Optional) Empty. This can be used for messages where no values are needed. See [Publish](#discovery-consul-publish-info-publish) below.
-
-<a id="discovery-consul-publish-info-disable"></a>
-
-### Discovery Consul Publish Info Disable
-
-<a id="discovery-consul-publish-info-publish"></a>
-
-### Discovery Consul Publish Info Publish
+`publish` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="discovery-k8s"></a>
 
@@ -160,7 +144,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `access_info` - (Optional) K8s API Server. K8S API server access. See [Access Info](#discovery-k8s-access-info) below.
 
-`default_all` - (Optional) Empty. This can be used for messages where no values are needed. See [Default All](#discovery-k8s-default-all) below.
+`default_all` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `namespace_mapping` - (Optional) K8S Namespace Mapping. Select the mapping between K8s namespaces from which services will be discovered and App Namespace to which the discovered services will be shared. See [Namespace Mapping](#discovery-k8s-namespace-mapping) below.
 
@@ -172,11 +156,11 @@ In addition to all arguments above, the following attributes are exported:
 
 `connection_info` - (Optional) REST API Config. Configuration details to access discovery service REST API. See [Connection Info](#discovery-k8s-access-info-connection-info) below.
 
-`isolated` - (Optional) Empty. This can be used for messages where no values are needed. See [Isolated](#discovery-k8s-access-info-isolated) below.
+`isolated` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `kubeconfig_url` - (Optional) Secret. SecretType is used in an object to indicate a sensitive/confidential field. See [Kubeconfig URL](#discovery-k8s-access-info-kubeconfig-url) below.
 
-`reachable` - (Optional) Empty. This can be used for messages where no values are needed. See [Reachable](#discovery-k8s-access-info-reachable) below.
+`reachable` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="discovery-k8s-access-info-connection-info"></a>
 
@@ -184,39 +168,15 @@ In addition to all arguments above, the following attributes are exported:
 
 `api_server` - (Optional) API Server and Port. API server must be a fully qualified domain string and port specified as host:port pair (`String`).
 
-`tls_info` - (Optional) Client TLS Config. TLS config for client of discovery service. See [TLS Info](#discovery-k8s-access-info-connection-info-tls-info) below.
-
-<a id="discovery-k8s-access-info-connection-info-tls-info"></a>
-
-### Discovery K8s Access Info Connection Info TLS Info
-
-<a id="discovery-k8s-access-info-isolated"></a>
-
-### Discovery K8s Access Info Isolated
+`tls_info` - (Optional) Client TLS Config. TLS config for client of discovery service (`Block`).
 
 <a id="discovery-k8s-access-info-kubeconfig-url"></a>
 
 ### Discovery K8s Access Info Kubeconfig URL
 
-`blindfold_secret_info` - (Optional) Blindfold Secret. BlindfoldSecretInfoType specifies information about the Secret managed by F5XC Secret Management. See [Blindfold Secret Info](#discovery-k8s-access-info-kubeconfig-url-blindfold-secret-info) below.
+`blindfold_secret_info` - (Optional) Blindfold Secret. BlindfoldSecretInfoType specifies information about the Secret managed by F5XC Secret Management (`Block`).
 
-`clear_secret_info` - (Optional) In-Clear Secret. ClearSecretInfoType specifies information about the Secret that is not encrypted. See [Clear Secret Info](#discovery-k8s-access-info-kubeconfig-url-clear-secret-info) below.
-
-<a id="discovery-k8s-access-info-kubeconfig-url-blindfold-secret-info"></a>
-
-### Discovery K8s Access Info Kubeconfig URL Blindfold Secret Info
-
-<a id="discovery-k8s-access-info-kubeconfig-url-clear-secret-info"></a>
-
-### Discovery K8s Access Info Kubeconfig URL Clear Secret Info
-
-<a id="discovery-k8s-access-info-reachable"></a>
-
-### Discovery K8s Access Info Reachable
-
-<a id="discovery-k8s-default-all"></a>
-
-### Discovery K8s Default All
+`clear_secret_info` - (Optional) In-Clear Secret. ClearSecretInfoType specifies information about the Secret that is not encrypted (`Block`).
 
 <a id="discovery-k8s-namespace-mapping"></a>
 
@@ -236,17 +196,13 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Discovery K8s Publish Info
 
-`disable` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable](#discovery-k8s-publish-info-disable) below.
+`disable` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `dns_delegation` - (Optional) K8SDelegationType. See [DNS Delegation](#discovery-k8s-publish-info-dns-delegation) below.
 
 `publish` - (Optional) K8SPublishType. See [Publish](#discovery-k8s-publish-info-publish) below.
 
-`publish_fqdns` - (Optional) Empty. This can be used for messages where no values are needed. See [Publish Fqdns](#discovery-k8s-publish-info-publish-fqdns) below.
-
-<a id="discovery-k8s-publish-info-disable"></a>
-
-### Discovery K8s Publish Info Disable
+`publish_fqdns` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="discovery-k8s-publish-info-dns-delegation"></a>
 
@@ -261,14 +217,6 @@ In addition to all arguments above, the following attributes are exported:
 ### Discovery K8s Publish Info Publish
 
 `namespace` - (Optional) Default Namespace. The namespace where the service/endpoints need to be created if it's not included in the domain. The external K8S administrator needs to ensure that the namespace exists (`String`).
-
-<a id="discovery-k8s-publish-info-publish-fqdns"></a>
-
-### Discovery K8s Publish Info Publish Fqdns
-
-<a id="no-cluster-id"></a>
-
-### No Cluster Id
 
 <a id="timeouts"></a>
 
@@ -296,21 +244,13 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Where Site
 
-`disable_internet_vip` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Internet VIP](#where-site-disable-internet-vip) below.
+`disable_internet_vip` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`enable_internet_vip` - (Optional) Empty. This can be used for messages where no values are needed. See [Enable Internet VIP](#where-site-enable-internet-vip) below.
+`enable_internet_vip` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `network_type` - (Optional) Virtual Network Type. Different types of virtual networks understood by the system Virtual-network of type VIRTUAL_NETWORK_SITE_LOCAL provides connectivity to public (outside) network. This is an insecure network and is connected to public internet via NAT Gateways/firwalls Virtual-network of this type is local to every site. Two virtual networks of this type on different sites are neither related nor connected. Constraints: There can be atmost one virtual network of this type in a given site... Possible values include `VIRTUAL_NETWORK_SITE_LOCAL`, `VIRTUAL_NETWORK_SITE_LOCAL_INSIDE`, `VIRTUAL_NETWORK_PER_SITE`, `VIRTUAL_NETWORK_PUBLIC`, `VIRTUAL_NETWORK_GLOBAL`, `VIRTUAL_NETWORK_SITE_SERVICE`, `VIRTUAL_NETWORK_VER_INTERNAL`, `VIRTUAL_NETWORK_SITE_LOCAL_INSIDE_OUTSIDE`, `VIRTUAL_NETWORK_IP_AUTO`, `VIRTUAL_NETWORK_VOLTADN_PRIVATE_NETWORK`, and others. Defaults to `VIRTUAL_NETWORK_SITE_LOCAL` (`String`).
 
 `ref` - (Optional) Reference. A site direct reference. See [Ref](#where-site-ref) below.
-
-<a id="where-site-disable-internet-vip"></a>
-
-### Where Site Disable Internet VIP
-
-<a id="where-site-enable-internet-vip"></a>
-
-### Where Site Enable Internet VIP
 
 <a id="where-site-ref"></a>
 
@@ -350,21 +290,13 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Where Virtual Site
 
-`disable_internet_vip` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Internet VIP](#where-virtual-site-disable-internet-vip) below.
+`disable_internet_vip` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`enable_internet_vip` - (Optional) Empty. This can be used for messages where no values are needed. See [Enable Internet VIP](#where-virtual-site-enable-internet-vip) below.
+`enable_internet_vip` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `network_type` - (Optional) Virtual Network Type. Different types of virtual networks understood by the system Virtual-network of type VIRTUAL_NETWORK_SITE_LOCAL provides connectivity to public (outside) network. This is an insecure network and is connected to public internet via NAT Gateways/firwalls Virtual-network of this type is local to every site. Two virtual networks of this type on different sites are neither related nor connected. Constraints: There can be atmost one virtual network of this type in a given site... Possible values include `VIRTUAL_NETWORK_SITE_LOCAL`, `VIRTUAL_NETWORK_SITE_LOCAL_INSIDE`, `VIRTUAL_NETWORK_PER_SITE`, `VIRTUAL_NETWORK_PUBLIC`, `VIRTUAL_NETWORK_GLOBAL`, `VIRTUAL_NETWORK_SITE_SERVICE`, `VIRTUAL_NETWORK_VER_INTERNAL`, `VIRTUAL_NETWORK_SITE_LOCAL_INSIDE_OUTSIDE`, `VIRTUAL_NETWORK_IP_AUTO`, `VIRTUAL_NETWORK_VOLTADN_PRIVATE_NETWORK`, and others. Defaults to `VIRTUAL_NETWORK_SITE_LOCAL` (`String`).
 
 `ref` - (Optional) Reference. A virtual_site direct reference. See [Ref](#where-virtual-site-ref) below.
-
-<a id="where-virtual-site-disable-internet-vip"></a>
-
-### Where Virtual Site Disable Internet VIP
-
-<a id="where-virtual-site-enable-internet-vip"></a>
-
-### Where Virtual Site Enable Internet VIP
 
 <a id="where-virtual-site-ref"></a>
 

--- a/docs/resources/dns_domain.md
+++ b/docs/resources/dns_domain.md
@@ -58,7 +58,7 @@ resource "f5xc_dns_domain" "example" {
 
 `timeouts` - (Optional) See [Timeouts](#timeouts) below for details.
 
-`volterra_managed` - (Optional) Empty. This can be used for messages where no values are needed. See [Volterra Managed](#volterra-managed) below for details.
+`volterra_managed` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 ### Attributes Reference
 
@@ -79,10 +79,6 @@ In addition to all arguments above, the following attributes are exported:
 `read` - (Optional) A string that can be [parsed as a duration](`HTTPS://pkg.go.dev/time#ParseDuration`) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Read operations occur during any refresh or planning operation when refresh is enabled (`String`).
 
 `update` - (Optional) A string that can be [parsed as a duration](`HTTPS://pkg.go.dev/time#ParseDuration`) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours) (`String`).
-
-<a id="volterra-managed"></a>
-
-### Volterra Managed
 
 ## Import
 

--- a/docs/resources/dns_lb_health_check.md
+++ b/docs/resources/dns_lb_health_check.md
@@ -68,7 +68,7 @@ resource "f5xc_dns_lb_health_check" "example" {
 
 `https_health_check` - (Optional) HTTP Health Check. See [HTTPS Health Check](#https-health-check) below for details.
 
-`icmp_health_check` - (Optional) Empty. This can be used for messages where no values are needed. See [ICMP Health Check](#icmp-health-check) below for details.
+`icmp_health_check` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `tcp_health_check` - (Optional) TCP Health Check. See [TCP Health Check](#tcp-health-check) below for details.
 
@@ -109,10 +109,6 @@ In addition to all arguments above, the following attributes are exported:
 `receive` - (Optional) Receive String. Regular expression used to match against the response to the health check's request. Mark node up upon receipt of a successful regular expression match. Uses re2 regular expression syntax (`String`).
 
 `send` - (Optional) Send String. HTTP payload to send to the target (`String`).
-
-<a id="icmp-health-check"></a>
-
-### ICMP Health Check
 
 <a id="tcp-health-check"></a>
 

--- a/docs/resources/dns_lb_pool.md
+++ b/docs/resources/dns_lb_pool.md
@@ -82,7 +82,7 @@ resource "f5xc_dns_lb_pool" "example" {
 
 `ttl` - (Optional) TTL. Custom TTL in seconds (default 30) for responses from this pool (`Number`).
 
-`use_rrset_ttl` - (Optional) Empty. This can be used for messages where no values are needed. See [Use Rrset TTL](#use-rrset-ttl) below for details.
+`use_rrset_ttl` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 ### Attributes Reference
 
@@ -96,17 +96,13 @@ In addition to all arguments above, the following attributes are exported:
 
 ### A Pool
 
-`disable_health_check` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Health Check](#a-pool-disable-health-check) below.
+`disable_health_check` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `health_check` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Health Check](#a-pool-health-check) below.
 
 `max_answers` - (Optional) Maximum Answers. Limit on number of Resource Records to be included in the response to query (`Number`).
 
 `members` - (Optional) Pool Members. See [Members](#a-pool-members) below.
-
-<a id="a-pool-disable-health-check"></a>
-
-### A Pool Disable Health Check
 
 <a id="a-pool-health-check"></a>
 
@@ -229,10 +225,6 @@ In addition to all arguments above, the following attributes are exported:
 `read` - (Optional) A string that can be [parsed as a duration](`HTTPS://pkg.go.dev/time#ParseDuration`) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Read operations occur during any refresh or planning operation when refresh is enabled (`String`).
 
 `update` - (Optional) A string that can be [parsed as a duration](`HTTPS://pkg.go.dev/time#ParseDuration`) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours) (`String`).
-
-<a id="use-rrset-ttl"></a>
-
-### Use Rrset TTL
 
 ## Import
 

--- a/docs/resources/dns_load_balancer.md
+++ b/docs/resources/dns_load_balancer.md
@@ -104,19 +104,11 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Response Cache
 
-`default_response_cache_parameters` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Response Cache Parameters](#response-cache-default-response-cache-parameters) below.
+`default_response_cache_parameters` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`disable` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable](#response-cache-disable) below.
+`disable` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `response_cache_parameters` - (Optional) Response Cache Parameters. See [Response Cache Parameters](#response-cache-response-cache-parameters) below.
-
-<a id="response-cache-default-response-cache-parameters"></a>
-
-### Response Cache Default Response Cache Parameters
-
-<a id="response-cache-disable"></a>
-
-### Response Cache Disable
 
 <a id="response-cache-response-cache-parameters"></a>
 
@@ -164,11 +156,7 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Rule List Rules Asn Matcher
 
-`asn_sets` - (Optional) BGP ASN Sets. A list of references to bgp_asn_set objects. See [Asn Sets](#rule-list-rules-asn-matcher-asn-sets) below.
-
-<a id="rule-list-rules-asn-matcher-asn-sets"></a>
-
-### Rule List Rules Asn Matcher Asn Sets
+`asn_sets` - (Optional) BGP ASN Sets. A list of references to bgp_asn_set objects (`Block`).
 
 <a id="rule-list-rules-geo-location-label-selector"></a>
 
@@ -200,11 +188,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `invert_matcher` - (Optional) Invert IP Matcher. Invert the match result (`Bool`).
 
-`prefix_sets` - (Optional) IP Prefix Sets. A list of references to ip_prefix_set objects. See [Prefix Sets](#rule-list-rules-ip-prefix-set-prefix-sets) below.
-
-<a id="rule-list-rules-ip-prefix-set-prefix-sets"></a>
-
-### Rule List Rules IP Prefix Set Prefix Sets
+`prefix_sets` - (Optional) IP Prefix Sets. A list of references to ip_prefix_set objects (`Block`).
 
 <a id="rule-list-rules-pool"></a>
 

--- a/docs/resources/dns_zone.md
+++ b/docs/resources/dns_zone.md
@@ -89,7 +89,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `default_rr_set_group` - (Optional) Add and manage DNS resource record sets part of Default set group. See [Default Rr Set Group](#primary-default-rr-set-group) below.
 
-`default_soa_parameters` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Soa Parameters](#primary-default-soa-parameters) below.
+`default_soa_parameters` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `dnssec_mode` - (Optional) Disable. See [Dnssec Mode](#primary-dnssec-mode) below.
 
@@ -169,11 +169,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `name` - (Optional) Record Name (Excluding Domain name). AFSDB Record name, please provide only the specific subdomain or record name without the base domain (`String`).
 
-`values` - (Optional) AFSDB Value. See [Values](#primary-default-rr-set-group-afsdb-record-values) below.
-
-<a id="primary-default-rr-set-group-afsdb-record-values"></a>
-
-### Primary Default Rr Set Group Afsdb Record Values
+`values` - (Optional) AFSDB Value (`Block`).
 
 <a id="primary-default-rr-set-group-alias-record"></a>
 
@@ -187,11 +183,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `name` - (Optional) Record Name (Excluding Domain name). CAA Record name, please provide only the specific subdomain or record name without the base domain (`String`).
 
-`values` - (Optional) CAA Record Value. See [Values](#primary-default-rr-set-group-caa-record-values) below.
-
-<a id="primary-default-rr-set-group-caa-record-values"></a>
-
-### Primary Default Rr Set Group Caa Record Values
+`values` - (Optional) CAA Record Value (`Block`).
 
 <a id="primary-default-rr-set-group-cds-record"></a>
 
@@ -199,11 +191,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `name` - (Optional) Record Name (Excluding Domain name). CDS Record name, please provide only the specific subdomain or record name without the base domain (`String`).
 
-`values` - (Optional) DS Value. See [Values](#primary-default-rr-set-group-cds-record-values) below.
-
-<a id="primary-default-rr-set-group-cds-record-values"></a>
-
-### Primary Default Rr Set Group Cds Record Values
+`values` - (Optional) DS Value (`Block`).
 
 <a id="primary-default-rr-set-group-cert-record"></a>
 
@@ -211,11 +199,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `name` - (Optional) Record Name (Excluding Domain name). CERT Record name, please provide only the specific subdomain or record name without the base domain (`String`).
 
-`values` - (Optional) CERT Value. See [Values](#primary-default-rr-set-group-cert-record-values) below.
-
-<a id="primary-default-rr-set-group-cert-record-values"></a>
-
-### Primary Default Rr Set Group Cert Record Values
+`values` - (Optional) CERT Value (`Block`).
 
 <a id="primary-default-rr-set-group-cname-record"></a>
 
@@ -231,11 +215,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `name` - (Optional) Record Name (Excluding Domain name). DS Record name, please provide only the specific subdomain or record name without the base domain (`String`).
 
-`values` - (Optional) DS Value. See [Values](#primary-default-rr-set-group-ds-record-values) below.
-
-<a id="primary-default-rr-set-group-ds-record-values"></a>
-
-### Primary Default Rr Set Group Ds Record Values
+`values` - (Optional) DS Value (`Block`).
 
 <a id="primary-default-rr-set-group-eui48-record"></a>
 
@@ -259,11 +239,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `name` - (Optional) Record Name (Excluding Domain name). Load Balancer record name (except for SRV DNS Load balancer record) should be a simple record name and not a subdomain of a subdomain (`String`).
 
-`value` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Value](#primary-default-rr-set-group-lb-record-value) below.
-
-<a id="primary-default-rr-set-group-lb-record-value"></a>
-
-### Primary Default Rr Set Group LB Record Value
+`value` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name (`Block`).
 
 <a id="primary-default-rr-set-group-loc-record"></a>
 
@@ -271,11 +247,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `name` - (Optional) Record Name (Excluding Domain name). LOC Record name, please provide only the specific subdomain or record name without the base domain (`String`).
 
-`values` - (Optional) LOC Value. See [Values](#primary-default-rr-set-group-loc-record-values) below.
-
-<a id="primary-default-rr-set-group-loc-record-values"></a>
-
-### Primary Default Rr Set Group Loc Record Values
+`values` - (Optional) LOC Value (`Block`).
 
 <a id="primary-default-rr-set-group-mx-record"></a>
 
@@ -283,11 +255,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `name` - (Optional) Record Name (Excluding Domain name). MX Record name, please provide only the specific subdomain or record name without the base domain (`String`).
 
-`values` - (Optional) MX Record Value. See [Values](#primary-default-rr-set-group-mx-record-values) below.
-
-<a id="primary-default-rr-set-group-mx-record-values"></a>
-
-### Primary Default Rr Set Group Mx Record Values
+`values` - (Optional) MX Record Value (`Block`).
 
 <a id="primary-default-rr-set-group-naptr-record"></a>
 
@@ -295,11 +263,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `name` - (Optional) Record Name (Excluding Domain name). NAPTR Record name, please provide only the specific subdomain or record name without the base domain (`String`).
 
-`values` - (Optional) NAPTR Value. See [Values](#primary-default-rr-set-group-naptr-record-values) below.
-
-<a id="primary-default-rr-set-group-naptr-record-values"></a>
-
-### Primary Default Rr Set Group Naptr Record Values
+`values` - (Optional) NAPTR Value (`Block`).
 
 <a id="primary-default-rr-set-group-ns-record"></a>
 
@@ -323,11 +287,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `name` - (Optional) Record Name (Excluding Domain name). SRV Record name, please provide only the specific subdomain or record name without the base domain (`String`).
 
-`values` - (Optional) SRV Value. See [Values](#primary-default-rr-set-group-srv-record-values) below.
-
-<a id="primary-default-rr-set-group-srv-record-values"></a>
-
-### Primary Default Rr Set Group Srv Record Values
+`values` - (Optional) SRV Value (`Block`).
 
 <a id="primary-default-rr-set-group-sshfp-record"></a>
 
@@ -335,11 +295,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `name` - (Optional) Record Name (Excluding Domain name). SSHFP Record name, please provide only the specific subdomain or record name without the base domain (`String`).
 
-`values` - (Optional) SSHFP Value. See [Values](#primary-default-rr-set-group-sshfp-record-values) below.
-
-<a id="primary-default-rr-set-group-sshfp-record-values"></a>
-
-### Primary Default Rr Set Group Sshfp Record Values
+`values` - (Optional) SSHFP Value (`Block`).
 
 <a id="primary-default-rr-set-group-tlsa-record"></a>
 
@@ -347,11 +303,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `name` - (Optional) Record Name (Excluding Domain name). TLSA Record name, please provide only the specific subdomain or record name without the base domain (`String`).
 
-`values` - (Optional) TLSA Value. See [Values](#primary-default-rr-set-group-tlsa-record-values) below.
-
-<a id="primary-default-rr-set-group-tlsa-record-values"></a>
-
-### Primary Default Rr Set Group Tlsa Record Values
+`values` - (Optional) TLSA Value (`Block`).
 
 <a id="primary-default-rr-set-group-txt-record"></a>
 
@@ -361,25 +313,13 @@ In addition to all arguments above, the following attributes are exported:
 
 `values` - (Optional) Text (`List`).
 
-<a id="primary-default-soa-parameters"></a>
-
-### Primary Default Soa Parameters
-
 <a id="primary-dnssec-mode"></a>
 
 ### Primary Dnssec Mode
 
-`disable` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable](#primary-dnssec-mode-disable) below.
+`disable` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`enable` - (Optional) Enable. DNSSEC enable. See [Enable](#primary-dnssec-mode-enable) below.
-
-<a id="primary-dnssec-mode-disable"></a>
-
-### Primary Dnssec Mode Disable
-
-<a id="primary-dnssec-mode-enable"></a>
-
-### Primary Dnssec Mode Enable
+`enable` - (Optional) Enable. DNSSEC enable (`Block`).
 
 <a id="primary-rr-set-group"></a>
 
@@ -401,135 +341,51 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Primary Rr Set Group Rr Set
 
-`a_record` - (Optional) DNSAResourceRecord. A Records. See [A Record](#primary-rr-set-group-rr-set-a-record) below.
+`a_record` - (Optional) DNSAResourceRecord. A Records (`Block`).
 
-`aaaa_record` - (Optional) DNSAAAAResourceRecord. RecordSet for AAAA Records. See [Aaaa Record](#primary-rr-set-group-rr-set-aaaa-record) below.
+`aaaa_record` - (Optional) DNSAAAAResourceRecord. RecordSet for AAAA Records (`Block`).
 
-`afsdb_record` - (Optional) DNS AFSDB Record. DNS AFSDB Record. See [Afsdb Record](#primary-rr-set-group-rr-set-afsdb-record) below.
+`afsdb_record` - (Optional) DNS AFSDB Record. DNS AFSDB Record (`Block`).
 
-`alias_record` - (Optional) DNSAliasResourceRecord. See [Alias Record](#primary-rr-set-group-rr-set-alias-record) below.
+`alias_record` - (Optional) DNSAliasResourceRecord (`Block`).
 
-`caa_record` - (Optional) DNSCAAResourceRecord. See [Caa Record](#primary-rr-set-group-rr-set-caa-record) below.
+`caa_record` - (Optional) DNSCAAResourceRecord (`Block`).
 
-`cds_record` - (Optional) DNS CDS Record. DNS CDS Record. See [Cds Record](#primary-rr-set-group-rr-set-cds-record) below.
+`cds_record` - (Optional) DNS CDS Record. DNS CDS Record (`Block`).
 
-`cert_record` - (Optional) DNS CERT Record. DNS CERT Record. See [Cert Record](#primary-rr-set-group-rr-set-cert-record) below.
+`cert_record` - (Optional) DNS CERT Record. DNS CERT Record (`Block`).
 
-`cname_record` - (Optional) DNSCNAMEResourceRecord. See [Cname Record](#primary-rr-set-group-rr-set-cname-record) below.
+`cname_record` - (Optional) DNSCNAMEResourceRecord (`Block`).
 
 `description` - (Optional) Comment (`String`).
 
-`ds_record` - (Optional) DNS DS Record. DNS DS Record. See [Ds Record](#primary-rr-set-group-rr-set-ds-record) below.
+`ds_record` - (Optional) DNS DS Record. DNS DS Record (`Block`).
 
-`eui48_record` - (Optional) DNS EUI48 Record. DNS EUI48 Record. See [Eui48 Record](#primary-rr-set-group-rr-set-eui48-record) below.
+`eui48_record` - (Optional) DNS EUI48 Record. DNS EUI48 Record (`Block`).
 
-`eui64_record` - (Optional) DNS EUI64 Record. DNS EUI64 Record. See [Eui64 Record](#primary-rr-set-group-rr-set-eui64-record) below.
+`eui64_record` - (Optional) DNS EUI64 Record. DNS EUI64 Record (`Block`).
 
-`lb_record` - (Optional) DNS Load Balancer Record. DNS Load Balancer Record. See [LB Record](#primary-rr-set-group-rr-set-lb-record) below.
+`lb_record` - (Optional) DNS Load Balancer Record. DNS Load Balancer Record (`Block`).
 
-`loc_record` - (Optional) DNS LOC Record. DNS LOC Record. See [Loc Record](#primary-rr-set-group-rr-set-loc-record) below.
+`loc_record` - (Optional) DNS LOC Record. DNS LOC Record (`Block`).
 
-`mx_record` - (Optional) DNSMXResourceRecord. See [Mx Record](#primary-rr-set-group-rr-set-mx-record) below.
+`mx_record` - (Optional) DNSMXResourceRecord (`Block`).
 
-`naptr_record` - (Optional) DNS NAPTR Record. DNS NAPTR Record. See [Naptr Record](#primary-rr-set-group-rr-set-naptr-record) below.
+`naptr_record` - (Optional) DNS NAPTR Record. DNS NAPTR Record (`Block`).
 
-`ns_record` - (Optional) DNSNSResourceRecord. See [Ns Record](#primary-rr-set-group-rr-set-ns-record) below.
+`ns_record` - (Optional) DNSNSResourceRecord (`Block`).
 
-`ptr_record` - (Optional) DNSPTRResourceRecord. See [Ptr Record](#primary-rr-set-group-rr-set-ptr-record) below.
+`ptr_record` - (Optional) DNSPTRResourceRecord (`Block`).
 
-`srv_record` - (Optional) DNSSRVResourceRecord. See [Srv Record](#primary-rr-set-group-rr-set-srv-record) below.
+`srv_record` - (Optional) DNSSRVResourceRecord (`Block`).
 
-`sshfp_record` - (Optional) DNS SSHFP Record. DNS SSHFP Record. See [Sshfp Record](#primary-rr-set-group-rr-set-sshfp-record) below.
+`sshfp_record` - (Optional) DNS SSHFP Record. DNS SSHFP Record (`Block`).
 
-`tlsa_record` - (Optional) DNS TLSA Record. DNS TLSA Record. See [Tlsa Record](#primary-rr-set-group-rr-set-tlsa-record) below.
+`tlsa_record` - (Optional) DNS TLSA Record. DNS TLSA Record (`Block`).
 
 `ttl` - (Optional) Time to live (`Number`).
 
-`txt_record` - (Optional) DNSTXTResourceRecord. See [Txt Record](#primary-rr-set-group-rr-set-txt-record) below.
-
-<a id="primary-rr-set-group-rr-set-a-record"></a>
-
-### Primary Rr Set Group Rr Set A Record
-
-<a id="primary-rr-set-group-rr-set-aaaa-record"></a>
-
-### Primary Rr Set Group Rr Set Aaaa Record
-
-<a id="primary-rr-set-group-rr-set-afsdb-record"></a>
-
-### Primary Rr Set Group Rr Set Afsdb Record
-
-<a id="primary-rr-set-group-rr-set-alias-record"></a>
-
-### Primary Rr Set Group Rr Set Alias Record
-
-<a id="primary-rr-set-group-rr-set-caa-record"></a>
-
-### Primary Rr Set Group Rr Set Caa Record
-
-<a id="primary-rr-set-group-rr-set-cds-record"></a>
-
-### Primary Rr Set Group Rr Set Cds Record
-
-<a id="primary-rr-set-group-rr-set-cert-record"></a>
-
-### Primary Rr Set Group Rr Set Cert Record
-
-<a id="primary-rr-set-group-rr-set-cname-record"></a>
-
-### Primary Rr Set Group Rr Set Cname Record
-
-<a id="primary-rr-set-group-rr-set-ds-record"></a>
-
-### Primary Rr Set Group Rr Set Ds Record
-
-<a id="primary-rr-set-group-rr-set-eui48-record"></a>
-
-### Primary Rr Set Group Rr Set Eui48 Record
-
-<a id="primary-rr-set-group-rr-set-eui64-record"></a>
-
-### Primary Rr Set Group Rr Set Eui64 Record
-
-<a id="primary-rr-set-group-rr-set-lb-record"></a>
-
-### Primary Rr Set Group Rr Set LB Record
-
-<a id="primary-rr-set-group-rr-set-loc-record"></a>
-
-### Primary Rr Set Group Rr Set Loc Record
-
-<a id="primary-rr-set-group-rr-set-mx-record"></a>
-
-### Primary Rr Set Group Rr Set Mx Record
-
-<a id="primary-rr-set-group-rr-set-naptr-record"></a>
-
-### Primary Rr Set Group Rr Set Naptr Record
-
-<a id="primary-rr-set-group-rr-set-ns-record"></a>
-
-### Primary Rr Set Group Rr Set Ns Record
-
-<a id="primary-rr-set-group-rr-set-ptr-record"></a>
-
-### Primary Rr Set Group Rr Set Ptr Record
-
-<a id="primary-rr-set-group-rr-set-srv-record"></a>
-
-### Primary Rr Set Group Rr Set Srv Record
-
-<a id="primary-rr-set-group-rr-set-sshfp-record"></a>
-
-### Primary Rr Set Group Rr Set Sshfp Record
-
-<a id="primary-rr-set-group-rr-set-tlsa-record"></a>
-
-### Primary Rr Set Group Rr Set Tlsa Record
-
-<a id="primary-rr-set-group-rr-set-txt-record"></a>
-
-### Primary Rr Set Group Rr Set Txt Record
+`txt_record` - (Optional) DNSTXTResourceRecord (`Block`).
 
 <a id="primary-soa-parameters"></a>
 

--- a/docs/resources/endpoint.md
+++ b/docs/resources/endpoint.md
@@ -120,13 +120,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Snat Pool
 
-`no_snat_pool` - (Optional) Empty. This can be used for messages where no values are needed. See [No Snat Pool](#snat-pool-no-snat-pool) below.
+`no_snat_pool` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `snat_pool` - (Optional) IPv4 Prefix List. x-example: '192.168.20.0/24' List of IPv4 prefixes that represent an endpoint. See [Snat Pool](#snat-pool-snat-pool) below.
-
-<a id="snat-pool-no-snat-pool"></a>
-
-### Snat Pool No Snat Pool
 
 <a id="snat-pool-snat-pool"></a>
 
@@ -160,21 +156,13 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Where Site
 
-`disable_internet_vip` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Internet VIP](#where-site-disable-internet-vip) below.
+`disable_internet_vip` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`enable_internet_vip` - (Optional) Empty. This can be used for messages where no values are needed. See [Enable Internet VIP](#where-site-enable-internet-vip) below.
+`enable_internet_vip` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `network_type` - (Optional) Virtual Network Type. Different types of virtual networks understood by the system Virtual-network of type VIRTUAL_NETWORK_SITE_LOCAL provides connectivity to public (outside) network. This is an insecure network and is connected to public internet via NAT Gateways/firwalls Virtual-network of this type is local to every site. Two virtual networks of this type on different sites are neither related nor connected. Constraints: There can be atmost one virtual network of this type in a given site... Possible values include `VIRTUAL_NETWORK_SITE_LOCAL`, `VIRTUAL_NETWORK_SITE_LOCAL_INSIDE`, `VIRTUAL_NETWORK_PER_SITE`, `VIRTUAL_NETWORK_PUBLIC`, `VIRTUAL_NETWORK_GLOBAL`, `VIRTUAL_NETWORK_SITE_SERVICE`, `VIRTUAL_NETWORK_VER_INTERNAL`, `VIRTUAL_NETWORK_SITE_LOCAL_INSIDE_OUTSIDE`, `VIRTUAL_NETWORK_IP_AUTO`, `VIRTUAL_NETWORK_VOLTADN_PRIVATE_NETWORK`, and others. Defaults to `VIRTUAL_NETWORK_SITE_LOCAL` (`String`).
 
 `ref` - (Optional) Reference. A site direct reference. See [Ref](#where-site-ref) below.
-
-<a id="where-site-disable-internet-vip"></a>
-
-### Where Site Disable Internet VIP
-
-<a id="where-site-enable-internet-vip"></a>
-
-### Where Site Enable Internet VIP
 
 <a id="where-site-ref"></a>
 
@@ -214,21 +202,13 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Where Virtual Site
 
-`disable_internet_vip` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Internet VIP](#where-virtual-site-disable-internet-vip) below.
+`disable_internet_vip` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`enable_internet_vip` - (Optional) Empty. This can be used for messages where no values are needed. See [Enable Internet VIP](#where-virtual-site-enable-internet-vip) below.
+`enable_internet_vip` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `network_type` - (Optional) Virtual Network Type. Different types of virtual networks understood by the system Virtual-network of type VIRTUAL_NETWORK_SITE_LOCAL provides connectivity to public (outside) network. This is an insecure network and is connected to public internet via NAT Gateways/firwalls Virtual-network of this type is local to every site. Two virtual networks of this type on different sites are neither related nor connected. Constraints: There can be atmost one virtual network of this type in a given site... Possible values include `VIRTUAL_NETWORK_SITE_LOCAL`, `VIRTUAL_NETWORK_SITE_LOCAL_INSIDE`, `VIRTUAL_NETWORK_PER_SITE`, `VIRTUAL_NETWORK_PUBLIC`, `VIRTUAL_NETWORK_GLOBAL`, `VIRTUAL_NETWORK_SITE_SERVICE`, `VIRTUAL_NETWORK_VER_INTERNAL`, `VIRTUAL_NETWORK_SITE_LOCAL_INSIDE_OUTSIDE`, `VIRTUAL_NETWORK_IP_AUTO`, `VIRTUAL_NETWORK_VOLTADN_PRIVATE_NETWORK`, and others. Defaults to `VIRTUAL_NETWORK_SITE_LOCAL` (`String`).
 
 `ref` - (Optional) Reference. A virtual_site direct reference. See [Ref](#where-virtual-site-ref) below.
-
-<a id="where-virtual-site-disable-internet-vip"></a>
-
-### Where Virtual Site Disable Internet VIP
-
-<a id="where-virtual-site-enable-internet-vip"></a>
-
-### Where Virtual Site Enable Internet VIP
 
 <a id="where-virtual-site-ref"></a>
 

--- a/docs/resources/enhanced_firewall_policy.md
+++ b/docs/resources/enhanced_firewall_policy.md
@@ -70,7 +70,7 @@ resource "f5xc_enhanced_firewall_policy" "example" {
 
 > **Note:** One of the arguments from this list "allow_all, allowed_destinations, allowed_sources, denied_destinations, denied_sources, deny_all, rule_list" must be set.
 
-`allow_all` - (Optional) Empty. This can be used for messages where no values are needed. See [Allow All](#allow-all) below for details.
+`allow_all` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `allowed_destinations` - (Optional) IP Prefix List. List of IP Address prefixes. Prefix must contain both prefix and prefix-length The list can contain mix of both IPv4 and IPv6 prefixes. See [Allowed Destinations](#allowed-destinations) below for details.
 
@@ -80,7 +80,7 @@ resource "f5xc_enhanced_firewall_policy" "example" {
 
 `denied_sources` - (Optional) IP Prefix List. List of IP Address prefixes. Prefix must contain both prefix and prefix-length The list can contain mix of both IPv4 and IPv6 prefixes. See [Denied Sources](#denied-sources) below for details.
 
-`deny_all` - (Optional) Empty. This can be used for messages where no values are needed. See [Deny All](#deny-all) below for details.
+`deny_all` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `rule_list` - (Optional) Custom Enhanced Firewall Policy Rules. Custom Enhanced Firewall Policy Rules. See [Rule List](#rule-list) below for details.
 
@@ -93,10 +93,6 @@ In addition to all arguments above, the following attributes are exported:
 `id` - (Optional) Unique identifier for the resource (`String`).
 
 ---
-
-<a id="allow-all"></a>
-
-### Allow All
 
 <a id="allowed-destinations"></a>
 
@@ -122,10 +118,6 @@ In addition to all arguments above, the following attributes are exported:
 
 `prefix` - (Optional) Prefix. IP Address prefix in string format. String must contain both prefix and prefix-length (`List`).
 
-<a id="deny-all"></a>
-
-### Deny All
-
 <a id="rule-list"></a>
 
 ### Rule List
@@ -138,25 +130,25 @@ In addition to all arguments above, the following attributes are exported:
 
 `advanced_action` - (Optional) Network Policy Rule Advanced Action. Network Policy Rule Advanced Action provides additional options along with RuleAction and PBRRuleAction. See [Advanced Action](#rule-list-rules-advanced-action) below.
 
-`all_destinations` - (Optional) Empty. This can be used for messages where no values are needed. See [All Destinations](#rule-list-rules-all-destinations) below.
+`all_destinations` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`all_sli_vips` - (Optional) Empty. This can be used for messages where no values are needed. See [All Sli Vips](#rule-list-rules-all-sli-vips) below.
+`all_sli_vips` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`all_slo_vips` - (Optional) Empty. This can be used for messages where no values are needed. See [All Slo Vips](#rule-list-rules-all-slo-vips) below.
+`all_slo_vips` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`all_sources` - (Optional) Empty. This can be used for messages where no values are needed. See [All Sources](#rule-list-rules-all-sources) below.
+`all_sources` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`all_tcp_traffic` - (Optional) Empty. This can be used for messages where no values are needed. See [All TCP Traffic](#rule-list-rules-all-tcp-traffic) below.
+`all_tcp_traffic` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`all_traffic` - (Optional) Empty. This can be used for messages where no values are needed. See [All Traffic](#rule-list-rules-all-traffic) below.
+`all_traffic` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`all_udp_traffic` - (Optional) Empty. This can be used for messages where no values are needed. See [All UDP Traffic](#rule-list-rules-all-udp-traffic) below.
+`all_udp_traffic` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`allow` - (Optional) Empty. This can be used for messages where no values are needed. See [Allow](#rule-list-rules-allow) below.
+`allow` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `applications` - (Optional) Applications. Application protocols like HTTP, SNMP. See [Applications](#rule-list-rules-applications) below.
 
-`deny` - (Optional) Empty. This can be used for messages where no values are needed. See [Deny](#rule-list-rules-deny) below.
+`deny` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `destination_aws_vpc_ids` - (Optional) AWS VPC List. List of VPC Identifiers in AWS. See [Destination AWS Vpc Ids](#rule-list-rules-destination-aws-vpc-ids) below.
 
@@ -168,17 +160,17 @@ In addition to all arguments above, the following attributes are exported:
 
 `insert_service` - (Optional) Policy Action to Forward Traffic to External Service. Action to forward traffic to external service. See [Insert Service](#rule-list-rules-insert-service) below.
 
-`inside_destinations` - (Optional) Empty. This can be used for messages where no values are needed. See [Inside Destinations](#rule-list-rules-inside-destinations) below.
+`inside_destinations` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`inside_sources` - (Optional) Empty. This can be used for messages where no values are needed. See [Inside Sources](#rule-list-rules-inside-sources) below.
+`inside_sources` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `label_matcher` - (Optional) Label Matcher. A label matcher specifies a list of label keys whose values need to match for source/client and destination/server. Note that the actual label values are not specified and do not matter. This allows an ability to scope grouping by the label key name. See [Label Matcher](#rule-list-rules-label-matcher) below.
 
 `metadata` - (Optional) Message Metadata. MessageMetaType is metadata (common attributes) of a message that only certain messages have. This information is propagated to the metadata of a child object that gets created from the containing message during view processing. The information in this type can be specified by user during create and replace APIs. See [Metadata](#rule-list-rules-metadata) below.
 
-`outside_destinations` - (Optional) Empty. This can be used for messages where no values are needed. See [Outside Destinations](#rule-list-rules-outside-destinations) below.
+`outside_destinations` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`outside_sources` - (Optional) Empty. This can be used for messages where no values are needed. See [Outside Sources](#rule-list-rules-outside-sources) below.
+`outside_sources` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `protocol_port_range` - (Optional) Protocol and Port. Protocol and Port ranges. See [Protocol Port Range](#rule-list-rules-protocol-port-range) below.
 
@@ -196,47 +188,11 @@ In addition to all arguments above, the following attributes are exported:
 
 `action` - (Optional) Log Action. Choice to choose logging or no logging This works together with option selected via NetworkPolicyRuleAction or any other action specified x-example: (No Selection in NetworkPolicyRuleAction + AdvancedAction as LOG) = LOG Only, (ALLOW/DENY in NetworkPolicyRuleAction + AdvancedAction as LOG) = Log and Allow/Deny, (ALLOW/DENY in NetworkPolicyRuleAction + NOLOG in AdvancedAction) = Allow/Deny with no log Don't sample the traffic hitting the rule Sample the traffic hitting the rule. Possible values are `NOLOG`, `LOG`. Defaults to `NOLOG` (`String`).
 
-<a id="rule-list-rules-all-destinations"></a>
-
-### Rule List Rules All Destinations
-
-<a id="rule-list-rules-all-sli-vips"></a>
-
-### Rule List Rules All Sli Vips
-
-<a id="rule-list-rules-all-slo-vips"></a>
-
-### Rule List Rules All Slo Vips
-
-<a id="rule-list-rules-all-sources"></a>
-
-### Rule List Rules All Sources
-
-<a id="rule-list-rules-all-tcp-traffic"></a>
-
-### Rule List Rules All TCP Traffic
-
-<a id="rule-list-rules-all-traffic"></a>
-
-### Rule List Rules All Traffic
-
-<a id="rule-list-rules-all-udp-traffic"></a>
-
-### Rule List Rules All UDP Traffic
-
-<a id="rule-list-rules-allow"></a>
-
-### Rule List Rules Allow
-
 <a id="rule-list-rules-applications"></a>
 
 ### Rule List Rules Applications
 
 `applications` - (Optional) Application Protocols. Application protocols like HTTP, SNMP (`List`).
-
-<a id="rule-list-rules-deny"></a>
-
-### Rule List Rules Deny
 
 <a id="rule-list-rules-destination-aws-vpc-ids"></a>
 
@@ -248,11 +204,7 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Rule List Rules Destination IP Prefix Set
 
-`ref` - (Optional) Reference. A list of references to ip_prefix_set objects. See [Ref](#rule-list-rules-destination-ip-prefix-set-ref) below.
-
-<a id="rule-list-rules-destination-ip-prefix-set-ref"></a>
-
-### Rule List Rules Destination IP Prefix Set Ref
+`ref` - (Optional) Reference. A list of references to ip_prefix_set objects (`Block`).
 
 <a id="rule-list-rules-destination-label-selector"></a>
 
@@ -270,19 +222,7 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Rule List Rules Insert Service
 
-`nfv_service` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Nfv Service](#rule-list-rules-insert-service-nfv-service) below.
-
-<a id="rule-list-rules-insert-service-nfv-service"></a>
-
-### Rule List Rules Insert Service Nfv Service
-
-<a id="rule-list-rules-inside-destinations"></a>
-
-### Rule List Rules Inside Destinations
-
-<a id="rule-list-rules-inside-sources"></a>
-
-### Rule List Rules Inside Sources
+`nfv_service` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name (`Block`).
 
 <a id="rule-list-rules-label-matcher"></a>
 
@@ -297,14 +237,6 @@ In addition to all arguments above, the following attributes are exported:
 `description` - (Optional) Description. Human readable description (`String`).
 
 `name` - (Optional) Name. This is the name of the message. The value of name has to follow DNS-1035 format (`String`).
-
-<a id="rule-list-rules-outside-destinations"></a>
-
-### Rule List Rules Outside Destinations
-
-<a id="rule-list-rules-outside-sources"></a>
-
-### Rule List Rules Outside Sources
 
 <a id="rule-list-rules-protocol-port-range"></a>
 
@@ -324,11 +256,7 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Rule List Rules Source IP Prefix Set
 
-`ref` - (Optional) Reference. A list of references to ip_prefix_set objects. See [Ref](#rule-list-rules-source-ip-prefix-set-ref) below.
-
-<a id="rule-list-rules-source-ip-prefix-set-ref"></a>
-
-### Rule List Rules Source IP Prefix Set Ref
+`ref` - (Optional) Reference. A list of references to ip_prefix_set objects (`Block`).
 
 <a id="rule-list-rules-source-label-selector"></a>
 

--- a/docs/resources/external_connector.md
+++ b/docs/resources/external_connector.md
@@ -98,7 +98,7 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Ipsec Ike Parameters
 
-`dpd_disabled` - (Optional) Empty. This can be used for messages where no values are needed. See [Dpd Disabled](#ipsec-ike-parameters-dpd-disabled) below.
+`dpd_disabled` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `dpd_keep_alive_timer` - (Optional) Keepalive Timer. See [Dpd Keep Alive Timer](#ipsec-ike-parameters-dpd-keep-alive-timer) below.
 
@@ -106,21 +106,17 @@ In addition to all arguments above, the following attributes are exported:
 
 `ike_phase2_profile` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Ike Phase2 Profile](#ipsec-ike-parameters-ike-phase2-profile) below.
 
-`initiator` - (Optional) Empty. This can be used for messages where no values are needed. See [Initiator](#ipsec-ike-parameters-initiator) below.
+`initiator` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`responder` - (Optional) Empty. This can be used for messages where no values are needed. See [Responder](#ipsec-ike-parameters-responder) below.
+`responder` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `rm_hostname` - (Optional) Hostname. Configure an hostname Remote IKE ID (`String`).
 
 `rm_ip_address` - (Optional) IP Address. IP Address used to specify an IPv4 or IPv6 address. See [Rm IP Address](#ipsec-ike-parameters-rm-ip-address) below.
 
-`use_default_local_ike_id` - (Optional) Empty. This can be used for messages where no values are needed. See [Use Default Local Ike Id](#ipsec-ike-parameters-use-default-local-ike-id) below.
+`use_default_local_ike_id` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`use_default_remote_ike_id` - (Optional) Empty. This can be used for messages where no values are needed. See [Use Default Remote Ike Id](#ipsec-ike-parameters-use-default-remote-ike-id) below.
-
-<a id="ipsec-ike-parameters-dpd-disabled"></a>
-
-### Ipsec Ike Parameters Dpd Disabled
+`use_default_remote_ike_id` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="ipsec-ike-parameters-dpd-keep-alive-timer"></a>
 
@@ -148,37 +144,13 @@ In addition to all arguments above, the following attributes are exported:
 
 `tenant` - (Optional) Tenant. When a configuration object(e.g. virtual_host) refers to another(e.g route) then tenant will hold the referred object's(e.g. route's) tenant (`String`).
 
-<a id="ipsec-ike-parameters-initiator"></a>
-
-### Ipsec Ike Parameters Initiator
-
-<a id="ipsec-ike-parameters-responder"></a>
-
-### Ipsec Ike Parameters Responder
-
 <a id="ipsec-ike-parameters-rm-ip-address"></a>
 
 ### Ipsec Ike Parameters Rm IP Address
 
-`ipv4` - (Optional) IPv4 Address. IPv4 Address in dot-decimal notation. See [IPv4](#ipsec-ike-parameters-rm-ip-address-ipv4) below.
+`ipv4` - (Optional) IPv4 Address. IPv4 Address in dot-decimal notation (`Block`).
 
-`ipv6` - (Optional) IPv6 Address. IPv6 Address specified as hexadecimal numbers separated by ':'. See [IPv6](#ipsec-ike-parameters-rm-ip-address-ipv6) below.
-
-<a id="ipsec-ike-parameters-rm-ip-address-ipv4"></a>
-
-### Ipsec Ike Parameters Rm IP Address IPv4
-
-<a id="ipsec-ike-parameters-rm-ip-address-ipv6"></a>
-
-### Ipsec Ike Parameters Rm IP Address IPv6
-
-<a id="ipsec-ike-parameters-use-default-local-ike-id"></a>
-
-### Ipsec Ike Parameters Use Default Local Ike Id
-
-<a id="ipsec-ike-parameters-use-default-remote-ike-id"></a>
-
-### Ipsec Ike Parameters Use Default Remote Ike Id
+`ipv6` - (Optional) IPv6 Address. IPv6 Address specified as hexadecimal numbers separated by ':' (`Block`).
 
 <a id="ipsec-ipsec-tunnel-parameters"></a>
 
@@ -190,9 +162,9 @@ In addition to all arguments above, the following attributes are exported:
 
 `segment` - (Optional) Segment Reference Type. Reference to Segment Object. See [Segment](#ipsec-ipsec-tunnel-parameters-segment) below.
 
-`site_local_inside_network` - (Optional) Empty. This can be used for messages where no values are needed. See [Site Local Inside Network](#ipsec-ipsec-tunnel-parameters-site-local-inside-network) below.
+`site_local_inside_network` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`site_local_network` - (Optional) Empty. This can be used for messages where no values are needed. See [Site Local Network](#ipsec-ipsec-tunnel-parameters-site-local-network) below.
+`site_local_network` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `tunnel_eps` - (Optional) Tunnel Endpoint. Configure tunnel parameters, local and remote IP addresses. See [Tunnel Eps](#ipsec-ipsec-tunnel-parameters-tunnel-eps) below.
 
@@ -208,19 +180,7 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Ipsec Ipsec Tunnel Parameters Segment
 
-`refs` - (Optional) Segment. Reference to Segment Object. See [Refs](#ipsec-ipsec-tunnel-parameters-segment-refs) below.
-
-<a id="ipsec-ipsec-tunnel-parameters-segment-refs"></a>
-
-### Ipsec Ipsec Tunnel Parameters Segment Refs
-
-<a id="ipsec-ipsec-tunnel-parameters-site-local-inside-network"></a>
-
-### Ipsec Ipsec Tunnel Parameters Site Local Inside Network
-
-<a id="ipsec-ipsec-tunnel-parameters-site-local-network"></a>
-
-### Ipsec Ipsec Tunnel Parameters Site Local Network
+`refs` - (Optional) Segment. Reference to Segment Object (`Block`).
 
 <a id="ipsec-ipsec-tunnel-parameters-tunnel-eps"></a>
 

--- a/docs/resources/fast_acl.md
+++ b/docs/resources/fast_acl.md
@@ -94,21 +94,13 @@ In addition to all arguments above, the following attributes are exported:
 
 ### RE ACL
 
-`all_public_vips` - (Optional) Empty. This can be used for messages where no values are needed. See [All Public Vips](#re-acl-all-public-vips) below.
+`all_public_vips` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`default_tenant_vip` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Tenant VIP](#re-acl-default-tenant-vip) below.
+`default_tenant_vip` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `fast_acl_rules` - (Optional) Rules. Fast ACL rules to match. See [Fast ACL Rules](#re-acl-fast-acl-rules) below.
 
 `selected_tenant_vip` - (Optional) Specific Tenant VIP. Select various tenant public VIP(s). See [Selected Tenant VIP](#re-acl-selected-tenant-vip) below.
-
-<a id="re-acl-all-public-vips"></a>
-
-### RE ACL All Public Vips
-
-<a id="re-acl-default-tenant-vip"></a>
-
-### RE ACL Default Tenant VIP
 
 <a id="re-acl-fast-acl-rules"></a>
 
@@ -128,29 +120,17 @@ In addition to all arguments above, the following attributes are exported:
 
 ### RE ACL Fast ACL Rules Action
 
-`policer_action` - (Optional) Policer Reference. Reference to policer object. See [Policer Action](#re-acl-fast-acl-rules-action-policer-action) below.
+`policer_action` - (Optional) Policer Reference. Reference to policer object (`Block`).
 
-`protocol_policer_action` - (Optional) Protocol Policer Reference. Reference to policer object. See [Protocol Policer Action](#re-acl-fast-acl-rules-action-protocol-policer-action) below.
+`protocol_policer_action` - (Optional) Protocol Policer Reference. Reference to policer object (`Block`).
 
 `simple_action` - (Optional) Simple Action. FastAclRuleSimpleAction specifies simple action like PASS or DENY Drop the traffic Forward the traffic. Possible values are `DENY`, `ALLOW`. Defaults to `DENY` (`String`).
-
-<a id="re-acl-fast-acl-rules-action-policer-action"></a>
-
-### RE ACL Fast ACL Rules Action Policer Action
-
-<a id="re-acl-fast-acl-rules-action-protocol-policer-action"></a>
-
-### RE ACL Fast ACL Rules Action Protocol Policer Action
 
 <a id="re-acl-fast-acl-rules-ip-prefix-set"></a>
 
 ### RE ACL Fast ACL Rules IP Prefix Set
 
-`ref` - (Optional) Reference. A list of references to ip_prefix_set objects. See [Ref](#re-acl-fast-acl-rules-ip-prefix-set-ref) below.
-
-<a id="re-acl-fast-acl-rules-ip-prefix-set-ref"></a>
-
-### RE ACL Fast ACL Rules IP Prefix Set Ref
+`ref` - (Optional) Reference. A list of references to ip_prefix_set objects (`Block`).
 
 <a id="re-acl-fast-acl-rules-metadata"></a>
 
@@ -164,19 +144,11 @@ In addition to all arguments above, the following attributes are exported:
 
 ### RE ACL Fast ACL Rules Port
 
-`all` - (Optional) Empty. This can be used for messages where no values are needed. See [All](#re-acl-fast-acl-rules-port-all) below.
+`all` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`dns` - (Optional) Empty. This can be used for messages where no values are needed. See [DNS](#re-acl-fast-acl-rules-port-dns) below.
+`dns` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `user_defined` - (Optional) Configuration for user_defined (`Number`).
-
-<a id="re-acl-fast-acl-rules-port-all"></a>
-
-### RE ACL Fast ACL Rules Port All
-
-<a id="re-acl-fast-acl-rules-port-dns"></a>
-
-### RE ACL Fast ACL Rules Port DNS
 
 <a id="re-acl-fast-acl-rules-prefix"></a>
 
@@ -206,21 +178,17 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Site ACL
 
-`all_services` - (Optional) Empty. This can be used for messages where no values are needed. See [All Services](#site-acl-all-services) below.
+`all_services` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `fast_acl_rules` - (Optional) Rules. Fast ACL rules to match. See [Fast ACL Rules](#site-acl-fast-acl-rules) below.
 
-`inside_network` - (Optional) Empty. This can be used for messages where no values are needed. See [Inside Network](#site-acl-inside-network) below.
+`inside_network` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`interface_services` - (Optional) Empty. This can be used for messages where no values are needed. See [Interface Services](#site-acl-interface-services) below.
+`interface_services` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`outside_network` - (Optional) Empty. This can be used for messages where no values are needed. See [Outside Network](#site-acl-outside-network) below.
+`outside_network` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`vip_services` - (Optional) Empty. This can be used for messages where no values are needed. See [VIP Services](#site-acl-vip-services) below.
-
-<a id="site-acl-all-services"></a>
-
-### Site ACL All Services
+`vip_services` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="site-acl-fast-acl-rules"></a>
 
@@ -240,29 +208,17 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Site ACL Fast ACL Rules Action
 
-`policer_action` - (Optional) Policer Reference. Reference to policer object. See [Policer Action](#site-acl-fast-acl-rules-action-policer-action) below.
+`policer_action` - (Optional) Policer Reference. Reference to policer object (`Block`).
 
-`protocol_policer_action` - (Optional) Protocol Policer Reference. Reference to policer object. See [Protocol Policer Action](#site-acl-fast-acl-rules-action-protocol-policer-action) below.
+`protocol_policer_action` - (Optional) Protocol Policer Reference. Reference to policer object (`Block`).
 
 `simple_action` - (Optional) Simple Action. FastAclRuleSimpleAction specifies simple action like PASS or DENY Drop the traffic Forward the traffic. Possible values are `DENY`, `ALLOW`. Defaults to `DENY` (`String`).
-
-<a id="site-acl-fast-acl-rules-action-policer-action"></a>
-
-### Site ACL Fast ACL Rules Action Policer Action
-
-<a id="site-acl-fast-acl-rules-action-protocol-policer-action"></a>
-
-### Site ACL Fast ACL Rules Action Protocol Policer Action
 
 <a id="site-acl-fast-acl-rules-ip-prefix-set"></a>
 
 ### Site ACL Fast ACL Rules IP Prefix Set
 
-`ref` - (Optional) Reference. A list of references to ip_prefix_set objects. See [Ref](#site-acl-fast-acl-rules-ip-prefix-set-ref) below.
-
-<a id="site-acl-fast-acl-rules-ip-prefix-set-ref"></a>
-
-### Site ACL Fast ACL Rules IP Prefix Set Ref
+`ref` - (Optional) Reference. A list of references to ip_prefix_set objects (`Block`).
 
 <a id="site-acl-fast-acl-rules-metadata"></a>
 
@@ -276,41 +232,17 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Site ACL Fast ACL Rules Port
 
-`all` - (Optional) Empty. This can be used for messages where no values are needed. See [All](#site-acl-fast-acl-rules-port-all) below.
+`all` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`dns` - (Optional) Empty. This can be used for messages where no values are needed. See [DNS](#site-acl-fast-acl-rules-port-dns) below.
+`dns` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `user_defined` - (Optional) Configuration for user_defined (`Number`).
-
-<a id="site-acl-fast-acl-rules-port-all"></a>
-
-### Site ACL Fast ACL Rules Port All
-
-<a id="site-acl-fast-acl-rules-port-dns"></a>
-
-### Site ACL Fast ACL Rules Port DNS
 
 <a id="site-acl-fast-acl-rules-prefix"></a>
 
 ### Site ACL Fast ACL Rules Prefix
 
 `prefix` - (Optional) Prefix. IP Address prefix in string format. String must contain both prefix and prefix-length (`List`).
-
-<a id="site-acl-inside-network"></a>
-
-### Site ACL Inside Network
-
-<a id="site-acl-interface-services"></a>
-
-### Site ACL Interface Services
-
-<a id="site-acl-outside-network"></a>
-
-### Site ACL Outside Network
-
-<a id="site-acl-vip-services"></a>
-
-### Site ACL VIP Services
 
 <a id="timeouts"></a>
 

--- a/docs/resources/fast_acl_rule.md
+++ b/docs/resources/fast_acl_rule.md
@@ -156,19 +156,11 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Port
 
-`all` - (Optional) Empty. This can be used for messages where no values are needed. See [All](#port-all) below.
+`all` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`dns` - (Optional) Empty. This can be used for messages where no values are needed. See [DNS](#port-dns) below.
+`dns` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `user_defined` - (Optional) Configuration for user_defined (`Number`).
-
-<a id="port-all"></a>
-
-### Port All
-
-<a id="port-dns"></a>
-
-### Port DNS
 
 <a id="prefix"></a>
 

--- a/docs/resources/fleet.md
+++ b/docs/resources/fleet.md
@@ -67,9 +67,9 @@ resource "f5xc_fleet" "example" {
 
 > **Note:** One of the arguments from this list "allow_all_usb, deny_all_usb, usb_policy" must be set.
 
-`allow_all_usb` - (Optional) Empty. This can be used for messages where no values are needed. See [Allow All Usb](#allow-all-usb) below for details.
+`allow_all_usb` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`deny_all_usb` - (Optional) Empty. This can be used for messages where no values are needed. See [Deny All Usb](#deny-all-usb) below for details.
+`deny_all_usb` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `usb_policy` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Usb Policy](#usb-policy) below for details.
 
@@ -79,7 +79,7 @@ resource "f5xc_fleet" "example" {
 
 `bond_device_list` - (Optional) Bond Devices List. List of bond devices for this fleet. See [Bond Device List](#bond-device-list) below for details.
 
-`no_bond_devices` - (Optional) Empty. This can be used for messages where no values are needed. See [No Bond Devices](#no-bond-devices) below for details.
+`no_bond_devices` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 > **Note:** One of the arguments from this list "dc_cluster_group, dc_cluster_group_inside, no_dc_cluster_group" must be set.
 
@@ -87,11 +87,11 @@ resource "f5xc_fleet" "example" {
 
 `dc_cluster_group_inside` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Dc Cluster Group Inside](#dc-cluster-group-inside) below for details.
 
-`no_dc_cluster_group` - (Optional) Empty. This can be used for messages where no values are needed. See [No Dc Cluster Group](#no-dc-cluster-group) below for details.
+`no_dc_cluster_group` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 > **Note:** One of the arguments from this list "default_config, device_list, interface_list" must be set.
 
-`default_config` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Config](#default-config) below for details.
+`default_config` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `device_list` - (Optional) List of Devices. Add device for all interfaces belonging to this fleet. See [Device List](#device-list) below for details.
 
@@ -99,29 +99,29 @@ resource "f5xc_fleet" "example" {
 
 > **Note:** One of the arguments from this list "default_sriov_interface, sriov_interfaces" must be set.
 
-`default_sriov_interface` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Sriov Interface](#default-sriov-interface) below for details.
+`default_sriov_interface` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `sriov_interfaces` - (Optional) Custom SR-IOV interfaces Configuration List. List of all custom SR-IOV interfaces configuration. See [Sriov Interfaces](#sriov-interfaces) below for details.
 
 > **Note:** One of the arguments from this list "default_storage_class, storage_class_list" must be set.
 
-`default_storage_class` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Storage Class](#default-storage-class) below for details.
+`default_storage_class` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `storage_class_list` - (Optional) Custom Storage Class List. Add additional custom storage classes in kubernetes for this fleet. See [Storage Class List](#storage-class-list) below for details.
 
 > **Note:** One of the arguments from this list "disable_gpu, enable_gpu, enable_vgpu" must be set.
 
-`disable_gpu` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable GPU](#disable-gpu) below for details.
+`disable_gpu` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`enable_gpu` - (Optional) Empty. This can be used for messages where no values are needed. See [Enable GPU](#enable-gpu) below for details.
+`enable_gpu` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `enable_vgpu` - (Optional) vGPU Configuration. Licensing configuration for NVIDIA vGPU. See [Enable Vgpu](#enable-vgpu) below for details.
 
 > **Note:** One of the arguments from this list "disable_vm, enable_vm" must be set.
 
-`disable_vm` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable VM](#disable-vm) below for details.
+`disable_vm` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`enable_vm` - (Optional) VM Configuration. VMs support configuration. See [Enable VM](#enable-vm) below for details.
+`enable_vm` - (Optional) VM Configuration. VMs support configuration (`Block`).
 
 `enable_default_fleet_config_download` - (Optional) Enable Default Fleet Config Download. Enable default fleet config, It must be set for storage config and GPU config (`Bool`).
 
@@ -135,7 +135,7 @@ resource "f5xc_fleet" "example" {
 
 `log_receiver` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Log Receiver](#log-receiver) below for details.
 
-`logs_streaming_disabled` - (Optional) Empty. This can be used for messages where no values are needed. See [Logs Streaming Disabled](#logs-streaming-disabled) below for details.
+`logs_streaming_disabled` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `network_connectors` - (Optional) Network Connectors. Network Connector defines connection between two virtual networks in a given site. Fleet defines one or more such network connectors. The network connectors configuration is applied on all sites that are member of the fleet. See [Network Connectors](#network-connectors) below for details.
 
@@ -143,19 +143,19 @@ resource "f5xc_fleet" "example" {
 
 > **Note:** One of the arguments from this list "no_storage_device, storage_device_list" must be set.
 
-`no_storage_device` - (Optional) Empty. This can be used for messages where no values are needed. See [No Storage Device](#no-storage-device) below for details.
+`no_storage_device` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `storage_device_list` - (Optional) Custom Storage Device List. Add additional custom storage classes in kubernetes for this fleet. See [Storage Device List](#storage-device-list) below for details.
 
 > **Note:** One of the arguments from this list "no_storage_interfaces, storage_interface_list" must be set.
 
-`no_storage_interfaces` - (Optional) Empty. This can be used for messages where no values are needed. See [No Storage Interfaces](#no-storage-interfaces) below for details.
+`no_storage_interfaces` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `storage_interface_list` - (Optional) List of Interfaces. Add all interfaces belonging to this fleet. See [Storage Interface List](#storage-interface-list) below for details.
 
 > **Note:** One of the arguments from this list "no_storage_static_routes, storage_static_routes" must be set.
 
-`no_storage_static_routes` - (Optional) Empty. This can be used for messages where no values are needed. See [No Storage Static Routes](#no-storage-static-routes) below for details.
+`no_storage_static_routes` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `storage_static_routes` - (Optional) Storage Static Routes List. List of storage static routes. See [Storage Static Routes](#storage-static-routes) below for details.
 
@@ -177,33 +177,17 @@ In addition to all arguments above, the following attributes are exported:
 
 ---
 
-<a id="allow-all-usb"></a>
-
-### Allow All Usb
-
 <a id="blocked-services"></a>
 
 ### Blocked Services
 
-`dns` - (Optional) Empty. This can be used for messages where no values are needed. See [DNS](#blocked-services-dns) below.
+`dns` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `network_type` - (Optional) Virtual Network Type. Different types of virtual networks understood by the system Virtual-network of type VIRTUAL_NETWORK_SITE_LOCAL provides connectivity to public (outside) network. This is an insecure network and is connected to public internet via NAT Gateways/firwalls Virtual-network of this type is local to every site. Two virtual networks of this type on different sites are neither related nor connected. Constraints: There can be atmost one virtual network of this type in a given site... Possible values include `VIRTUAL_NETWORK_SITE_LOCAL`, `VIRTUAL_NETWORK_SITE_LOCAL_INSIDE`, `VIRTUAL_NETWORK_PER_SITE`, `VIRTUAL_NETWORK_PUBLIC`, `VIRTUAL_NETWORK_GLOBAL`, `VIRTUAL_NETWORK_SITE_SERVICE`, `VIRTUAL_NETWORK_VER_INTERNAL`, `VIRTUAL_NETWORK_SITE_LOCAL_INSIDE_OUTSIDE`, `VIRTUAL_NETWORK_IP_AUTO`, `VIRTUAL_NETWORK_VOLTADN_PRIVATE_NETWORK`, and others. Defaults to `VIRTUAL_NETWORK_SITE_LOCAL` (`String`).
 
-`ssh` - (Optional) Empty. This can be used for messages where no values are needed. See [SSH](#blocked-services-ssh) below.
+`ssh` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`web_user_interface` - (Optional) Empty. This can be used for messages where no values are needed. See [Web User Interface](#blocked-services-web-user-interface) below.
-
-<a id="blocked-services-dns"></a>
-
-### Blocked Services DNS
-
-<a id="blocked-services-ssh"></a>
-
-### Blocked Services SSH
-
-<a id="blocked-services-web-user-interface"></a>
-
-### Blocked Services Web User Interface
+`web_user_interface` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="bond-device-list"></a>
 
@@ -215,7 +199,7 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Bond Device List Bond Devices
 
-`active_backup` - (Optional) Empty. This can be used for messages where no values are needed. See [Active Backup](#bond-device-list-bond-devices-active-backup) below.
+`active_backup` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `devices` - (Optional) Member Ethernet Devices. Ethernet devices that will make up this bond (`List`).
 
@@ -226,10 +210,6 @@ In addition to all arguments above, the following attributes are exported:
 `link_up_delay` - (Optional) Link Up Delay. Milliseconds wait before link is declared up (`Number`).
 
 `name` - (Optional) Bond Device Name. Name for the Bond. Ex 'bond0' (`String`).
-
-<a id="bond-device-list-bond-devices-active-backup"></a>
-
-### Bond Device List Bond Devices Active Backup
 
 <a id="bond-device-list-bond-devices-lacp"></a>
 
@@ -257,22 +237,6 @@ In addition to all arguments above, the following attributes are exported:
 
 `tenant` - (Optional) Tenant. When a configuration object(e.g. virtual_host) refers to another(e.g route) then tenant will hold the referred object's(e.g. route's) tenant (`String`).
 
-<a id="default-config"></a>
-
-### Default Config
-
-<a id="default-sriov-interface"></a>
-
-### Default Sriov Interface
-
-<a id="default-storage-class"></a>
-
-### Default Storage Class
-
-<a id="deny-all-usb"></a>
-
-### Deny All Usb
-
 <a id="device-list"></a>
 
 ### Device List
@@ -293,25 +257,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Device List Devices Network Device
 
-`interface` - (Optional) Network Interface. Network Interface attributes for the device. User network interface configuration for this network device. Attributes like labels, MTU from the 'interface' are applied to corresponding interface in VER node If network interface refers to a virtual-network, the virtual-netowrk type must be consistent with use attribute given below If use is NETWORK_INTERFACE_USE_REGULAR, the virtual-network must be of type VIRTUAL_NETWORK_SITE_LOCAL or VIRTUAL_NETWORK_SITE_LOCAL_INSIDE if us. See [Interface](#device-list-devices-network-device-interface) below.
+`interface` - (Optional) Network Interface. Network Interface attributes for the device. User network interface configuration for this network device. Attributes like labels, MTU from the 'interface' are applied to corresponding interface in VER node If network interface refers to a virtual-network, the virtual-netowrk type must be consistent with use attribute given below If use is NETWORK_INTERFACE_USE_REGULAR, the virtual-network must be of type VIRTUAL_NETWORK_SITE_LOCAL or VIRTUAL_NETWORK_SITE_LOCAL_INSIDE if us (`Block`).
 
 `use` - (Optional) Network Device Use. Defines how the device is used If networking device is owned by VER, it is available for users to configure as required If networking device is owned by VER, it is included in bootstrap config and member of outside network. If networking device is owned by VER, it is included in bootstrap config and member of inside network. Possible values are `NETWORK_INTERFACE_USE_REGULAR`, `NETWORK_INTERFACE_USE_OUTSIDE`, `NETWORK_INTERFACE_USE_INSIDE`. Defaults to `NETWORK_INTERFACE_USE_REGULAR` (`String`).
-
-<a id="device-list-devices-network-device-interface"></a>
-
-### Device List Devices Network Device Interface
-
-<a id="disable-gpu"></a>
-
-### Disable GPU
-
-<a id="disable-vm"></a>
-
-### Disable VM
-
-<a id="enable-gpu"></a>
-
-### Enable GPU
 
 <a id="enable-vgpu"></a>
 
@@ -322,10 +270,6 @@ In addition to all arguments above, the following attributes are exported:
 `server_address` - (Optional) License Server Address. Set License Server Address (`String`).
 
 `server_port` - (Optional) License Server Port Number. Set License Server port number (`Number`).
-
-<a id="enable-vm"></a>
-
-### Enable VM
 
 <a id="inside-virtual-network"></a>
 
@@ -361,33 +305,21 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Kubernetes Upgrade Drain
 
-`disable_upgrade_drain` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Upgrade Drain](#kubernetes-upgrade-drain-disable-upgrade-drain) below.
+`disable_upgrade_drain` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `enable_upgrade_drain` - (Optional) Enable Node by Node Upgrade. Specify batch upgrade settings for worker nodes within a site. See [Enable Upgrade Drain](#kubernetes-upgrade-drain-enable-upgrade-drain) below.
-
-<a id="kubernetes-upgrade-drain-disable-upgrade-drain"></a>
-
-### Kubernetes Upgrade Drain Disable Upgrade Drain
 
 <a id="kubernetes-upgrade-drain-enable-upgrade-drain"></a>
 
 ### Kubernetes Upgrade Drain Enable Upgrade Drain
 
-`disable_vega_upgrade_mode` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Vega Upgrade Mode](#kubernetes-upgrade-drain-enable-upgrade-drain-disable-vega-upgrade-mode) below.
+`disable_vega_upgrade_mode` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `drain_max_unavailable_node_count` - (Optional) Node Batch Size Count (`Number`).
 
 `drain_node_timeout` - (Optional) Upgrade Wait Time. Seconds to wait before initiating upgrade on the next set of nodes. Setting it to 0 will wait indefinitely for all services on nodes to be upgraded gracefully before proceeding to the next set of nodes. (Warning: It may block upgrade if services on a node cannot be gracefully upgraded. It is recommended to use the default value) (`Number`).
 
-`enable_vega_upgrade_mode` - (Optional) Empty. This can be used for messages where no values are needed. See [Enable Vega Upgrade Mode](#kubernetes-upgrade-drain-enable-upgrade-drain-enable-vega-upgrade-mode) below.
-
-<a id="kubernetes-upgrade-drain-enable-upgrade-drain-disable-vega-upgrade-mode"></a>
-
-### Kubernetes Upgrade Drain Enable Upgrade Drain Disable Vega Upgrade Mode
-
-<a id="kubernetes-upgrade-drain-enable-upgrade-drain-enable-vega-upgrade-mode"></a>
-
-### Kubernetes Upgrade Drain Enable Upgrade Drain Enable Vega Upgrade Mode
+`enable_vega_upgrade_mode` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="log-receiver"></a>
 
@@ -398,10 +330,6 @@ In addition to all arguments above, the following attributes are exported:
 `namespace` - (Optional) Namespace. When a configuration object(e.g. virtual_host) refers to another(e.g route) then namespace will hold the referred object's(e.g. route's) namespace (`String`).
 
 `tenant` - (Optional) Tenant. When a configuration object(e.g. virtual_host) refers to another(e.g route) then tenant will hold the referred object's(e.g. route's) tenant (`String`).
-
-<a id="logs-streaming-disabled"></a>
-
-### Logs Streaming Disabled
 
 <a id="network-connectors"></a>
 
@@ -431,26 +359,6 @@ In addition to all arguments above, the following attributes are exported:
 
 `uid` - (Optional) UID. When a configuration object(e.g. virtual_host) refers to another(e.g route) then uid will hold the referred object's(e.g. route's) uid (`String`).
 
-<a id="no-bond-devices"></a>
-
-### No Bond Devices
-
-<a id="no-dc-cluster-group"></a>
-
-### No Dc Cluster Group
-
-<a id="no-storage-device"></a>
-
-### No Storage Device
-
-<a id="no-storage-interfaces"></a>
-
-### No Storage Interfaces
-
-<a id="no-storage-static-routes"></a>
-
-### No Storage Static Routes
-
 <a id="outside-virtual-network"></a>
 
 ### Outside Virtual Network
@@ -471,27 +379,15 @@ In addition to all arguments above, the following attributes are exported:
 
 `perf_mode_l3_enhanced` - (Optional) L3 Mode Enhanced Performance. x-required L3 enhanced performance mode options. See [Perf Mode L3 Enhanced](#performance-enhancement-mode-perf-mode-l3-enhanced) below.
 
-`perf_mode_l7_enhanced` - (Optional) Empty. This can be used for messages where no values are needed. See [Perf Mode L7 Enhanced](#performance-enhancement-mode-perf-mode-l7-enhanced) below.
+`perf_mode_l7_enhanced` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="performance-enhancement-mode-perf-mode-l3-enhanced"></a>
 
 ### Performance Enhancement Mode Perf Mode L3 Enhanced
 
-`jumbo` - (Optional) Empty. This can be used for messages where no values are needed. See [Jumbo](#performance-enhancement-mode-perf-mode-l3-enhanced-jumbo) below.
+`jumbo` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_jumbo` - (Optional) Empty. This can be used for messages where no values are needed. See [No Jumbo](#performance-enhancement-mode-perf-mode-l3-enhanced-no-jumbo) below.
-
-<a id="performance-enhancement-mode-perf-mode-l3-enhanced-jumbo"></a>
-
-### Performance Enhancement Mode Perf Mode L3 Enhanced Jumbo
-
-<a id="performance-enhancement-mode-perf-mode-l3-enhanced-no-jumbo"></a>
-
-### Performance Enhancement Mode Perf Mode L3 Enhanced No Jumbo
-
-<a id="performance-enhancement-mode-perf-mode-l7-enhanced"></a>
-
-### Performance Enhancement Mode Perf Mode L7 Enhanced
+`no_jumbo` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="sriov-interfaces"></a>
 
@@ -519,7 +415,7 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Storage Class List Storage Classes
 
-`advanced_storage_parameters` - (Optional) Advanced Parameters. Map of parameter name and string value. See [Advanced Storage Parameters](#storage-class-list-storage-classes-advanced-storage-parameters) below.
+`advanced_storage_parameters` - (Optional) Advanced Parameters. Map of parameter name and string value (`Block`).
 
 `allow_volume_expansion` - (Optional) Allow Volume Expansion. Allow volume expansion (`Bool`).
 
@@ -540,10 +436,6 @@ In addition to all arguments above, the following attributes are exported:
 `storage_class_name` - (Optional) Storage Class Name. Name of the storage class as it will appear in K8s (`String`).
 
 `storage_device` - (Optional) Storage Device. Storage device that this class will use. The Device name defined at previous step (`String`).
-
-<a id="storage-class-list-storage-classes-advanced-storage-parameters"></a>
-
-### Storage Class List Storage Classes Advanced Storage Parameters
 
 <a id="storage-class-list-storage-classes-custom-storage"></a>
 
@@ -591,13 +483,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Storage Class List Storage Classes Netapp Trident
 
-`selector` - (Optional) Selector. Using the Selector field, each StorageClass calls out which virtual pool(s) may be used to host a volume. The volume will have the aspects defined in the chosen virtual pool. See [Selector](#storage-class-list-storage-classes-netapp-trident-selector) below.
+`selector` - (Optional) Selector. Using the Selector field, each StorageClass calls out which virtual pool(s) may be used to host a volume. The volume will have the aspects defined in the chosen virtual pool (`Block`).
 
 `storage_pools` - (Optional) Storage Pools. The storagePools parameter is used to further restrict the set of pools that match any specified attributes (`String`).
-
-<a id="storage-class-list-storage-classes-netapp-trident-selector"></a>
-
-### Storage Class List Storage Classes Netapp Trident Selector
 
 <a id="storage-class-list-storage-classes-pure-service-orchestrator"></a>
 
@@ -619,9 +507,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Storage Device List Storage Devices
 
-`advanced_advanced_parameters` - (Optional) Advanced Parameters. Map of parameter name and string value. See [Advanced Advanced Parameters](#storage-device-list-storage-devices-advanced-advanced-parameters) below.
+`advanced_advanced_parameters` - (Optional) Advanced Parameters. Map of parameter name and string value (`Block`).
 
-`custom_storage` - (Optional) Empty. This can be used for messages where no values are needed. See [Custom Storage](#storage-device-list-storage-devices-custom-storage) below.
+`custom_storage` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `hpe_storage` - (Optional) HPE Storage. Device configuration for HPE Storage. See [Hpe Storage](#storage-device-list-storage-devices-hpe-storage) below.
 
@@ -631,25 +519,17 @@ In addition to all arguments above, the following attributes are exported:
 
 `storage_device` - (Optional) Storage Device. Storage device and device unit (`String`).
 
-<a id="storage-device-list-storage-devices-advanced-advanced-parameters"></a>
-
-### Storage Device List Storage Devices Advanced Advanced Parameters
-
-<a id="storage-device-list-storage-devices-custom-storage"></a>
-
-### Storage Device List Storage Devices Custom Storage
-
 <a id="storage-device-list-storage-devices-hpe-storage"></a>
 
 ### Storage Device List Storage Devices Hpe Storage
 
 `api_server_port` - (Optional) Storage server Port. Enter Storage Server Port (`Number`).
 
-`iscsi_chap_password` - (Optional) Secret. SecretType is used in an object to indicate a sensitive/confidential field. See [iSCSI Chap Password](#storage-device-list-storage-devices-hpe-storage-iscsi-chap-password) below.
+`iscsi_chap_password` - (Optional) Secret. SecretType is used in an object to indicate a sensitive/confidential field (`Block`).
 
 `iscsi_chap_user` - (Optional) iSCSI chapUser. chap Username to connect to the HPE storage (`String`).
 
-`password` - (Optional) Secret. SecretType is used in an object to indicate a sensitive/confidential field. See [Password](#storage-device-list-storage-devices-hpe-storage-password) below.
+`password` - (Optional) Secret. SecretType is used in an object to indicate a sensitive/confidential field (`Block`).
 
 `storage_server_ip_address` - (Optional) Storage Server IP address. Enter storage server IP address (`String`).
 
@@ -657,45 +537,25 @@ In addition to all arguments above, the following attributes are exported:
 
 `username` - (Optional) Username. Username to connect to the HPE storage management IP (`String`).
 
-<a id="storage-device-list-storage-devices-hpe-storage-iscsi-chap-password"></a>
-
-### Storage Device List Storage Devices Hpe Storage iSCSI Chap Password
-
-<a id="storage-device-list-storage-devices-hpe-storage-password"></a>
-
-### Storage Device List Storage Devices Hpe Storage Password
-
 <a id="storage-device-list-storage-devices-netapp-trident"></a>
 
 ### Storage Device List Storage Devices Netapp Trident
 
-`netapp_backend_ontap_nas` - (Optional) Storage Backend NetApp ONTAP NAS. Configuration of storage backend for NetApp ONTAP NAS. See [Netapp Backend Ontap Nas](#storage-device-list-storage-devices-netapp-trident-netapp-backend-ontap-nas) below.
+`netapp_backend_ontap_nas` - (Optional) Storage Backend NetApp ONTAP NAS. Configuration of storage backend for NetApp ONTAP NAS (`Block`).
 
-`netapp_backend_ontap_san` - (Optional) Storage Backend NetApp ONTAP SAN. Configuration of storage backend for NetApp ONTAP SAN. See [Netapp Backend Ontap San](#storage-device-list-storage-devices-netapp-trident-netapp-backend-ontap-san) below.
-
-<a id="storage-device-list-storage-devices-netapp-trident-netapp-backend-ontap-nas"></a>
-
-### Storage Device List Storage Devices Netapp Trident Netapp Backend Ontap Nas
-
-<a id="storage-device-list-storage-devices-netapp-trident-netapp-backend-ontap-san"></a>
-
-### Storage Device List Storage Devices Netapp Trident Netapp Backend Ontap San
+`netapp_backend_ontap_san` - (Optional) Storage Backend NetApp ONTAP SAN. Configuration of storage backend for NetApp ONTAP SAN (`Block`).
 
 <a id="storage-device-list-storage-devices-pure-service-orchestrator"></a>
 
 ### Storage Device List Storage Devices Pure Service Orchestrator
 
-`arrays` - (Optional) Arrays Configuration. Device configuration for PSO Arrays. See [Arrays](#storage-device-list-storage-devices-pure-service-orchestrator-arrays) below.
+`arrays` - (Optional) Arrays Configuration. Device configuration for PSO Arrays (`Block`).
 
 `cluster_id` - (Optional) Cluster ID. clusterID is added as a prefix for all volumes created by this PSO installation. clusterID is also used to identify the volumes used by the datastore, pso-db. clusterID MUST BE UNIQUE for multiple K8s clusters running on top of the same storage arrays. characters allowed: alphanumeric and underscores (`String`).
 
 `enable_storage_topology` - (Optional) Enable Storage Topology. This option is to enable/disable the csi topology feature for pso-csi (`Bool`).
 
 `enable_strict_topology` - (Optional) Enable Strict Topology. This option is to enable/disable the strict csi topology feature for pso-csi (`Bool`).
-
-<a id="storage-device-list-storage-devices-pure-service-orchestrator-arrays"></a>
-
-### Storage Device List Storage Devices Pure Service Orchestrator Arrays
 
 <a id="storage-interface-list"></a>
 
@@ -725,49 +585,29 @@ In addition to all arguments above, the following attributes are exported:
 
 `attrs` - (Optional) Attributes. List of route attributes associated with the static route (`List`).
 
-`labels` - (Optional) Static Route Labels. Add Labels for this Static Route, these labels can be used in network policy. See [Labels](#storage-static-routes-storage-routes-labels) below.
+`labels` - (Optional) Static Route Labels. Add Labels for this Static Route, these labels can be used in network policy (`Block`).
 
 `nexthop` - (Optional) Nexthop. Identifies the next-hop for a route. See [Nexthop](#storage-static-routes-storage-routes-nexthop) below.
 
 `subnets` - (Optional) Subnets. List of route prefixes. See [Subnets](#storage-static-routes-storage-routes-subnets) below.
 
-<a id="storage-static-routes-storage-routes-labels"></a>
-
-### Storage Static Routes Storage Routes Labels
-
 <a id="storage-static-routes-storage-routes-nexthop"></a>
 
 ### Storage Static Routes Storage Routes Nexthop
 
-`interface` - (Optional) Network Interface. Nexthop is network interface when type is 'Network-Interface'. See [Interface](#storage-static-routes-storage-routes-nexthop-interface) below.
+`interface` - (Optional) Network Interface. Nexthop is network interface when type is 'Network-Interface' (`Block`).
 
-`nexthop_address` - (Optional) IP Address. IP Address used to specify an IPv4 or IPv6 address. See [Nexthop Address](#storage-static-routes-storage-routes-nexthop-nexthop-address) below.
+`nexthop_address` - (Optional) IP Address. IP Address used to specify an IPv4 or IPv6 address (`Block`).
 
 `type` - (Optional) Nexthop Types. Defines types of next-hop Use default gateway on the local interface as gateway for route. Assumes there is only one local interface on the virtual network. Use the specified address as nexthop Use the network interface as nexthop Discard nexthop, used when attr type is Advertise Used in VoltADN private virtual network. Possible values are `NEXT_HOP_DEFAULT_GATEWAY`, `NEXT_HOP_USE_CONFIGURED`, `NEXT_HOP_NETWORK_INTERFACE`. Defaults to `NEXT_HOP_DEFAULT_GATEWAY` (`String`).
-
-<a id="storage-static-routes-storage-routes-nexthop-interface"></a>
-
-### Storage Static Routes Storage Routes Nexthop Interface
-
-<a id="storage-static-routes-storage-routes-nexthop-nexthop-address"></a>
-
-### Storage Static Routes Storage Routes Nexthop Nexthop Address
 
 <a id="storage-static-routes-storage-routes-subnets"></a>
 
 ### Storage Static Routes Storage Routes Subnets
 
-`ipv4` - (Optional) IPv4 Subnet. IPv4 subnets specified as prefix and prefix-length. Prefix length must be <= 32. See [IPv4](#storage-static-routes-storage-routes-subnets-ipv4) below.
+`ipv4` - (Optional) IPv4 Subnet. IPv4 subnets specified as prefix and prefix-length. Prefix length must be <= 32 (`Block`).
 
-`ipv6` - (Optional) IPv6 Subnet. IPv6 subnets specified as prefix and prefix-length. prefix-legnth must be <= 128. See [IPv6](#storage-static-routes-storage-routes-subnets-ipv6) below.
-
-<a id="storage-static-routes-storage-routes-subnets-ipv4"></a>
-
-### Storage Static Routes Storage Routes Subnets IPv4
-
-<a id="storage-static-routes-storage-routes-subnets-ipv6"></a>
-
-### Storage Static Routes Storage Routes Subnets IPv6
+`ipv6` - (Optional) IPv6 Subnet. IPv6 subnets specified as prefix and prefix-length. prefix-legnth must be <= 128 (`Block`).
 
 <a id="timeouts"></a>
 

--- a/docs/resources/forward_proxy_policy.md
+++ b/docs/resources/forward_proxy_policy.md
@@ -72,7 +72,7 @@ resource "f5xc_forward_proxy_policy" "example" {
 
 > **Note:** One of the arguments from this list "allow_all, allow_list, deny_list, rule_list" must be set.
 
-`allow_all` - (Optional) Empty. This can be used for messages where no values are needed. See [Allow All](#allow-all) below for details.
+`allow_all` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `allow_list` - (Optional) Forward Proxy Rule. URL(s) and domains policy for forward proxy for a connection type (TLS or HTTP). See [Allow List](#allow-list) below for details.
 
@@ -82,9 +82,9 @@ resource "f5xc_forward_proxy_policy" "example" {
 
 > **Note:** One of the arguments from this list "any_proxy, drp_http_connect, network_connector, proxy_label_selector" must be set.
 
-`any_proxy` - (Optional) Empty. This can be used for messages where no values are needed. See [Any Proxy](#any-proxy) below for details.
+`any_proxy` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`drp_http_connect` - (Optional) Empty. This can be used for messages where no values are needed. See [Drp HTTP Connect](#drp-http-connect) below for details.
+`drp_http_connect` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `network_connector` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Network Connector](#network-connector) below for details.
 
@@ -100,37 +100,21 @@ In addition to all arguments above, the following attributes are exported:
 
 ---
 
-<a id="allow-all"></a>
-
-### Allow All
-
 <a id="allow-list"></a>
 
 ### Allow List
 
-`default_action_allow` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Action Allow](#allow-list-default-action-allow) below.
+`default_action_allow` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`default_action_deny` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Action Deny](#allow-list-default-action-deny) below.
+`default_action_deny` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`default_action_next_policy` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Action Next Policy](#allow-list-default-action-next-policy) below.
+`default_action_next_policy` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `dest_list` - (Optional) L4 Destination List. L4 destinations for non-HTTP and non-TLS connections and TLS connections without SNI. See [Dest List](#allow-list-dest-list) below.
 
 `http_list` - (Optional) HTTP URLs. URLs for HTTP connections. See [HTTP List](#allow-list-http-list) below.
 
 `tls_list` - (Optional) TLS Domains. Domains in SNI for TLS connections. See [TLS List](#allow-list-tls-list) below.
-
-<a id="allow-list-default-action-allow"></a>
-
-### Allow List Default Action Allow
-
-<a id="allow-list-default-action-deny"></a>
-
-### Allow List Default Action Deny
-
-<a id="allow-list-default-action-next-policy"></a>
-
-### Allow List Default Action Next Policy
 
 <a id="allow-list-dest-list"></a>
 
@@ -146,7 +130,7 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Allow List HTTP List
 
-`any_path` - (Optional) Empty. This can be used for messages where no values are needed. See [Any Path](#allow-list-http-list-any-path) below.
+`any_path` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `exact_value` - (Optional) Exact Values. Exact domain name (`String`).
 
@@ -160,10 +144,6 @@ In addition to all arguments above, the following attributes are exported:
 
 `suffix_value` - (Optional) Suffix Values. Suffix of domain names e.g 'xyz.com' will match '*.xyz.com' (`String`).
 
-<a id="allow-list-http-list-any-path"></a>
-
-### Allow List HTTP List Any Path
-
 <a id="allow-list-tls-list"></a>
 
 ### Allow List TLS List
@@ -174,37 +154,21 @@ In addition to all arguments above, the following attributes are exported:
 
 `suffix_value` - (Optional) Suffix Value. Suffix of domain name e.g 'xyz.com' will match '*.xyz.com' and 'xyz.com' (`String`).
 
-<a id="any-proxy"></a>
-
-### Any Proxy
-
 <a id="deny-list"></a>
 
 ### Deny List
 
-`default_action_allow` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Action Allow](#deny-list-default-action-allow) below.
+`default_action_allow` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`default_action_deny` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Action Deny](#deny-list-default-action-deny) below.
+`default_action_deny` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`default_action_next_policy` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Action Next Policy](#deny-list-default-action-next-policy) below.
+`default_action_next_policy` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `dest_list` - (Optional) L4 Destination List. L4 destinations for non-HTTP and non-TLS connections and TLS connections without SNI. See [Dest List](#deny-list-dest-list) below.
 
 `http_list` - (Optional) HTTP URLs. URLs for HTTP connections. See [HTTP List](#deny-list-http-list) below.
 
 `tls_list` - (Optional) TLS Domains. Domains in SNI for TLS connections. See [TLS List](#deny-list-tls-list) below.
-
-<a id="deny-list-default-action-allow"></a>
-
-### Deny List Default Action Allow
-
-<a id="deny-list-default-action-deny"></a>
-
-### Deny List Default Action Deny
-
-<a id="deny-list-default-action-next-policy"></a>
-
-### Deny List Default Action Next Policy
 
 <a id="deny-list-dest-list"></a>
 
@@ -220,7 +184,7 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Deny List HTTP List
 
-`any_path` - (Optional) Empty. This can be used for messages where no values are needed. See [Any Path](#deny-list-http-list-any-path) below.
+`any_path` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `exact_value` - (Optional) Exact Values. Exact domain name (`String`).
 
@@ -234,10 +198,6 @@ In addition to all arguments above, the following attributes are exported:
 
 `suffix_value` - (Optional) Suffix Values. Suffix of domain names e.g 'xyz.com' will match '*.xyz.com' (`String`).
 
-<a id="deny-list-http-list-any-path"></a>
-
-### Deny List HTTP List Any Path
-
 <a id="deny-list-tls-list"></a>
 
 ### Deny List TLS List
@@ -247,10 +207,6 @@ In addition to all arguments above, the following attributes are exported:
 `regex_value` - (Optional) Regex Values of Domains. Regular Expression value for the domain name (`String`).
 
 `suffix_value` - (Optional) Suffix Value. Suffix of domain name e.g 'xyz.com' will match '*.xyz.com' and 'xyz.com' (`String`).
-
-<a id="drp-http-connect"></a>
-
-### Drp HTTP Connect
 
 <a id="network-connector"></a>
 
@@ -280,9 +236,9 @@ In addition to all arguments above, the following attributes are exported:
 
 `action` - (Optional) Rule Action. The rule action determines the disposition of the input request API. If a policy matches a rule with an ALLOW action, the processing of the request proceeds forward. If it matches a rule with a DENY action, the processing of the request is terminated and an appropriate message/code returned to the originator. If it matches a rule with a NEXT_POLICY_SET action, evaluation of the current policy set terminates and evaluation of the next policy set in the chain begins. - DENY: DENY D... Possible values are `DENY`, `ALLOW`, `NEXT_POLICY`. Defaults to `DENY` (`String`).
 
-`all_destinations` - (Optional) Empty. This can be used for messages where no values are needed. See [All Destinations](#rule-list-rules-all-destinations) below.
+`all_destinations` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`all_sources` - (Optional) Empty. This can be used for messages where no values are needed. See [All Sources](#rule-list-rules-all-sources) below.
+`all_sources` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `dst_asn_list` - (Optional) ASN Match List. An unordered set of RFC 6793 defined 4-byte AS numbers that can be used to create allow or deny lists for use in network policy or service policy. It can be used to create the allow list only for DNS Load Balancer. See [Dst Asn List](#rule-list-rules-dst-asn-list) below.
 
@@ -302,7 +258,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `metadata` - (Optional) Message Metadata. MessageMetaType is metadata (common attributes) of a message that only certain messages have. This information is propagated to the metadata of a child object that gets created from the containing message during view processing. The information in this type can be specified by user during create and replace APIs. See [Metadata](#rule-list-rules-metadata) below.
 
-`no_http_connect_port` - (Optional) Empty. This can be used for messages where no values are needed. See [No HTTP Connect Port](#rule-list-rules-no-http-connect-port) below.
+`no_http_connect_port` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `port_matcher` - (Optional) Port Matcher. A port matcher specifies a list of port ranges as match criteria. The match is considered successful if the input port falls within any of the port ranges. The result of the match is inverted if invert_matcher is true. See [Port Matcher](#rule-list-rules-port-matcher) below.
 
@@ -311,14 +267,6 @@ In addition to all arguments above, the following attributes are exported:
 `tls_list` - (Optional) DomainListType. See [TLS List](#rule-list-rules-tls-list) below.
 
 `url_category_list` - (Optional) URL Category List Type. List of URL categories. See [URL Category List](#rule-list-rules-url-category-list) below.
-
-<a id="rule-list-rules-all-destinations"></a>
-
-### Rule List Rules All Destinations
-
-<a id="rule-list-rules-all-sources"></a>
-
-### Rule List Rules All Sources
 
 <a id="rule-list-rules-dst-asn-list"></a>
 
@@ -362,11 +310,7 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Rule List Rules HTTP List
 
-`http_list` - (Optional) HTTP URLs. URLs for HTTP connections. See [HTTP List](#rule-list-rules-http-list-http-list) below.
-
-<a id="rule-list-rules-http-list-http-list"></a>
-
-### Rule List Rules HTTP List HTTP List
+`http_list` - (Optional) HTTP URLs. URLs for HTTP connections (`Block`).
 
 <a id="rule-list-rules-ip-prefix-set"></a>
 
@@ -392,10 +336,6 @@ In addition to all arguments above, the following attributes are exported:
 
 `name` - (Optional) Name. This is the name of the message. The value of name has to follow DNS-1035 format (`String`).
 
-<a id="rule-list-rules-no-http-connect-port"></a>
-
-### Rule List Rules No HTTP Connect Port
-
 <a id="rule-list-rules-port-matcher"></a>
 
 ### Rule List Rules Port Matcher
@@ -414,11 +354,7 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Rule List Rules TLS List
 
-`tls_list` - (Optional) TLS Domains. Domains in SNI for TLS connections. See [TLS List](#rule-list-rules-tls-list-tls-list) below.
-
-<a id="rule-list-rules-tls-list-tls-list"></a>
-
-### Rule List Rules TLS List TLS List
+`tls_list` - (Optional) TLS Domains. Domains in SNI for TLS connections (`Block`).
 
 <a id="rule-list-rules-url-category-list"></a>
 

--- a/docs/resources/forwarding_class.md
+++ b/docs/resources/forwarding_class.md
@@ -66,13 +66,13 @@ resource "f5xc_forwarding_class" "example" {
 
 `dscp` - (Optional) DSCP Marking setting. DSCP marking setting as per RFC 2475. See [Dscp](#dscp) below for details.
 
-`no_marking` - (Optional) Empty. This can be used for messages where no values are needed. See [No Marking](#no-marking) below for details.
+`no_marking` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `tos_value` - (Optional) TOS value. Decimal value of raw 8 bit TOS. In above example DSCP 10 = Precedence Class 1 and drop precedence low (`Number`).
 
 > **Note:** One of the arguments from this list "dscp_based_queue, queue_id_to_use" must be set.
 
-`dscp_based_queue` - (Optional) Empty. This can be used for messages where no values are needed. See [Dscp Based Queue](#dscp-based-queue) below for details.
+`dscp_based_queue` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `queue_id_to_use` - (Optional) Precedence Level Values. DSCP Precedence Level Values Best Effort service will get any available bandwidth DSCP Class 1 service DSCP Class 2 service DSCP Class 3 service DSCP Class 4 service Express Forwarding is used for low latency traffic Control is used for routing traffic, not recommended Link Layer traffic like LACP or keepalive, not recommended. Possible values are `DSCP_BEST_EFFORT`, `DSCP_CLASS1`, `DSCP_CLASS2`, `DSCP_CLASS3`, `DSCP_CLASS4`, `DSCP_EXPRESS_FORWARDING`, `DSCP_CONTROL_L3`, `DSCP_CONTROL_L2`. Defaults to `DSCP_BEST_EFFORT` (`String`).
 
@@ -80,7 +80,7 @@ resource "f5xc_forwarding_class" "example" {
 
 > **Note:** One of the arguments from this list "no_policer, policer" must be set.
 
-`no_policer` - (Optional) Empty. This can be used for messages where no values are needed. See [No Policer](#no-policer) below for details.
+`no_policer` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `policer` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Policer](#policer) below for details.
 
@@ -101,18 +101,6 @@ In addition to all arguments above, the following attributes are exported:
 `drop_precedence` - (Optional) DSCP AF Drop Precedence. DSCP Assured forwarding drop precedence DSCP Low drop precedence DSCP Low drop precedence DSCP Low drop precedence DSCP drop precedence value is taken from output of policer. Possible values are `DSCP_AF_LOW`, `DSCP_AF_MEDIUM`, `DSCP_AF_HIGH`, `DSCP_AF_POLICER`. Defaults to `DSCP_AF_FAKE` (`String`).
 
 `dscp_class` - (Optional) Precedence Level Values. DSCP Precedence Level Values Best Effort service will get any available bandwidth DSCP Class 1 service DSCP Class 2 service DSCP Class 3 service DSCP Class 4 service Express Forwarding is used for low latency traffic Control is used for routing traffic, not recommended Link Layer traffic like LACP or keepalive, not recommended. Possible values are `DSCP_BEST_EFFORT`, `DSCP_CLASS1`, `DSCP_CLASS2`, `DSCP_CLASS3`, `DSCP_CLASS4`, `DSCP_EXPRESS_FORWARDING`, `DSCP_CONTROL_L3`, `DSCP_CONTROL_L2`. Defaults to `DSCP_BEST_EFFORT` (`String`).
-
-<a id="dscp-based-queue"></a>
-
-### Dscp Based Queue
-
-<a id="no-marking"></a>
-
-### No Marking
-
-<a id="no-policer"></a>
-
-### No Policer
 
 <a id="policer"></a>
 

--- a/docs/resources/gcp_vpc_site.md
+++ b/docs/resources/gcp_vpc_site.md
@@ -97,11 +97,11 @@ resource "f5xc_gcp_vpc_site" "example" {
 
 > **Note:** One of the arguments from this list "block_all_services, blocked_services, default_blocked_services" must be set.
 
-`block_all_services` - (Optional) Empty. This can be used for messages where no values are needed. See [Block All Services](#block-all-services) below for details.
+`block_all_services` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `blocked_services` - (Optional) Disable Node Local Services. Disable node local services on this site. Note: The chosen services will get disabled on all nodes in the site. See [Blocked Services](#blocked-services) below for details.
 
-`default_blocked_services` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Blocked Services](#default-blocked-services) below for details.
+`default_blocked_services` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `cloud_credentials` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Cloud Credentials](#cloud-credentials) below for details.
 
@@ -111,7 +111,7 @@ resource "f5xc_gcp_vpc_site" "example" {
 
 `disk_size` - (Optional) Cloud Disk Size. Disk size to be used for this instance in GiB. 80 is 80 GiB (`Number`).
 
-`gcp_labels` - (Optional) GCP Labels. GCP Label is a label consisting of a user-defined key and value. It helps to manage, identify, organize, search for, and filter resources in GCP console. See [GCP Labels](#gcp-labels) below for details.
+`gcp_labels` - (Optional) GCP Labels. GCP Label is a label consisting of a user-defined key and value. It helps to manage, identify, organize, search for, and filter resources in GCP console (`Block`).
 
 `gcp_region` - (Optional) GCP Region. Name for GCP Region (`String`).
 
@@ -131,7 +131,7 @@ resource "f5xc_gcp_vpc_site" "example" {
 
 `log_receiver` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Log Receiver](#log-receiver) below for details.
 
-`logs_streaming_disabled` - (Optional) Empty. This can be used for messages where no values are needed. See [Logs Streaming Disabled](#logs-streaming-disabled) below for details.
+`logs_streaming_disabled` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `offline_survivability_mode` - (Optional) Offline Survivability Mode. Offline Survivability allows the Site to continue functioning normally without traffic loss during periods of connectivity loss to the Regional Edge (RE) or the Global Controller (GC). When this feature is enabled, a site can continue to function as is with existing configuration for upto 7 days, even when the site is offline. The certificates needed to keep the services running on this site are signed using a local CA. Secrets would also be cached locally to handl. See [Offline Survivability Mode](#offline-survivability-mode) below for details.
 
@@ -139,7 +139,7 @@ resource "f5xc_gcp_vpc_site" "example" {
 
 > **Note:** One of the arguments from this list "private_connect_disabled, private_connectivity" must be set.
 
-`private_connect_disabled` - (Optional) Empty. This can be used for messages where no values are needed. See [Private Connect Disabled](#private-connect-disabled) below for details.
+`private_connect_disabled` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `private_connectivity` - (Optional) Private Connect Configuration. Private Connect Configuration. See [Private Connectivity](#private-connectivity) below for details.
 
@@ -183,10 +183,6 @@ In addition to all arguments above, the following attributes are exported:
 
 `url` - (Optional) URL. URL of the secret. Currently supported URL schemes is string:///. For string:/// scheme, Secret needs to be encoded Base64 format. When asked for this secret, caller will get Secret bytes after Base64 decoding (`String`).
 
-<a id="block-all-services"></a>
-
-### Block All Services
-
 <a id="blocked-services"></a>
 
 ### Blocked Services
@@ -197,25 +193,13 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Blocked Services Blocked Sevice
 
-`dns` - (Optional) Empty. This can be used for messages where no values are needed. See [DNS](#blocked-services-blocked-sevice-dns) below.
+`dns` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `network_type` - (Optional) Virtual Network Type. Different types of virtual networks understood by the system Virtual-network of type VIRTUAL_NETWORK_SITE_LOCAL provides connectivity to public (outside) network. This is an insecure network and is connected to public internet via NAT Gateways/firwalls Virtual-network of this type is local to every site. Two virtual networks of this type on different sites are neither related nor connected. Constraints: There can be atmost one virtual network of this type in a given site... Possible values include `VIRTUAL_NETWORK_SITE_LOCAL`, `VIRTUAL_NETWORK_SITE_LOCAL_INSIDE`, `VIRTUAL_NETWORK_PER_SITE`, `VIRTUAL_NETWORK_PUBLIC`, `VIRTUAL_NETWORK_GLOBAL`, `VIRTUAL_NETWORK_SITE_SERVICE`, `VIRTUAL_NETWORK_VER_INTERNAL`, `VIRTUAL_NETWORK_SITE_LOCAL_INSIDE_OUTSIDE`, `VIRTUAL_NETWORK_IP_AUTO`, `VIRTUAL_NETWORK_VOLTADN_PRIVATE_NETWORK`, and others. Defaults to `VIRTUAL_NETWORK_SITE_LOCAL` (`String`).
 
-`ssh` - (Optional) Empty. This can be used for messages where no values are needed. See [SSH](#blocked-services-blocked-sevice-ssh) below.
+`ssh` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`web_user_interface` - (Optional) Empty. This can be used for messages where no values are needed. See [Web User Interface](#blocked-services-blocked-sevice-web-user-interface) below.
-
-<a id="blocked-services-blocked-sevice-dns"></a>
-
-### Blocked Services Blocked Sevice DNS
-
-<a id="blocked-services-blocked-sevice-ssh"></a>
-
-### Blocked Services Blocked Sevice SSH
-
-<a id="blocked-services-blocked-sevice-web-user-interface"></a>
-
-### Blocked Services Blocked Sevice Web User Interface
+`web_user_interface` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="cloud-credentials"></a>
 
@@ -243,14 +227,6 @@ In addition to all arguments above, the following attributes are exported:
 
 `outside_nameserver` - (Optional) DNS Server for Outside Network. Optional DNS server IP to be used for name resolution in outside network (`String`).
 
-<a id="default-blocked-services"></a>
-
-### Default Blocked Services
-
-<a id="gcp-labels"></a>
-
-### GCP Labels
-
 <a id="ingress-egress-gw"></a>
 
 ### Ingress Egress Gw
@@ -265,7 +241,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `dc_cluster_group_outside_vn` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Dc Cluster Group Outside Vn](#ingress-egress-gw-dc-cluster-group-outside-vn) below.
 
-`forward_proxy_allow_all` - (Optional) Empty. This can be used for messages where no values are needed. See [Forward Proxy Allow All](#ingress-egress-gw-forward-proxy-allow-all) below.
+`forward_proxy_allow_all` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `gcp_certified_hw` - (Optional) GCP Certified Hardware. Name for GCP certified hardware (`String`).
 
@@ -279,17 +255,17 @@ In addition to all arguments above, the following attributes are exported:
 
 `inside_subnet` - (Optional) GCP VPC network choice. This defines choice about GCP VPC network for a view. See [Inside Subnet](#ingress-egress-gw-inside-subnet) below.
 
-`no_dc_cluster_group` - (Optional) Empty. This can be used for messages where no values are needed. See [No Dc Cluster Group](#ingress-egress-gw-no-dc-cluster-group) below.
+`no_dc_cluster_group` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_forward_proxy` - (Optional) Empty. This can be used for messages where no values are needed. See [No Forward Proxy](#ingress-egress-gw-no-forward-proxy) below.
+`no_forward_proxy` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_global_network` - (Optional) Empty. This can be used for messages where no values are needed. See [No Global Network](#ingress-egress-gw-no-global-network) below.
+`no_global_network` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_inside_static_routes` - (Optional) Empty. This can be used for messages where no values are needed. See [No Inside Static Routes](#ingress-egress-gw-no-inside-static-routes) below.
+`no_inside_static_routes` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_network_policy` - (Optional) Empty. This can be used for messages where no values are needed. See [No Network Policy](#ingress-egress-gw-no-network-policy) below.
+`no_network_policy` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_outside_static_routes` - (Optional) Empty. This can be used for messages where no values are needed. See [No Outside Static Routes](#ingress-egress-gw-no-outside-static-routes) below.
+`no_outside_static_routes` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `node_number` - (Optional) Number of main nodes. Number of main nodes to create, either 1 or 3 (`Number`).
 
@@ -301,9 +277,9 @@ In addition to all arguments above, the following attributes are exported:
 
 `performance_enhancement_mode` - (Optional) Performance Enhancement Mode. x-required Optimize the site for L3 or L7 traffic processing. L7 optimized is the default. See [Performance Enhancement Mode](#ingress-egress-gw-performance-enhancement-mode) below.
 
-`sm_connection_public_ip` - (Optional) Empty. This can be used for messages where no values are needed. See [Sm Connection Public IP](#ingress-egress-gw-sm-connection-public-ip) below.
+`sm_connection_public_ip` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`sm_connection_pvt_ip` - (Optional) Empty. This can be used for messages where no values are needed. See [Sm Connection Pvt IP](#ingress-egress-gw-sm-connection-pvt-ip) below.
+`sm_connection_pvt_ip` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="ingress-egress-gw-active-enhanced-firewall-policies"></a>
 
@@ -373,10 +349,6 @@ In addition to all arguments above, the following attributes are exported:
 
 `tenant` - (Optional) Tenant. When a configuration object(e.g. virtual_host) refers to another(e.g route) then tenant will hold the referred object's(e.g. route's) tenant (`String`).
 
-<a id="ingress-egress-gw-forward-proxy-allow-all"></a>
-
-### Ingress Egress Gw Forward Proxy Allow All
-
 <a id="ingress-egress-gw-global-network-list"></a>
 
 ### Ingress Egress Gw Global Network List
@@ -387,17 +359,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Ingress Egress Gw Global Network List Global Network Connections
 
-`sli_to_global_dr` - (Optional) Global Network. Global network reference for direct connection. See [Sli To Global DR](#ingress-egress-gw-global-network-list-global-network-connections-sli-to-global-dr) below.
+`sli_to_global_dr` - (Optional) Global Network. Global network reference for direct connection (`Block`).
 
-`slo_to_global_dr` - (Optional) Global Network. Global network reference for direct connection. See [Slo To Global DR](#ingress-egress-gw-global-network-list-global-network-connections-slo-to-global-dr) below.
-
-<a id="ingress-egress-gw-global-network-list-global-network-connections-sli-to-global-dr"></a>
-
-### Ingress Egress Gw Global Network List Global Network Connections Sli To Global DR
-
-<a id="ingress-egress-gw-global-network-list-global-network-connections-slo-to-global-dr"></a>
-
-### Ingress Egress Gw Global Network List Global Network Connections Slo To Global DR
+`slo_to_global_dr` - (Optional) Global Network. Global network reference for direct connection (`Block`).
 
 <a id="ingress-egress-gw-inside-network"></a>
 
@@ -407,7 +371,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `new_network` - (Optional) GCP VPC Network Manual Parameters. Parameters to create a new GCP VPC Network. See [New Network](#ingress-egress-gw-inside-network-new-network) below.
 
-`new_network_autogenerate` - (Optional) GCP VPC Network Autogenerated Parameters. Create a new GCP VPC Network with autogenerated name. See [New Network Autogenerate](#ingress-egress-gw-inside-network-new-network-autogenerate) below.
+`new_network_autogenerate` - (Optional) GCP VPC Network Autogenerated Parameters. Create a new GCP VPC Network with autogenerated name (`Block`).
 
 <a id="ingress-egress-gw-inside-network-existing-network"></a>
 
@@ -421,10 +385,6 @@ In addition to all arguments above, the following attributes are exported:
 
 `name` - (Optional) GCP VPC Network Name. Name for your GCP VPC Network (`String`).
 
-<a id="ingress-egress-gw-inside-network-new-network-autogenerate"></a>
-
-### Ingress Egress Gw Inside Network New Network Autogenerate
-
 <a id="ingress-egress-gw-inside-static-routes"></a>
 
 ### Ingress Egress Gw Inside Static Routes
@@ -435,13 +395,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Ingress Egress Gw Inside Static Routes Static Route List
 
-`custom_static_route` - (Optional) Static Route. Defines a static route, configuring a list of prefixes and a next-hop to be used for them. See [Custom Static Route](#ingress-egress-gw-inside-static-routes-static-route-list-custom-static-route) below.
+`custom_static_route` - (Optional) Static Route. Defines a static route, configuring a list of prefixes and a next-hop to be used for them (`Block`).
 
 `simple_static_route` - (Optional) Simple Static Route. Use simple static route for prefix pointing to single interface in the network (`String`).
-
-<a id="ingress-egress-gw-inside-static-routes-static-route-list-custom-static-route"></a>
-
-### Ingress Egress Gw Inside Static Routes Static Route List Custom Static Route
 
 <a id="ingress-egress-gw-inside-subnet"></a>
 
@@ -465,30 +421,6 @@ In addition to all arguments above, the following attributes are exported:
 
 `subnet_name` - (Optional) VPC Subnet Name. Name of new VPC Subnet, will be autogenerated if empty (`String`).
 
-<a id="ingress-egress-gw-no-dc-cluster-group"></a>
-
-### Ingress Egress Gw No Dc Cluster Group
-
-<a id="ingress-egress-gw-no-forward-proxy"></a>
-
-### Ingress Egress Gw No Forward Proxy
-
-<a id="ingress-egress-gw-no-global-network"></a>
-
-### Ingress Egress Gw No Global Network
-
-<a id="ingress-egress-gw-no-inside-static-routes"></a>
-
-### Ingress Egress Gw No Inside Static Routes
-
-<a id="ingress-egress-gw-no-network-policy"></a>
-
-### Ingress Egress Gw No Network Policy
-
-<a id="ingress-egress-gw-no-outside-static-routes"></a>
-
-### Ingress Egress Gw No Outside Static Routes
-
 <a id="ingress-egress-gw-outside-network"></a>
 
 ### Ingress Egress Gw Outside Network
@@ -497,7 +429,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `new_network` - (Optional) GCP VPC Network Manual Parameters. Parameters to create a new GCP VPC Network. See [New Network](#ingress-egress-gw-outside-network-new-network) below.
 
-`new_network_autogenerate` - (Optional) GCP VPC Network Autogenerated Parameters. Create a new GCP VPC Network with autogenerated name. See [New Network Autogenerate](#ingress-egress-gw-outside-network-new-network-autogenerate) below.
+`new_network_autogenerate` - (Optional) GCP VPC Network Autogenerated Parameters. Create a new GCP VPC Network with autogenerated name (`Block`).
 
 <a id="ingress-egress-gw-outside-network-existing-network"></a>
 
@@ -511,10 +443,6 @@ In addition to all arguments above, the following attributes are exported:
 
 `name` - (Optional) GCP VPC Network Name. Name for your GCP VPC Network (`String`).
 
-<a id="ingress-egress-gw-outside-network-new-network-autogenerate"></a>
-
-### Ingress Egress Gw Outside Network New Network Autogenerate
-
 <a id="ingress-egress-gw-outside-static-routes"></a>
 
 ### Ingress Egress Gw Outside Static Routes
@@ -525,13 +453,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Ingress Egress Gw Outside Static Routes Static Route List
 
-`custom_static_route` - (Optional) Static Route. Defines a static route, configuring a list of prefixes and a next-hop to be used for them. See [Custom Static Route](#ingress-egress-gw-outside-static-routes-static-route-list-custom-static-route) below.
+`custom_static_route` - (Optional) Static Route. Defines a static route, configuring a list of prefixes and a next-hop to be used for them (`Block`).
 
 `simple_static_route` - (Optional) Simple Static Route. Use simple static route for prefix pointing to single interface in the network (`String`).
-
-<a id="ingress-egress-gw-outside-static-routes-static-route-list-custom-static-route"></a>
-
-### Ingress Egress Gw Outside Static Routes Static Route List Custom Static Route
 
 <a id="ingress-egress-gw-outside-subnet"></a>
 
@@ -561,35 +485,15 @@ In addition to all arguments above, the following attributes are exported:
 
 `perf_mode_l3_enhanced` - (Optional) L3 Mode Enhanced Performance. x-required L3 enhanced performance mode options. See [Perf Mode L3 Enhanced](#ingress-egress-gw-performance-enhancement-mode-perf-mode-l3-enhanced) below.
 
-`perf_mode_l7_enhanced` - (Optional) Empty. This can be used for messages where no values are needed. See [Perf Mode L7 Enhanced](#ingress-egress-gw-performance-enhancement-mode-perf-mode-l7-enhanced) below.
+`perf_mode_l7_enhanced` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="ingress-egress-gw-performance-enhancement-mode-perf-mode-l3-enhanced"></a>
 
 ### Ingress Egress Gw Performance Enhancement Mode Perf Mode L3 Enhanced
 
-`jumbo` - (Optional) Empty. This can be used for messages where no values are needed. See [Jumbo](#ingress-egress-gw-performance-enhancement-mode-perf-mode-l3-enhanced-jumbo) below.
+`jumbo` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_jumbo` - (Optional) Empty. This can be used for messages where no values are needed. See [No Jumbo](#ingress-egress-gw-performance-enhancement-mode-perf-mode-l3-enhanced-no-jumbo) below.
-
-<a id="ingress-egress-gw-performance-enhancement-mode-perf-mode-l3-enhanced-jumbo"></a>
-
-### Ingress Egress Gw Performance Enhancement Mode Perf Mode L3 Enhanced Jumbo
-
-<a id="ingress-egress-gw-performance-enhancement-mode-perf-mode-l3-enhanced-no-jumbo"></a>
-
-### Ingress Egress Gw Performance Enhancement Mode Perf Mode L3 Enhanced No Jumbo
-
-<a id="ingress-egress-gw-performance-enhancement-mode-perf-mode-l7-enhanced"></a>
-
-### Ingress Egress Gw Performance Enhancement Mode Perf Mode L7 Enhanced
-
-<a id="ingress-egress-gw-sm-connection-public-ip"></a>
-
-### Ingress Egress Gw Sm Connection Public IP
-
-<a id="ingress-egress-gw-sm-connection-pvt-ip"></a>
-
-### Ingress Egress Gw Sm Connection Pvt IP
+`no_jumbo` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="ingress-gw"></a>
 
@@ -615,7 +519,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `new_network` - (Optional) GCP VPC Network Manual Parameters. Parameters to create a new GCP VPC Network. See [New Network](#ingress-gw-local-network-new-network) below.
 
-`new_network_autogenerate` - (Optional) GCP VPC Network Autogenerated Parameters. Create a new GCP VPC Network with autogenerated name. See [New Network Autogenerate](#ingress-gw-local-network-new-network-autogenerate) below.
+`new_network_autogenerate` - (Optional) GCP VPC Network Autogenerated Parameters. Create a new GCP VPC Network with autogenerated name (`Block`).
 
 <a id="ingress-gw-local-network-existing-network"></a>
 
@@ -628,10 +532,6 @@ In addition to all arguments above, the following attributes are exported:
 ### Ingress Gw Local Network New Network
 
 `name` - (Optional) GCP VPC Network Name. Name for your GCP VPC Network (`String`).
-
-<a id="ingress-gw-local-network-new-network-autogenerate"></a>
-
-### Ingress Gw Local Network New Network Autogenerate
 
 <a id="ingress-gw-local-subnet"></a>
 
@@ -661,59 +561,35 @@ In addition to all arguments above, the following attributes are exported:
 
 `perf_mode_l3_enhanced` - (Optional) L3 Mode Enhanced Performance. x-required L3 enhanced performance mode options. See [Perf Mode L3 Enhanced](#ingress-gw-performance-enhancement-mode-perf-mode-l3-enhanced) below.
 
-`perf_mode_l7_enhanced` - (Optional) Empty. This can be used for messages where no values are needed. See [Perf Mode L7 Enhanced](#ingress-gw-performance-enhancement-mode-perf-mode-l7-enhanced) below.
+`perf_mode_l7_enhanced` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="ingress-gw-performance-enhancement-mode-perf-mode-l3-enhanced"></a>
 
 ### Ingress Gw Performance Enhancement Mode Perf Mode L3 Enhanced
 
-`jumbo` - (Optional) Empty. This can be used for messages where no values are needed. See [Jumbo](#ingress-gw-performance-enhancement-mode-perf-mode-l3-enhanced-jumbo) below.
+`jumbo` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_jumbo` - (Optional) Empty. This can be used for messages where no values are needed. See [No Jumbo](#ingress-gw-performance-enhancement-mode-perf-mode-l3-enhanced-no-jumbo) below.
-
-<a id="ingress-gw-performance-enhancement-mode-perf-mode-l3-enhanced-jumbo"></a>
-
-### Ingress Gw Performance Enhancement Mode Perf Mode L3 Enhanced Jumbo
-
-<a id="ingress-gw-performance-enhancement-mode-perf-mode-l3-enhanced-no-jumbo"></a>
-
-### Ingress Gw Performance Enhancement Mode Perf Mode L3 Enhanced No Jumbo
-
-<a id="ingress-gw-performance-enhancement-mode-perf-mode-l7-enhanced"></a>
-
-### Ingress Gw Performance Enhancement Mode Perf Mode L7 Enhanced
+`no_jumbo` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="kubernetes-upgrade-drain"></a>
 
 ### Kubernetes Upgrade Drain
 
-`disable_upgrade_drain` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Upgrade Drain](#kubernetes-upgrade-drain-disable-upgrade-drain) below.
+`disable_upgrade_drain` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `enable_upgrade_drain` - (Optional) Enable Node by Node Upgrade. Specify batch upgrade settings for worker nodes within a site. See [Enable Upgrade Drain](#kubernetes-upgrade-drain-enable-upgrade-drain) below.
-
-<a id="kubernetes-upgrade-drain-disable-upgrade-drain"></a>
-
-### Kubernetes Upgrade Drain Disable Upgrade Drain
 
 <a id="kubernetes-upgrade-drain-enable-upgrade-drain"></a>
 
 ### Kubernetes Upgrade Drain Enable Upgrade Drain
 
-`disable_vega_upgrade_mode` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Vega Upgrade Mode](#kubernetes-upgrade-drain-enable-upgrade-drain-disable-vega-upgrade-mode) below.
+`disable_vega_upgrade_mode` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `drain_max_unavailable_node_count` - (Optional) Node Batch Size Count (`Number`).
 
 `drain_node_timeout` - (Optional) Upgrade Wait Time. Seconds to wait before initiating upgrade on the next set of nodes. Setting it to 0 will wait indefinitely for all services on nodes to be upgraded gracefully before proceeding to the next set of nodes. (Warning: It may block upgrade if services on a node cannot be gracefully upgraded. It is recommended to use the default value) (`Number`).
 
-`enable_vega_upgrade_mode` - (Optional) Empty. This can be used for messages where no values are needed. See [Enable Vega Upgrade Mode](#kubernetes-upgrade-drain-enable-upgrade-drain-enable-vega-upgrade-mode) below.
-
-<a id="kubernetes-upgrade-drain-enable-upgrade-drain-disable-vega-upgrade-mode"></a>
-
-### Kubernetes Upgrade Drain Enable Upgrade Drain Disable Vega Upgrade Mode
-
-<a id="kubernetes-upgrade-drain-enable-upgrade-drain-enable-vega-upgrade-mode"></a>
-
-### Kubernetes Upgrade Drain Enable Upgrade Drain Enable Vega Upgrade Mode
+`enable_vega_upgrade_mode` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="log-receiver"></a>
 
@@ -725,41 +601,21 @@ In addition to all arguments above, the following attributes are exported:
 
 `tenant` - (Optional) Tenant. When a configuration object(e.g. virtual_host) refers to another(e.g route) then tenant will hold the referred object's(e.g. route's) tenant (`String`).
 
-<a id="logs-streaming-disabled"></a>
-
-### Logs Streaming Disabled
-
 <a id="offline-survivability-mode"></a>
 
 ### Offline Survivability Mode
 
-`enable_offline_survivability_mode` - (Optional) Empty. This can be used for messages where no values are needed. See [Enable Offline Survivability Mode](#offline-survivability-mode-enable-offline-survivability-mode) below.
+`enable_offline_survivability_mode` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_offline_survivability_mode` - (Optional) Empty. This can be used for messages where no values are needed. See [No Offline Survivability Mode](#offline-survivability-mode-no-offline-survivability-mode) below.
-
-<a id="offline-survivability-mode-enable-offline-survivability-mode"></a>
-
-### Offline Survivability Mode Enable Offline Survivability Mode
-
-<a id="offline-survivability-mode-no-offline-survivability-mode"></a>
-
-### Offline Survivability Mode No Offline Survivability Mode
+`no_offline_survivability_mode` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="os"></a>
 
 ### OS
 
-`default_os_version` - (Optional) Empty. This can be used for messages where no values are needed. See [Default OS Version](#os-default-os-version) below.
+`default_os_version` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `operating_system_version` - (Optional) Operating System Version. Specify a OS version to be used e.g. 9.2024.6 (`String`).
-
-<a id="os-default-os-version"></a>
-
-### OS Default OS Version
-
-<a id="private-connect-disabled"></a>
-
-### Private Connect Disabled
 
 <a id="private-connectivity"></a>
 
@@ -767,9 +623,9 @@ In addition to all arguments above, the following attributes are exported:
 
 `cloud_link` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Cloud Link](#private-connectivity-cloud-link) below.
 
-`inside` - (Optional) Empty. This can be used for messages where no values are needed. See [Inside](#private-connectivity-inside) below.
+`inside` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`outside` - (Optional) Empty. This can be used for messages where no values are needed. See [Outside](#private-connectivity-outside) below.
+`outside` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="private-connectivity-cloud-link"></a>
 
@@ -781,25 +637,13 @@ In addition to all arguments above, the following attributes are exported:
 
 `tenant` - (Optional) Tenant. When a configuration object(e.g. virtual_host) refers to another(e.g route) then tenant will hold the referred object's(e.g. route's) tenant (`String`).
 
-<a id="private-connectivity-inside"></a>
-
-### Private Connectivity Inside
-
-<a id="private-connectivity-outside"></a>
-
-### Private Connectivity Outside
-
 <a id="sw"></a>
 
 ### Sw
 
-`default_sw_version` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Sw Version](#sw-default-sw-version) below.
+`default_sw_version` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `volterra_software_version` - (Optional) F5XC Software Version. Specify a F5XC Software Version to be used e.g. crt-20210329-1002 (`String`).
-
-<a id="sw-default-sw-version"></a>
-
-### Sw Default Sw Version
 
 <a id="timeouts"></a>
 
@@ -825,9 +669,9 @@ In addition to all arguments above, the following attributes are exported:
 
 `dc_cluster_group` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Dc Cluster Group](#voltstack-cluster-dc-cluster-group) below.
 
-`default_storage` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Storage](#voltstack-cluster-default-storage) below.
+`default_storage` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`forward_proxy_allow_all` - (Optional) Empty. This can be used for messages where no values are needed. See [Forward Proxy Allow All](#voltstack-cluster-forward-proxy-allow-all) below.
+`forward_proxy_allow_all` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `gcp_certified_hw` - (Optional) GCP Certified Hardware. Name for GCP certified hardware (`String`).
 
@@ -837,17 +681,17 @@ In addition to all arguments above, the following attributes are exported:
 
 `k8s_cluster` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [K8s Cluster](#voltstack-cluster-k8s-cluster) below.
 
-`no_dc_cluster_group` - (Optional) Empty. This can be used for messages where no values are needed. See [No Dc Cluster Group](#voltstack-cluster-no-dc-cluster-group) below.
+`no_dc_cluster_group` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_forward_proxy` - (Optional) Empty. This can be used for messages where no values are needed. See [No Forward Proxy](#voltstack-cluster-no-forward-proxy) below.
+`no_forward_proxy` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_global_network` - (Optional) Empty. This can be used for messages where no values are needed. See [No Global Network](#voltstack-cluster-no-global-network) below.
+`no_global_network` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_k8s_cluster` - (Optional) Empty. This can be used for messages where no values are needed. See [No K8s Cluster](#voltstack-cluster-no-k8s-cluster) below.
+`no_k8s_cluster` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_network_policy` - (Optional) Empty. This can be used for messages where no values are needed. See [No Network Policy](#voltstack-cluster-no-network-policy) below.
+`no_network_policy` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_outside_static_routes` - (Optional) Empty. This can be used for messages where no values are needed. See [No Outside Static Routes](#voltstack-cluster-no-outside-static-routes) below.
+`no_outside_static_routes` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `node_number` - (Optional) Number of main Nodes. Number of main nodes to create, either 1 or 3 (`Number`).
 
@@ -857,9 +701,9 @@ In addition to all arguments above, the following attributes are exported:
 
 `site_local_subnet` - (Optional) GCP VPC network choice. This defines choice about GCP VPC network for a view. See [Site Local Subnet](#voltstack-cluster-site-local-subnet) below.
 
-`sm_connection_public_ip` - (Optional) Empty. This can be used for messages where no values are needed. See [Sm Connection Public IP](#voltstack-cluster-sm-connection-public-ip) below.
+`sm_connection_public_ip` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`sm_connection_pvt_ip` - (Optional) Empty. This can be used for messages where no values are needed. See [Sm Connection Pvt IP](#voltstack-cluster-sm-connection-pvt-ip) below.
+`sm_connection_pvt_ip` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `storage_class_list` - (Optional) Custom Storage Class List. Add additional custom storage classes in kubernetes for this site. See [Storage Class List](#voltstack-cluster-storage-class-list) below.
 
@@ -921,14 +765,6 @@ In addition to all arguments above, the following attributes are exported:
 
 `tenant` - (Optional) Tenant. When a configuration object(e.g. virtual_host) refers to another(e.g route) then tenant will hold the referred object's(e.g. route's) tenant (`String`).
 
-<a id="voltstack-cluster-default-storage"></a>
-
-### Voltstack Cluster Default Storage
-
-<a id="voltstack-cluster-forward-proxy-allow-all"></a>
-
-### Voltstack Cluster Forward Proxy Allow All
-
 <a id="voltstack-cluster-global-network-list"></a>
 
 ### Voltstack Cluster Global Network List
@@ -939,17 +775,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Voltstack Cluster Global Network List Global Network Connections
 
-`sli_to_global_dr` - (Optional) Global Network. Global network reference for direct connection. See [Sli To Global DR](#voltstack-cluster-global-network-list-global-network-connections-sli-to-global-dr) below.
+`sli_to_global_dr` - (Optional) Global Network. Global network reference for direct connection (`Block`).
 
-`slo_to_global_dr` - (Optional) Global Network. Global network reference for direct connection. See [Slo To Global DR](#voltstack-cluster-global-network-list-global-network-connections-slo-to-global-dr) below.
-
-<a id="voltstack-cluster-global-network-list-global-network-connections-sli-to-global-dr"></a>
-
-### Voltstack Cluster Global Network List Global Network Connections Sli To Global DR
-
-<a id="voltstack-cluster-global-network-list-global-network-connections-slo-to-global-dr"></a>
-
-### Voltstack Cluster Global Network List Global Network Connections Slo To Global DR
+`slo_to_global_dr` - (Optional) Global Network. Global network reference for direct connection (`Block`).
 
 <a id="voltstack-cluster-k8s-cluster"></a>
 
@@ -961,30 +789,6 @@ In addition to all arguments above, the following attributes are exported:
 
 `tenant` - (Optional) Tenant. When a configuration object(e.g. virtual_host) refers to another(e.g route) then tenant will hold the referred object's(e.g. route's) tenant (`String`).
 
-<a id="voltstack-cluster-no-dc-cluster-group"></a>
-
-### Voltstack Cluster No Dc Cluster Group
-
-<a id="voltstack-cluster-no-forward-proxy"></a>
-
-### Voltstack Cluster No Forward Proxy
-
-<a id="voltstack-cluster-no-global-network"></a>
-
-### Voltstack Cluster No Global Network
-
-<a id="voltstack-cluster-no-k8s-cluster"></a>
-
-### Voltstack Cluster No K8s Cluster
-
-<a id="voltstack-cluster-no-network-policy"></a>
-
-### Voltstack Cluster No Network Policy
-
-<a id="voltstack-cluster-no-outside-static-routes"></a>
-
-### Voltstack Cluster No Outside Static Routes
-
 <a id="voltstack-cluster-outside-static-routes"></a>
 
 ### Voltstack Cluster Outside Static Routes
@@ -995,13 +799,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Voltstack Cluster Outside Static Routes Static Route List
 
-`custom_static_route` - (Optional) Static Route. Defines a static route, configuring a list of prefixes and a next-hop to be used for them. See [Custom Static Route](#voltstack-cluster-outside-static-routes-static-route-list-custom-static-route) below.
+`custom_static_route` - (Optional) Static Route. Defines a static route, configuring a list of prefixes and a next-hop to be used for them (`Block`).
 
 `simple_static_route` - (Optional) Simple Static Route. Use simple static route for prefix pointing to single interface in the network (`String`).
-
-<a id="voltstack-cluster-outside-static-routes-static-route-list-custom-static-route"></a>
-
-### Voltstack Cluster Outside Static Routes Static Route List Custom Static Route
 
 <a id="voltstack-cluster-site-local-network"></a>
 
@@ -1011,7 +811,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `new_network` - (Optional) GCP VPC Network Manual Parameters. Parameters to create a new GCP VPC Network. See [New Network](#voltstack-cluster-site-local-network-new-network) below.
 
-`new_network_autogenerate` - (Optional) GCP VPC Network Autogenerated Parameters. Create a new GCP VPC Network with autogenerated name. See [New Network Autogenerate](#voltstack-cluster-site-local-network-new-network-autogenerate) below.
+`new_network_autogenerate` - (Optional) GCP VPC Network Autogenerated Parameters. Create a new GCP VPC Network with autogenerated name (`Block`).
 
 <a id="voltstack-cluster-site-local-network-existing-network"></a>
 
@@ -1024,10 +824,6 @@ In addition to all arguments above, the following attributes are exported:
 ### Voltstack Cluster Site Local Network New Network
 
 `name` - (Optional) GCP VPC Network Name. Name for your GCP VPC Network (`String`).
-
-<a id="voltstack-cluster-site-local-network-new-network-autogenerate"></a>
-
-### Voltstack Cluster Site Local Network New Network Autogenerate
 
 <a id="voltstack-cluster-site-local-subnet"></a>
 
@@ -1050,14 +846,6 @@ In addition to all arguments above, the following attributes are exported:
 `primary_ipv4` - (Optional) IPv4 Subnet Prefix. IPv4 prefix for this Subnet. It has to be private address space (`String`).
 
 `subnet_name` - (Optional) VPC Subnet Name. Name of new VPC Subnet, will be autogenerated if empty (`String`).
-
-<a id="voltstack-cluster-sm-connection-public-ip"></a>
-
-### Voltstack Cluster Sm Connection Public IP
-
-<a id="voltstack-cluster-sm-connection-pvt-ip"></a>
-
-### Voltstack Cluster Sm Connection Pvt IP
 
 <a id="voltstack-cluster-storage-class-list"></a>
 

--- a/docs/resources/geo_location_set.md
+++ b/docs/resources/geo_location_set.md
@@ -55,7 +55,7 @@ resource "f5xc_geo_location_set" "example" {
 
 `custom_geo_location_selector` - (Optional) Label Selector. This type can be used to establish a 'selector reference' from one object(called selector) to a set of other objects(called selectees) based on the value of expresssions. A label selector is a label query over a set of resources. An empty label selector matches all objects. A null label selector matches no objects. Label selector is immutable. expressions is a list of strings of label selection expression. Each string has ',' separated values which are 'AND' and all strings ar. See [Custom Geo Location Selector](#custom-geo-location-selector) below for details.
 
-`global` - (Optional) Empty. This can be used for messages where no values are needed. See [Global](#global) below for details.
+`global` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `timeouts` - (Optional) See [Timeouts](#timeouts) below for details.
 
@@ -72,10 +72,6 @@ In addition to all arguments above, the following attributes are exported:
 ### Custom Geo Location Selector
 
 `expressions` - (Optional) Selector Expression. expressions contains the kubernetes style label expression for selections (`List`).
-
-<a id="global"></a>
-
-### Global
 
 <a id="timeouts"></a>
 

--- a/docs/resources/global_log_receiver.md
+++ b/docs/resources/global_log_receiver.md
@@ -64,13 +64,13 @@ resource "f5xc_global_log_receiver" "example" {
 
 > **Note:** One of the arguments from this list "audit_logs, dns_logs, request_logs, security_events" must be set.
 
-`audit_logs` - (Optional) Empty. This can be used for messages where no values are needed. See [Audit Logs](#audit-logs) below for details.
+`audit_logs` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`dns_logs` - (Optional) Empty. This can be used for messages where no values are needed. See [DNS Logs](#dns-logs) below for details.
+`dns_logs` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`request_logs` - (Optional) Empty. This can be used for messages where no values are needed. See [Request Logs](#request-logs) below for details.
+`request_logs` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`security_events` - (Optional) Empty. This can be used for messages where no values are needed. See [Security Events](#security-events) below for details.
+`security_events` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 > **Note:** One of the arguments from this list "aws_cloud_watch_receiver, azure_event_hubs_receiver, azure_receiver, datadog_receiver, gcp_bucket_receiver, http_receiver, kafka_receiver, new_relic_receiver, qradar_receiver, s3_receiver, splunk_receiver, sumo_logic_receiver" must be set.
 
@@ -100,9 +100,9 @@ resource "f5xc_global_log_receiver" "example" {
 
 > **Note:** One of the arguments from this list "ns_all, ns_current, ns_list" must be set.
 
-`ns_all` - (Optional) Empty. This can be used for messages where no values are needed. See [Ns All](#ns-all) below for details.
+`ns_all` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`ns_current` - (Optional) Empty. This can be used for messages where no values are needed. See [Ns Current](#ns-current) below for details.
+`ns_current` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `ns_list` - (Optional) Namespace List. Namespace List. See [Ns List](#ns-list) below for details.
 
@@ -115,10 +115,6 @@ In addition to all arguments above, the following attributes are exported:
 `id` - (Optional) Unique identifier for the resource (`String`).
 
 ---
-
-<a id="audit-logs"></a>
-
-### Audit Logs
 
 <a id="aws-cloud-watch-receiver"></a>
 
@@ -152,49 +148,25 @@ In addition to all arguments above, the following attributes are exported:
 
 `max_bytes` - (Optional) Max Bytes. Send batch to endpoint after the batch is equal to or larger than this many bytes (`Number`).
 
-`max_bytes_disabled` - (Optional) Empty. This can be used for messages where no values are needed. See [Max Bytes Disabled](#aws-cloud-watch-receiver-batch-max-bytes-disabled) below.
+`max_bytes_disabled` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `max_events` - (Optional) Max Events. Send batch to endpoint after this many log messages are in the batch (`Number`).
 
-`max_events_disabled` - (Optional) Empty. This can be used for messages where no values are needed. See [Max Events Disabled](#aws-cloud-watch-receiver-batch-max-events-disabled) below.
+`max_events_disabled` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `timeout_seconds` - (Optional) Timeout Seconds. Send batch to the endpoint after this many seconds (`String`).
 
-`timeout_seconds_default` - (Optional) Empty. This can be used for messages where no values are needed. See [Timeout Seconds Default](#aws-cloud-watch-receiver-batch-timeout-seconds-default) below.
-
-<a id="aws-cloud-watch-receiver-batch-max-bytes-disabled"></a>
-
-### AWS Cloud Watch Receiver Batch Max Bytes Disabled
-
-<a id="aws-cloud-watch-receiver-batch-max-events-disabled"></a>
-
-### AWS Cloud Watch Receiver Batch Max Events Disabled
-
-<a id="aws-cloud-watch-receiver-batch-timeout-seconds-default"></a>
-
-### AWS Cloud Watch Receiver Batch Timeout Seconds Default
+`timeout_seconds_default` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="aws-cloud-watch-receiver-compression"></a>
 
 ### AWS Cloud Watch Receiver Compression
 
-`compression_default` - (Optional) Empty. This can be used for messages where no values are needed. See [Compression Default](#aws-cloud-watch-receiver-compression-compression-default) below.
+`compression_default` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`compression_gzip` - (Optional) Empty. This can be used for messages where no values are needed. See [Compression Gzip](#aws-cloud-watch-receiver-compression-compression-gzip) below.
+`compression_gzip` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`compression_none` - (Optional) Empty. This can be used for messages where no values are needed. See [Compression None](#aws-cloud-watch-receiver-compression-compression-none) below.
-
-<a id="aws-cloud-watch-receiver-compression-compression-default"></a>
-
-### AWS Cloud Watch Receiver Compression Compression Default
-
-<a id="aws-cloud-watch-receiver-compression-compression-gzip"></a>
-
-### AWS Cloud Watch Receiver Compression Compression Gzip
-
-<a id="aws-cloud-watch-receiver-compression-compression-none"></a>
-
-### AWS Cloud Watch Receiver Compression Compression None
+`compression_none` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="azure-event-hubs-receiver"></a>
 
@@ -252,49 +224,25 @@ In addition to all arguments above, the following attributes are exported:
 
 `max_bytes` - (Optional) Max Bytes. Send batch to endpoint after the batch is equal to or larger than this many bytes (`Number`).
 
-`max_bytes_disabled` - (Optional) Empty. This can be used for messages where no values are needed. See [Max Bytes Disabled](#azure-receiver-batch-max-bytes-disabled) below.
+`max_bytes_disabled` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `max_events` - (Optional) Max Events. Send batch to endpoint after this many log messages are in the batch (`Number`).
 
-`max_events_disabled` - (Optional) Empty. This can be used for messages where no values are needed. See [Max Events Disabled](#azure-receiver-batch-max-events-disabled) below.
+`max_events_disabled` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `timeout_seconds` - (Optional) Timeout Seconds. Send batch to the endpoint after this many seconds (`String`).
 
-`timeout_seconds_default` - (Optional) Empty. This can be used for messages where no values are needed. See [Timeout Seconds Default](#azure-receiver-batch-timeout-seconds-default) below.
-
-<a id="azure-receiver-batch-max-bytes-disabled"></a>
-
-### Azure Receiver Batch Max Bytes Disabled
-
-<a id="azure-receiver-batch-max-events-disabled"></a>
-
-### Azure Receiver Batch Max Events Disabled
-
-<a id="azure-receiver-batch-timeout-seconds-default"></a>
-
-### Azure Receiver Batch Timeout Seconds Default
+`timeout_seconds_default` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="azure-receiver-compression"></a>
 
 ### Azure Receiver Compression
 
-`compression_default` - (Optional) Empty. This can be used for messages where no values are needed. See [Compression Default](#azure-receiver-compression-compression-default) below.
+`compression_default` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`compression_gzip` - (Optional) Empty. This can be used for messages where no values are needed. See [Compression Gzip](#azure-receiver-compression-compression-gzip) below.
+`compression_gzip` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`compression_none` - (Optional) Empty. This can be used for messages where no values are needed. See [Compression None](#azure-receiver-compression-compression-none) below.
-
-<a id="azure-receiver-compression-compression-default"></a>
-
-### Azure Receiver Compression Compression Default
-
-<a id="azure-receiver-compression-compression-gzip"></a>
-
-### Azure Receiver Compression Compression Gzip
-
-<a id="azure-receiver-compression-compression-none"></a>
-
-### Azure Receiver Compression Compression None
+`compression_none` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="azure-receiver-connection-string"></a>
 
@@ -328,17 +276,9 @@ In addition to all arguments above, the following attributes are exported:
 
 `custom_folder` - (Optional) Custom Folder. Use your own folder name as the name of the folder in the endpoint bucket or file The folder name must match `/^[a-z_]\[a-z0-9\-\._]*$/i` (`String`).
 
-`log_type_folder` - (Optional) Empty. This can be used for messages where no values are needed. See [Log Type Folder](#azure-receiver-filename-options-log-type-folder) below.
+`log_type_folder` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_folder` - (Optional) Empty. This can be used for messages where no values are needed. See [No Folder](#azure-receiver-filename-options-no-folder) below.
-
-<a id="azure-receiver-filename-options-log-type-folder"></a>
-
-### Azure Receiver Filename Options Log Type Folder
-
-<a id="azure-receiver-filename-options-no-folder"></a>
-
-### Azure Receiver Filename Options No Folder
+`no_folder` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="datadog-receiver"></a>
 
@@ -352,7 +292,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `endpoint` - (Optional) Datadog Endpoint. Datadog Endpoint, example: `example.com:9000` (`String`).
 
-`no_tls` - (Optional) Empty. This can be used for messages where no values are needed. See [No TLS](#datadog-receiver-no-tls) below.
+`no_tls` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `site` - (Optional) Datadog Site. Datadog Site, example: `datadoghq.com` (`String`).
 
@@ -364,49 +304,25 @@ In addition to all arguments above, the following attributes are exported:
 
 `max_bytes` - (Optional) Max Bytes. Send batch to endpoint after the batch is equal to or larger than this many bytes (`Number`).
 
-`max_bytes_disabled` - (Optional) Empty. This can be used for messages where no values are needed. See [Max Bytes Disabled](#datadog-receiver-batch-max-bytes-disabled) below.
+`max_bytes_disabled` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `max_events` - (Optional) Max Events. Send batch to endpoint after this many log messages are in the batch (`Number`).
 
-`max_events_disabled` - (Optional) Empty. This can be used for messages where no values are needed. See [Max Events Disabled](#datadog-receiver-batch-max-events-disabled) below.
+`max_events_disabled` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `timeout_seconds` - (Optional) Timeout Seconds. Send batch to the endpoint after this many seconds (`String`).
 
-`timeout_seconds_default` - (Optional) Empty. This can be used for messages where no values are needed. See [Timeout Seconds Default](#datadog-receiver-batch-timeout-seconds-default) below.
-
-<a id="datadog-receiver-batch-max-bytes-disabled"></a>
-
-### Datadog Receiver Batch Max Bytes Disabled
-
-<a id="datadog-receiver-batch-max-events-disabled"></a>
-
-### Datadog Receiver Batch Max Events Disabled
-
-<a id="datadog-receiver-batch-timeout-seconds-default"></a>
-
-### Datadog Receiver Batch Timeout Seconds Default
+`timeout_seconds_default` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="datadog-receiver-compression"></a>
 
 ### Datadog Receiver Compression
 
-`compression_default` - (Optional) Empty. This can be used for messages where no values are needed. See [Compression Default](#datadog-receiver-compression-compression-default) below.
+`compression_default` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`compression_gzip` - (Optional) Empty. This can be used for messages where no values are needed. See [Compression Gzip](#datadog-receiver-compression-compression-gzip) below.
+`compression_gzip` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`compression_none` - (Optional) Empty. This can be used for messages where no values are needed. See [Compression None](#datadog-receiver-compression-compression-none) below.
-
-<a id="datadog-receiver-compression-compression-default"></a>
-
-### Datadog Receiver Compression Compression Default
-
-<a id="datadog-receiver-compression-compression-gzip"></a>
-
-### Datadog Receiver Compression Compression Gzip
-
-<a id="datadog-receiver-compression-compression-none"></a>
-
-### Datadog Receiver Compression Compression None
+`compression_none` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="datadog-receiver-datadog-api-key"></a>
 
@@ -434,49 +350,25 @@ In addition to all arguments above, the following attributes are exported:
 
 `url` - (Optional) URL. URL of the secret. Currently supported URL schemes is string:///. For string:/// scheme, Secret needs to be encoded Base64 format. When asked for this secret, caller will get Secret bytes after Base64 decoding (`String`).
 
-<a id="datadog-receiver-no-tls"></a>
-
-### Datadog Receiver No TLS
-
 <a id="datadog-receiver-use-tls"></a>
 
 ### Datadog Receiver Use TLS
 
-`disable_verify_certificate` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Verify Certificate](#datadog-receiver-use-tls-disable-verify-certificate) below.
+`disable_verify_certificate` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`disable_verify_hostname` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Verify Hostname](#datadog-receiver-use-tls-disable-verify-hostname) below.
+`disable_verify_hostname` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`enable_verify_certificate` - (Optional) Empty. This can be used for messages where no values are needed. See [Enable Verify Certificate](#datadog-receiver-use-tls-enable-verify-certificate) below.
+`enable_verify_certificate` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`enable_verify_hostname` - (Optional) Empty. This can be used for messages where no values are needed. See [Enable Verify Hostname](#datadog-receiver-use-tls-enable-verify-hostname) below.
+`enable_verify_hostname` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`mtls_disabled` - (Optional) Empty. This can be used for messages where no values are needed. See [mTLS Disabled](#datadog-receiver-use-tls-mtls-disabled) below.
+`mtls_disabled` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `mtls_enable` - (Optional) mTLS Client Config. mTLS Client config allows configuration of mTLS client options. See [mTLS Enable](#datadog-receiver-use-tls-mtls-enable) below.
 
-`no_ca` - (Optional) Empty. This can be used for messages where no values are needed. See [No CA](#datadog-receiver-use-tls-no-ca) below.
+`no_ca` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `trusted_ca_url` - (Optional) Server CA Certificates. The URL or value for trusted Server CA certificate or certificate chain Certificates in PEM format including the PEM headers (`String`).
-
-<a id="datadog-receiver-use-tls-disable-verify-certificate"></a>
-
-### Datadog Receiver Use TLS Disable Verify Certificate
-
-<a id="datadog-receiver-use-tls-disable-verify-hostname"></a>
-
-### Datadog Receiver Use TLS Disable Verify Hostname
-
-<a id="datadog-receiver-use-tls-enable-verify-certificate"></a>
-
-### Datadog Receiver Use TLS Enable Verify Certificate
-
-<a id="datadog-receiver-use-tls-enable-verify-hostname"></a>
-
-### Datadog Receiver Use TLS Enable Verify Hostname
-
-<a id="datadog-receiver-use-tls-mtls-disabled"></a>
-
-### Datadog Receiver Use TLS mTLS Disabled
 
 <a id="datadog-receiver-use-tls-mtls-enable"></a>
 
@@ -484,19 +376,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `certificate` - (Optional) Client Certificate. Client certificate is PEM-encoded certificate or certificate-chain (`String`).
 
-`key_url` - (Optional) Secret. SecretType is used in an object to indicate a sensitive/confidential field. See [Key URL](#datadog-receiver-use-tls-mtls-enable-key-url) below.
-
-<a id="datadog-receiver-use-tls-mtls-enable-key-url"></a>
-
-### Datadog Receiver Use TLS mTLS Enable Key URL
-
-<a id="datadog-receiver-use-tls-no-ca"></a>
-
-### Datadog Receiver Use TLS No CA
-
-<a id="dns-logs"></a>
-
-### DNS Logs
+`key_url` - (Optional) Secret. SecretType is used in an object to indicate a sensitive/confidential field (`Block`).
 
 <a id="gcp-bucket-receiver"></a>
 
@@ -518,49 +398,25 @@ In addition to all arguments above, the following attributes are exported:
 
 `max_bytes` - (Optional) Max Bytes. Send batch to endpoint after the batch is equal to or larger than this many bytes (`Number`).
 
-`max_bytes_disabled` - (Optional) Empty. This can be used for messages where no values are needed. See [Max Bytes Disabled](#gcp-bucket-receiver-batch-max-bytes-disabled) below.
+`max_bytes_disabled` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `max_events` - (Optional) Max Events. Send batch to endpoint after this many log messages are in the batch (`Number`).
 
-`max_events_disabled` - (Optional) Empty. This can be used for messages where no values are needed. See [Max Events Disabled](#gcp-bucket-receiver-batch-max-events-disabled) below.
+`max_events_disabled` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `timeout_seconds` - (Optional) Timeout Seconds. Send batch to the endpoint after this many seconds (`String`).
 
-`timeout_seconds_default` - (Optional) Empty. This can be used for messages where no values are needed. See [Timeout Seconds Default](#gcp-bucket-receiver-batch-timeout-seconds-default) below.
-
-<a id="gcp-bucket-receiver-batch-max-bytes-disabled"></a>
-
-### GCP Bucket Receiver Batch Max Bytes Disabled
-
-<a id="gcp-bucket-receiver-batch-max-events-disabled"></a>
-
-### GCP Bucket Receiver Batch Max Events Disabled
-
-<a id="gcp-bucket-receiver-batch-timeout-seconds-default"></a>
-
-### GCP Bucket Receiver Batch Timeout Seconds Default
+`timeout_seconds_default` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="gcp-bucket-receiver-compression"></a>
 
 ### GCP Bucket Receiver Compression
 
-`compression_default` - (Optional) Empty. This can be used for messages where no values are needed. See [Compression Default](#gcp-bucket-receiver-compression-compression-default) below.
+`compression_default` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`compression_gzip` - (Optional) Empty. This can be used for messages where no values are needed. See [Compression Gzip](#gcp-bucket-receiver-compression-compression-gzip) below.
+`compression_gzip` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`compression_none` - (Optional) Empty. This can be used for messages where no values are needed. See [Compression None](#gcp-bucket-receiver-compression-compression-none) below.
-
-<a id="gcp-bucket-receiver-compression-compression-default"></a>
-
-### GCP Bucket Receiver Compression Compression Default
-
-<a id="gcp-bucket-receiver-compression-compression-gzip"></a>
-
-### GCP Bucket Receiver Compression Compression Gzip
-
-<a id="gcp-bucket-receiver-compression-compression-none"></a>
-
-### GCP Bucket Receiver Compression Compression None
+`compression_none` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="gcp-bucket-receiver-filename-options"></a>
 
@@ -568,17 +424,9 @@ In addition to all arguments above, the following attributes are exported:
 
 `custom_folder` - (Optional) Custom Folder. Use your own folder name as the name of the folder in the endpoint bucket or file The folder name must match `/^[a-z_]\[a-z0-9\-\._]*$/i` (`String`).
 
-`log_type_folder` - (Optional) Empty. This can be used for messages where no values are needed. See [Log Type Folder](#gcp-bucket-receiver-filename-options-log-type-folder) below.
+`log_type_folder` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_folder` - (Optional) Empty. This can be used for messages where no values are needed. See [No Folder](#gcp-bucket-receiver-filename-options-no-folder) below.
-
-<a id="gcp-bucket-receiver-filename-options-log-type-folder"></a>
-
-### GCP Bucket Receiver Filename Options Log Type Folder
-
-<a id="gcp-bucket-receiver-filename-options-no-folder"></a>
-
-### GCP Bucket Receiver Filename Options No Folder
+`no_folder` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="gcp-bucket-receiver-gcp-cred"></a>
 
@@ -596,7 +444,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `auth_basic` - (Optional) Basic Authentication Credentials. Authentication parameters to access HTPP Log Receiver Endpoint. See [Auth Basic](#http-receiver-auth-basic) below.
 
-`auth_none` - (Optional) Empty. This can be used for messages where no values are needed. See [Auth None](#http-receiver-auth-none) below.
+`auth_none` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `auth_token` - (Optional) Access Token. Authentication Token for access. See [Auth Token](#http-receiver-auth-token) below.
 
@@ -604,7 +452,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `compression` - (Optional) Compression Type. Compression Type. See [Compression](#http-receiver-compression) below.
 
-`no_tls` - (Optional) Empty. This can be used for messages where no values are needed. See [No TLS](#http-receiver-no-tls) below.
+`no_tls` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `uri` - (Optional) HTTP URI. HTTP URI is the URI of the HTTP endpoint to send logs to, example: `HTTP://example.com:9000/logs` (`String`).
 
@@ -622,21 +470,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ### HTTP Receiver Auth Basic Password
 
-`blindfold_secret_info` - (Optional) Blindfold Secret. BlindfoldSecretInfoType specifies information about the Secret managed by F5XC Secret Management. See [Blindfold Secret Info](#http-receiver-auth-basic-password-blindfold-secret-info) below.
+`blindfold_secret_info` - (Optional) Blindfold Secret. BlindfoldSecretInfoType specifies information about the Secret managed by F5XC Secret Management (`Block`).
 
-`clear_secret_info` - (Optional) In-Clear Secret. ClearSecretInfoType specifies information about the Secret that is not encrypted. See [Clear Secret Info](#http-receiver-auth-basic-password-clear-secret-info) below.
-
-<a id="http-receiver-auth-basic-password-blindfold-secret-info"></a>
-
-### HTTP Receiver Auth Basic Password Blindfold Secret Info
-
-<a id="http-receiver-auth-basic-password-clear-secret-info"></a>
-
-### HTTP Receiver Auth Basic Password Clear Secret Info
-
-<a id="http-receiver-auth-none"></a>
-
-### HTTP Receiver Auth None
+`clear_secret_info` - (Optional) In-Clear Secret. ClearSecretInfoType specifies information about the Secret that is not encrypted (`Block`).
 
 <a id="http-receiver-auth-token"></a>
 
@@ -648,17 +484,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ### HTTP Receiver Auth Token Token
 
-`blindfold_secret_info` - (Optional) Blindfold Secret. BlindfoldSecretInfoType specifies information about the Secret managed by F5XC Secret Management. See [Blindfold Secret Info](#http-receiver-auth-token-token-blindfold-secret-info) below.
+`blindfold_secret_info` - (Optional) Blindfold Secret. BlindfoldSecretInfoType specifies information about the Secret managed by F5XC Secret Management (`Block`).
 
-`clear_secret_info` - (Optional) In-Clear Secret. ClearSecretInfoType specifies information about the Secret that is not encrypted. See [Clear Secret Info](#http-receiver-auth-token-token-clear-secret-info) below.
-
-<a id="http-receiver-auth-token-token-blindfold-secret-info"></a>
-
-### HTTP Receiver Auth Token Token Blindfold Secret Info
-
-<a id="http-receiver-auth-token-token-clear-secret-info"></a>
-
-### HTTP Receiver Auth Token Token Clear Secret Info
+`clear_secret_info` - (Optional) In-Clear Secret. ClearSecretInfoType specifies information about the Secret that is not encrypted (`Block`).
 
 <a id="http-receiver-batch"></a>
 
@@ -666,93 +494,45 @@ In addition to all arguments above, the following attributes are exported:
 
 `max_bytes` - (Optional) Max Bytes. Send batch to endpoint after the batch is equal to or larger than this many bytes (`Number`).
 
-`max_bytes_disabled` - (Optional) Empty. This can be used for messages where no values are needed. See [Max Bytes Disabled](#http-receiver-batch-max-bytes-disabled) below.
+`max_bytes_disabled` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `max_events` - (Optional) Max Events. Send batch to endpoint after this many log messages are in the batch (`Number`).
 
-`max_events_disabled` - (Optional) Empty. This can be used for messages where no values are needed. See [Max Events Disabled](#http-receiver-batch-max-events-disabled) below.
+`max_events_disabled` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `timeout_seconds` - (Optional) Timeout Seconds. Send batch to the endpoint after this many seconds (`String`).
 
-`timeout_seconds_default` - (Optional) Empty. This can be used for messages where no values are needed. See [Timeout Seconds Default](#http-receiver-batch-timeout-seconds-default) below.
-
-<a id="http-receiver-batch-max-bytes-disabled"></a>
-
-### HTTP Receiver Batch Max Bytes Disabled
-
-<a id="http-receiver-batch-max-events-disabled"></a>
-
-### HTTP Receiver Batch Max Events Disabled
-
-<a id="http-receiver-batch-timeout-seconds-default"></a>
-
-### HTTP Receiver Batch Timeout Seconds Default
+`timeout_seconds_default` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="http-receiver-compression"></a>
 
 ### HTTP Receiver Compression
 
-`compression_default` - (Optional) Empty. This can be used for messages where no values are needed. See [Compression Default](#http-receiver-compression-compression-default) below.
+`compression_default` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`compression_gzip` - (Optional) Empty. This can be used for messages where no values are needed. See [Compression Gzip](#http-receiver-compression-compression-gzip) below.
+`compression_gzip` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`compression_none` - (Optional) Empty. This can be used for messages where no values are needed. See [Compression None](#http-receiver-compression-compression-none) below.
-
-<a id="http-receiver-compression-compression-default"></a>
-
-### HTTP Receiver Compression Compression Default
-
-<a id="http-receiver-compression-compression-gzip"></a>
-
-### HTTP Receiver Compression Compression Gzip
-
-<a id="http-receiver-compression-compression-none"></a>
-
-### HTTP Receiver Compression Compression None
-
-<a id="http-receiver-no-tls"></a>
-
-### HTTP Receiver No TLS
+`compression_none` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="http-receiver-use-tls"></a>
 
 ### HTTP Receiver Use TLS
 
-`disable_verify_certificate` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Verify Certificate](#http-receiver-use-tls-disable-verify-certificate) below.
+`disable_verify_certificate` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`disable_verify_hostname` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Verify Hostname](#http-receiver-use-tls-disable-verify-hostname) below.
+`disable_verify_hostname` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`enable_verify_certificate` - (Optional) Empty. This can be used for messages where no values are needed. See [Enable Verify Certificate](#http-receiver-use-tls-enable-verify-certificate) below.
+`enable_verify_certificate` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`enable_verify_hostname` - (Optional) Empty. This can be used for messages where no values are needed. See [Enable Verify Hostname](#http-receiver-use-tls-enable-verify-hostname) below.
+`enable_verify_hostname` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`mtls_disabled` - (Optional) Empty. This can be used for messages where no values are needed. See [mTLS Disabled](#http-receiver-use-tls-mtls-disabled) below.
+`mtls_disabled` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `mtls_enable` - (Optional) mTLS Client Config. mTLS Client config allows configuration of mTLS client options. See [mTLS Enable](#http-receiver-use-tls-mtls-enable) below.
 
-`no_ca` - (Optional) Empty. This can be used for messages where no values are needed. See [No CA](#http-receiver-use-tls-no-ca) below.
+`no_ca` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `trusted_ca_url` - (Optional) Server CA Certificates. The URL or value for trusted Server CA certificate or certificate chain Certificates in PEM format including the PEM headers (`String`).
-
-<a id="http-receiver-use-tls-disable-verify-certificate"></a>
-
-### HTTP Receiver Use TLS Disable Verify Certificate
-
-<a id="http-receiver-use-tls-disable-verify-hostname"></a>
-
-### HTTP Receiver Use TLS Disable Verify Hostname
-
-<a id="http-receiver-use-tls-enable-verify-certificate"></a>
-
-### HTTP Receiver Use TLS Enable Verify Certificate
-
-<a id="http-receiver-use-tls-enable-verify-hostname"></a>
-
-### HTTP Receiver Use TLS Enable Verify Hostname
-
-<a id="http-receiver-use-tls-mtls-disabled"></a>
-
-### HTTP Receiver Use TLS mTLS Disabled
 
 <a id="http-receiver-use-tls-mtls-enable"></a>
 
@@ -760,15 +540,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `certificate` - (Optional) Client Certificate. Client certificate is PEM-encoded certificate or certificate-chain (`String`).
 
-`key_url` - (Optional) Secret. SecretType is used in an object to indicate a sensitive/confidential field. See [Key URL](#http-receiver-use-tls-mtls-enable-key-url) below.
-
-<a id="http-receiver-use-tls-mtls-enable-key-url"></a>
-
-### HTTP Receiver Use TLS mTLS Enable Key URL
-
-<a id="http-receiver-use-tls-no-ca"></a>
-
-### HTTP Receiver Use TLS No CA
+`key_url` - (Optional) Secret. SecretType is used in an object to indicate a sensitive/confidential field (`Block`).
 
 <a id="kafka-receiver"></a>
 
@@ -782,7 +554,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `kafka_topic` - (Optional) Kafka Topic. The Kafka topic name to write events to (`String`).
 
-`no_tls` - (Optional) Empty. This can be used for messages where no values are needed. See [No TLS](#kafka-receiver-no-tls) below.
+`no_tls` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `use_tls` - (Optional) TLS Parameters Endpoint. TLS Parameters for client connection to the endpoint. See [Use TLS](#kafka-receiver-use-tls) below.
 
@@ -792,93 +564,45 @@ In addition to all arguments above, the following attributes are exported:
 
 `max_bytes` - (Optional) Max Bytes. Send batch to endpoint after the batch is equal to or larger than this many bytes (`Number`).
 
-`max_bytes_disabled` - (Optional) Empty. This can be used for messages where no values are needed. See [Max Bytes Disabled](#kafka-receiver-batch-max-bytes-disabled) below.
+`max_bytes_disabled` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `max_events` - (Optional) Max Events. Send batch to endpoint after this many log messages are in the batch (`Number`).
 
-`max_events_disabled` - (Optional) Empty. This can be used for messages where no values are needed. See [Max Events Disabled](#kafka-receiver-batch-max-events-disabled) below.
+`max_events_disabled` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `timeout_seconds` - (Optional) Timeout Seconds. Send batch to the endpoint after this many seconds (`String`).
 
-`timeout_seconds_default` - (Optional) Empty. This can be used for messages where no values are needed. See [Timeout Seconds Default](#kafka-receiver-batch-timeout-seconds-default) below.
-
-<a id="kafka-receiver-batch-max-bytes-disabled"></a>
-
-### Kafka Receiver Batch Max Bytes Disabled
-
-<a id="kafka-receiver-batch-max-events-disabled"></a>
-
-### Kafka Receiver Batch Max Events Disabled
-
-<a id="kafka-receiver-batch-timeout-seconds-default"></a>
-
-### Kafka Receiver Batch Timeout Seconds Default
+`timeout_seconds_default` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="kafka-receiver-compression"></a>
 
 ### Kafka Receiver Compression
 
-`compression_default` - (Optional) Empty. This can be used for messages where no values are needed. See [Compression Default](#kafka-receiver-compression-compression-default) below.
+`compression_default` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`compression_gzip` - (Optional) Empty. This can be used for messages where no values are needed. See [Compression Gzip](#kafka-receiver-compression-compression-gzip) below.
+`compression_gzip` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`compression_none` - (Optional) Empty. This can be used for messages where no values are needed. See [Compression None](#kafka-receiver-compression-compression-none) below.
-
-<a id="kafka-receiver-compression-compression-default"></a>
-
-### Kafka Receiver Compression Compression Default
-
-<a id="kafka-receiver-compression-compression-gzip"></a>
-
-### Kafka Receiver Compression Compression Gzip
-
-<a id="kafka-receiver-compression-compression-none"></a>
-
-### Kafka Receiver Compression Compression None
-
-<a id="kafka-receiver-no-tls"></a>
-
-### Kafka Receiver No TLS
+`compression_none` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="kafka-receiver-use-tls"></a>
 
 ### Kafka Receiver Use TLS
 
-`disable_verify_certificate` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Verify Certificate](#kafka-receiver-use-tls-disable-verify-certificate) below.
+`disable_verify_certificate` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`disable_verify_hostname` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Verify Hostname](#kafka-receiver-use-tls-disable-verify-hostname) below.
+`disable_verify_hostname` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`enable_verify_certificate` - (Optional) Empty. This can be used for messages where no values are needed. See [Enable Verify Certificate](#kafka-receiver-use-tls-enable-verify-certificate) below.
+`enable_verify_certificate` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`enable_verify_hostname` - (Optional) Empty. This can be used for messages where no values are needed. See [Enable Verify Hostname](#kafka-receiver-use-tls-enable-verify-hostname) below.
+`enable_verify_hostname` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`mtls_disabled` - (Optional) Empty. This can be used for messages where no values are needed. See [mTLS Disabled](#kafka-receiver-use-tls-mtls-disabled) below.
+`mtls_disabled` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `mtls_enable` - (Optional) mTLS Client Config. mTLS Client config allows configuration of mTLS client options. See [mTLS Enable](#kafka-receiver-use-tls-mtls-enable) below.
 
-`no_ca` - (Optional) Empty. This can be used for messages where no values are needed. See [No CA](#kafka-receiver-use-tls-no-ca) below.
+`no_ca` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `trusted_ca_url` - (Optional) Server CA Certificates. The URL or value for trusted Server CA certificate or certificate chain Certificates in PEM format including the PEM headers (`String`).
-
-<a id="kafka-receiver-use-tls-disable-verify-certificate"></a>
-
-### Kafka Receiver Use TLS Disable Verify Certificate
-
-<a id="kafka-receiver-use-tls-disable-verify-hostname"></a>
-
-### Kafka Receiver Use TLS Disable Verify Hostname
-
-<a id="kafka-receiver-use-tls-enable-verify-certificate"></a>
-
-### Kafka Receiver Use TLS Enable Verify Certificate
-
-<a id="kafka-receiver-use-tls-enable-verify-hostname"></a>
-
-### Kafka Receiver Use TLS Enable Verify Hostname
-
-<a id="kafka-receiver-use-tls-mtls-disabled"></a>
-
-### Kafka Receiver Use TLS mTLS Disabled
 
 <a id="kafka-receiver-use-tls-mtls-enable"></a>
 
@@ -886,15 +610,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `certificate` - (Optional) Client Certificate. Client certificate is PEM-encoded certificate or certificate-chain (`String`).
 
-`key_url` - (Optional) Secret. SecretType is used in an object to indicate a sensitive/confidential field. See [Key URL](#kafka-receiver-use-tls-mtls-enable-key-url) below.
-
-<a id="kafka-receiver-use-tls-mtls-enable-key-url"></a>
-
-### Kafka Receiver Use TLS mTLS Enable Key URL
-
-<a id="kafka-receiver-use-tls-no-ca"></a>
-
-### Kafka Receiver Use TLS No CA
+`key_url` - (Optional) Secret. SecretType is used in an object to indicate a sensitive/confidential field (`Block`).
 
 <a id="new-relic-receiver"></a>
 
@@ -902,9 +618,9 @@ In addition to all arguments above, the following attributes are exported:
 
 `api_key` - (Optional) Secret. SecretType is used in an object to indicate a sensitive/confidential field. See [API Key](#new-relic-receiver-api-key) below.
 
-`eu` - (Optional) Empty. This can be used for messages where no values are needed. See [Eu](#new-relic-receiver-eu) below.
+`eu` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`us` - (Optional) Empty. This can be used for messages where no values are needed. See [Us](#new-relic-receiver-us) below.
+`us` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="new-relic-receiver-api-key"></a>
 
@@ -932,22 +648,6 @@ In addition to all arguments above, the following attributes are exported:
 
 `url` - (Optional) URL. URL of the secret. Currently supported URL schemes is string:///. For string:/// scheme, Secret needs to be encoded Base64 format. When asked for this secret, caller will get Secret bytes after Base64 decoding (`String`).
 
-<a id="new-relic-receiver-eu"></a>
-
-### New Relic Receiver Eu
-
-<a id="new-relic-receiver-us"></a>
-
-### New Relic Receiver Us
-
-<a id="ns-all"></a>
-
-### Ns All
-
-<a id="ns-current"></a>
-
-### Ns Current
-
 <a id="ns-list"></a>
 
 ### Ns List
@@ -962,7 +662,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `compression` - (Optional) Compression Type. Compression Type. See [Compression](#qradar-receiver-compression) below.
 
-`no_tls` - (Optional) Empty. This can be used for messages where no values are needed. See [No TLS](#qradar-receiver-no-tls) below.
+`no_tls` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `uri` - (Optional) Log Source Collector URL. Log Source Collector URL is the URL of the IBM QRadar Log Source Collector to send logs to, example: `HTTP://example.com:9000` (`String`).
 
@@ -974,93 +674,45 @@ In addition to all arguments above, the following attributes are exported:
 
 `max_bytes` - (Optional) Max Bytes. Send batch to endpoint after the batch is equal to or larger than this many bytes (`Number`).
 
-`max_bytes_disabled` - (Optional) Empty. This can be used for messages where no values are needed. See [Max Bytes Disabled](#qradar-receiver-batch-max-bytes-disabled) below.
+`max_bytes_disabled` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `max_events` - (Optional) Max Events. Send batch to endpoint after this many log messages are in the batch (`Number`).
 
-`max_events_disabled` - (Optional) Empty. This can be used for messages where no values are needed. See [Max Events Disabled](#qradar-receiver-batch-max-events-disabled) below.
+`max_events_disabled` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `timeout_seconds` - (Optional) Timeout Seconds. Send batch to the endpoint after this many seconds (`String`).
 
-`timeout_seconds_default` - (Optional) Empty. This can be used for messages where no values are needed. See [Timeout Seconds Default](#qradar-receiver-batch-timeout-seconds-default) below.
-
-<a id="qradar-receiver-batch-max-bytes-disabled"></a>
-
-### Qradar Receiver Batch Max Bytes Disabled
-
-<a id="qradar-receiver-batch-max-events-disabled"></a>
-
-### Qradar Receiver Batch Max Events Disabled
-
-<a id="qradar-receiver-batch-timeout-seconds-default"></a>
-
-### Qradar Receiver Batch Timeout Seconds Default
+`timeout_seconds_default` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="qradar-receiver-compression"></a>
 
 ### Qradar Receiver Compression
 
-`compression_default` - (Optional) Empty. This can be used for messages where no values are needed. See [Compression Default](#qradar-receiver-compression-compression-default) below.
+`compression_default` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`compression_gzip` - (Optional) Empty. This can be used for messages where no values are needed. See [Compression Gzip](#qradar-receiver-compression-compression-gzip) below.
+`compression_gzip` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`compression_none` - (Optional) Empty. This can be used for messages where no values are needed. See [Compression None](#qradar-receiver-compression-compression-none) below.
-
-<a id="qradar-receiver-compression-compression-default"></a>
-
-### Qradar Receiver Compression Compression Default
-
-<a id="qradar-receiver-compression-compression-gzip"></a>
-
-### Qradar Receiver Compression Compression Gzip
-
-<a id="qradar-receiver-compression-compression-none"></a>
-
-### Qradar Receiver Compression Compression None
-
-<a id="qradar-receiver-no-tls"></a>
-
-### Qradar Receiver No TLS
+`compression_none` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="qradar-receiver-use-tls"></a>
 
 ### Qradar Receiver Use TLS
 
-`disable_verify_certificate` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Verify Certificate](#qradar-receiver-use-tls-disable-verify-certificate) below.
+`disable_verify_certificate` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`disable_verify_hostname` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Verify Hostname](#qradar-receiver-use-tls-disable-verify-hostname) below.
+`disable_verify_hostname` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`enable_verify_certificate` - (Optional) Empty. This can be used for messages where no values are needed. See [Enable Verify Certificate](#qradar-receiver-use-tls-enable-verify-certificate) below.
+`enable_verify_certificate` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`enable_verify_hostname` - (Optional) Empty. This can be used for messages where no values are needed. See [Enable Verify Hostname](#qradar-receiver-use-tls-enable-verify-hostname) below.
+`enable_verify_hostname` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`mtls_disabled` - (Optional) Empty. This can be used for messages where no values are needed. See [mTLS Disabled](#qradar-receiver-use-tls-mtls-disabled) below.
+`mtls_disabled` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `mtls_enable` - (Optional) mTLS Client Config. mTLS Client config allows configuration of mTLS client options. See [mTLS Enable](#qradar-receiver-use-tls-mtls-enable) below.
 
-`no_ca` - (Optional) Empty. This can be used for messages where no values are needed. See [No CA](#qradar-receiver-use-tls-no-ca) below.
+`no_ca` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `trusted_ca_url` - (Optional) Server CA Certificates. The URL or value for trusted Server CA certificate or certificate chain Certificates in PEM format including the PEM headers (`String`).
-
-<a id="qradar-receiver-use-tls-disable-verify-certificate"></a>
-
-### Qradar Receiver Use TLS Disable Verify Certificate
-
-<a id="qradar-receiver-use-tls-disable-verify-hostname"></a>
-
-### Qradar Receiver Use TLS Disable Verify Hostname
-
-<a id="qradar-receiver-use-tls-enable-verify-certificate"></a>
-
-### Qradar Receiver Use TLS Enable Verify Certificate
-
-<a id="qradar-receiver-use-tls-enable-verify-hostname"></a>
-
-### Qradar Receiver Use TLS Enable Verify Hostname
-
-<a id="qradar-receiver-use-tls-mtls-disabled"></a>
-
-### Qradar Receiver Use TLS mTLS Disabled
 
 <a id="qradar-receiver-use-tls-mtls-enable"></a>
 
@@ -1068,19 +720,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `certificate` - (Optional) Client Certificate. Client certificate is PEM-encoded certificate or certificate-chain (`String`).
 
-`key_url` - (Optional) Secret. SecretType is used in an object to indicate a sensitive/confidential field. See [Key URL](#qradar-receiver-use-tls-mtls-enable-key-url) below.
-
-<a id="qradar-receiver-use-tls-mtls-enable-key-url"></a>
-
-### Qradar Receiver Use TLS mTLS Enable Key URL
-
-<a id="qradar-receiver-use-tls-no-ca"></a>
-
-### Qradar Receiver Use TLS No CA
-
-<a id="request-logs"></a>
-
-### Request Logs
+`key_url` - (Optional) Secret. SecretType is used in an object to indicate a sensitive/confidential field (`Block`).
 
 <a id="s3-receiver"></a>
 
@@ -1114,49 +754,25 @@ In addition to all arguments above, the following attributes are exported:
 
 `max_bytes` - (Optional) Max Bytes. Send batch to endpoint after the batch is equal to or larger than this many bytes (`Number`).
 
-`max_bytes_disabled` - (Optional) Empty. This can be used for messages where no values are needed. See [Max Bytes Disabled](#s3-receiver-batch-max-bytes-disabled) below.
+`max_bytes_disabled` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `max_events` - (Optional) Max Events. Send batch to endpoint after this many log messages are in the batch (`Number`).
 
-`max_events_disabled` - (Optional) Empty. This can be used for messages where no values are needed. See [Max Events Disabled](#s3-receiver-batch-max-events-disabled) below.
+`max_events_disabled` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `timeout_seconds` - (Optional) Timeout Seconds. Send batch to the endpoint after this many seconds (`String`).
 
-`timeout_seconds_default` - (Optional) Empty. This can be used for messages where no values are needed. See [Timeout Seconds Default](#s3-receiver-batch-timeout-seconds-default) below.
-
-<a id="s3-receiver-batch-max-bytes-disabled"></a>
-
-### S3 Receiver Batch Max Bytes Disabled
-
-<a id="s3-receiver-batch-max-events-disabled"></a>
-
-### S3 Receiver Batch Max Events Disabled
-
-<a id="s3-receiver-batch-timeout-seconds-default"></a>
-
-### S3 Receiver Batch Timeout Seconds Default
+`timeout_seconds_default` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="s3-receiver-compression"></a>
 
 ### S3 Receiver Compression
 
-`compression_default` - (Optional) Empty. This can be used for messages where no values are needed. See [Compression Default](#s3-receiver-compression-compression-default) below.
+`compression_default` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`compression_gzip` - (Optional) Empty. This can be used for messages where no values are needed. See [Compression Gzip](#s3-receiver-compression-compression-gzip) below.
+`compression_gzip` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`compression_none` - (Optional) Empty. This can be used for messages where no values are needed. See [Compression None](#s3-receiver-compression-compression-none) below.
-
-<a id="s3-receiver-compression-compression-default"></a>
-
-### S3 Receiver Compression Compression Default
-
-<a id="s3-receiver-compression-compression-gzip"></a>
-
-### S3 Receiver Compression Compression Gzip
-
-<a id="s3-receiver-compression-compression-none"></a>
-
-### S3 Receiver Compression Compression None
+`compression_none` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="s3-receiver-filename-options"></a>
 
@@ -1164,21 +780,9 @@ In addition to all arguments above, the following attributes are exported:
 
 `custom_folder` - (Optional) Custom Folder. Use your own folder name as the name of the folder in the endpoint bucket or file The folder name must match `/^[a-z_]\[a-z0-9\-\._]*$/i` (`String`).
 
-`log_type_folder` - (Optional) Empty. This can be used for messages where no values are needed. See [Log Type Folder](#s3-receiver-filename-options-log-type-folder) below.
+`log_type_folder` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_folder` - (Optional) Empty. This can be used for messages where no values are needed. See [No Folder](#s3-receiver-filename-options-no-folder) below.
-
-<a id="s3-receiver-filename-options-log-type-folder"></a>
-
-### S3 Receiver Filename Options Log Type Folder
-
-<a id="s3-receiver-filename-options-no-folder"></a>
-
-### S3 Receiver Filename Options No Folder
-
-<a id="security-events"></a>
-
-### Security Events
+`no_folder` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="splunk-receiver"></a>
 
@@ -1190,7 +794,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `endpoint` - (Optional) Splunk HEC Logs Endpoint. Splunk HEC Logs Endpoint, example: `HTTPS://HTTP-input-hec.splunkcloud.com` (Note: must not contain `/services/collector`) (`String`).
 
-`no_tls` - (Optional) Empty. This can be used for messages where no values are needed. See [No TLS](#splunk-receiver-no-tls) below.
+`no_tls` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `splunk_hec_token` - (Optional) Secret. SecretType is used in an object to indicate a sensitive/confidential field. See [Splunk Hec Token](#splunk-receiver-splunk-hec-token) below.
 
@@ -1202,53 +806,25 @@ In addition to all arguments above, the following attributes are exported:
 
 `max_bytes` - (Optional) Max Bytes. Send batch to endpoint after the batch is equal to or larger than this many bytes (`Number`).
 
-`max_bytes_disabled` - (Optional) Empty. This can be used for messages where no values are needed. See [Max Bytes Disabled](#splunk-receiver-batch-max-bytes-disabled) below.
+`max_bytes_disabled` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `max_events` - (Optional) Max Events. Send batch to endpoint after this many log messages are in the batch (`Number`).
 
-`max_events_disabled` - (Optional) Empty. This can be used for messages where no values are needed. See [Max Events Disabled](#splunk-receiver-batch-max-events-disabled) below.
+`max_events_disabled` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `timeout_seconds` - (Optional) Timeout Seconds. Send batch to the endpoint after this many seconds (`String`).
 
-`timeout_seconds_default` - (Optional) Empty. This can be used for messages where no values are needed. See [Timeout Seconds Default](#splunk-receiver-batch-timeout-seconds-default) below.
-
-<a id="splunk-receiver-batch-max-bytes-disabled"></a>
-
-### Splunk Receiver Batch Max Bytes Disabled
-
-<a id="splunk-receiver-batch-max-events-disabled"></a>
-
-### Splunk Receiver Batch Max Events Disabled
-
-<a id="splunk-receiver-batch-timeout-seconds-default"></a>
-
-### Splunk Receiver Batch Timeout Seconds Default
+`timeout_seconds_default` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="splunk-receiver-compression"></a>
 
 ### Splunk Receiver Compression
 
-`compression_default` - (Optional) Empty. This can be used for messages where no values are needed. See [Compression Default](#splunk-receiver-compression-compression-default) below.
+`compression_default` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`compression_gzip` - (Optional) Empty. This can be used for messages where no values are needed. See [Compression Gzip](#splunk-receiver-compression-compression-gzip) below.
+`compression_gzip` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`compression_none` - (Optional) Empty. This can be used for messages where no values are needed. See [Compression None](#splunk-receiver-compression-compression-none) below.
-
-<a id="splunk-receiver-compression-compression-default"></a>
-
-### Splunk Receiver Compression Compression Default
-
-<a id="splunk-receiver-compression-compression-gzip"></a>
-
-### Splunk Receiver Compression Compression Gzip
-
-<a id="splunk-receiver-compression-compression-none"></a>
-
-### Splunk Receiver Compression Compression None
-
-<a id="splunk-receiver-no-tls"></a>
-
-### Splunk Receiver No TLS
+`compression_none` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="splunk-receiver-splunk-hec-token"></a>
 
@@ -1280,41 +856,21 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Splunk Receiver Use TLS
 
-`disable_verify_certificate` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Verify Certificate](#splunk-receiver-use-tls-disable-verify-certificate) below.
+`disable_verify_certificate` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`disable_verify_hostname` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Verify Hostname](#splunk-receiver-use-tls-disable-verify-hostname) below.
+`disable_verify_hostname` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`enable_verify_certificate` - (Optional) Empty. This can be used for messages where no values are needed. See [Enable Verify Certificate](#splunk-receiver-use-tls-enable-verify-certificate) below.
+`enable_verify_certificate` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`enable_verify_hostname` - (Optional) Empty. This can be used for messages where no values are needed. See [Enable Verify Hostname](#splunk-receiver-use-tls-enable-verify-hostname) below.
+`enable_verify_hostname` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`mtls_disabled` - (Optional) Empty. This can be used for messages where no values are needed. See [mTLS Disabled](#splunk-receiver-use-tls-mtls-disabled) below.
+`mtls_disabled` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `mtls_enable` - (Optional) mTLS Client Config. mTLS Client config allows configuration of mTLS client options. See [mTLS Enable](#splunk-receiver-use-tls-mtls-enable) below.
 
-`no_ca` - (Optional) Empty. This can be used for messages where no values are needed. See [No CA](#splunk-receiver-use-tls-no-ca) below.
+`no_ca` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `trusted_ca_url` - (Optional) Server CA Certificates. The URL or value for trusted Server CA certificate or certificate chain Certificates in PEM format including the PEM headers (`String`).
-
-<a id="splunk-receiver-use-tls-disable-verify-certificate"></a>
-
-### Splunk Receiver Use TLS Disable Verify Certificate
-
-<a id="splunk-receiver-use-tls-disable-verify-hostname"></a>
-
-### Splunk Receiver Use TLS Disable Verify Hostname
-
-<a id="splunk-receiver-use-tls-enable-verify-certificate"></a>
-
-### Splunk Receiver Use TLS Enable Verify Certificate
-
-<a id="splunk-receiver-use-tls-enable-verify-hostname"></a>
-
-### Splunk Receiver Use TLS Enable Verify Hostname
-
-<a id="splunk-receiver-use-tls-mtls-disabled"></a>
-
-### Splunk Receiver Use TLS mTLS Disabled
 
 <a id="splunk-receiver-use-tls-mtls-enable"></a>
 
@@ -1322,15 +878,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `certificate` - (Optional) Client Certificate. Client certificate is PEM-encoded certificate or certificate-chain (`String`).
 
-`key_url` - (Optional) Secret. SecretType is used in an object to indicate a sensitive/confidential field. See [Key URL](#splunk-receiver-use-tls-mtls-enable-key-url) below.
-
-<a id="splunk-receiver-use-tls-mtls-enable-key-url"></a>
-
-### Splunk Receiver Use TLS mTLS Enable Key URL
-
-<a id="splunk-receiver-use-tls-no-ca"></a>
-
-### Splunk Receiver Use TLS No CA
+`key_url` - (Optional) Secret. SecretType is used in an object to indicate a sensitive/confidential field (`Block`).
 
 <a id="sumo-logic-receiver"></a>
 

--- a/docs/resources/healthcheck.md
+++ b/docs/resources/healthcheck.md
@@ -69,7 +69,7 @@ resource "f5xc_healthcheck" "example" {
 
 `tcp_health_check` - (Optional) TCP Health Check. Healthy if TCP connection is successful and response payload matches <expected_response>. See [TCP Health Check](#tcp-health-check) below for details.
 
-`udp_icmp_health_check` - (Optional) Empty. This can be used for messages where no values are needed. See [UDP ICMP Health Check](#udp-icmp-health-check) below for details.
+`udp_icmp_health_check` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `interval` - (Optional) Interval. Time interval in seconds between two healthcheck requests (`Number`).
 
@@ -95,7 +95,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `expected_status_codes` - (Optional) Expected Status Codes. Specifies a list of HTTP response status codes considered healthy. To treat default HTTP expected status code 200 as healthy, user has to configure it explicitly. This is a list of strings, each of which is single HTTP status code or a range with start and end values separated by '-' (`List`).
 
-`headers` - (Optional) Request Headers to Add. Specifies a list of HTTP headers that should be added to each request that is sent to the health checked cluster. This is a list of key-value pairs. See [Headers](#http-health-check-headers) below.
+`headers` - (Optional) Request Headers to Add. Specifies a list of HTTP headers that should be added to each request that is sent to the health checked cluster. This is a list of key-value pairs (`Block`).
 
 `host_header` - (Optional) Host Header Value. The value of the host header (`String`).
 
@@ -105,15 +105,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `use_http2` - (Optional) Use HTTP2. If set, health checks will be made using HTTP/2 (`Bool`).
 
-`use_origin_server_name` - (Optional) Empty. This can be used for messages where no values are needed. See [Use Origin Server Name](#http-health-check-use-origin-server-name) below.
-
-<a id="http-health-check-headers"></a>
-
-### HTTP Health Check Headers
-
-<a id="http-health-check-use-origin-server-name"></a>
-
-### HTTP Health Check Use Origin Server Name
+`use_origin_server_name` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="tcp-health-check"></a>
 
@@ -134,10 +126,6 @@ In addition to all arguments above, the following attributes are exported:
 `read` - (Optional) A string that can be [parsed as a duration](`HTTPS://pkg.go.dev/time#ParseDuration`) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Read operations occur during any refresh or planning operation when refresh is enabled (`String`).
 
 `update` - (Optional) A string that can be [parsed as a duration](`HTTPS://pkg.go.dev/time#ParseDuration`) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours) (`String`).
-
-<a id="udp-icmp-health-check"></a>
-
-### UDP ICMP Health Check
 
 ## Import
 

--- a/docs/resources/http_loadbalancer.md
+++ b/docs/resources/http_loadbalancer.md
@@ -87,9 +87,9 @@ resource "f5xc_http_loadbalancer" "example" {
 
 `advertise_on_public` - (Optional) Advertise Public. This defines a way to advertise a load balancer on public. If optional public_ip is provided, it will only be advertised on RE sites where that public_ip is available. See [Advertise On Public](#advertise-on-public) below for details.
 
-`advertise_on_public_default_vip` - (Optional) Empty. This can be used for messages where no values are needed. See [Advertise On Public Default VIP](#advertise-on-public-default-vip) below for details.
+`advertise_on_public_default_vip` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`do_not_advertise` - (Optional) Empty. This can be used for messages where no values are needed. See [Do Not Advertise](#do-not-advertise) below for details.
+`do_not_advertise` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `api_protection_rules` - (Optional) API Protection Rules. API Protection Rules. See [API Protection Rules](#api-protection-rules) below for details.
 
@@ -97,7 +97,7 @@ resource "f5xc_http_loadbalancer" "example" {
 
 `api_rate_limit` - (Optional) APIRateLimit. See [API Rate Limit](#api-rate-limit) below for details.
 
-`disable_rate_limit` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Rate Limit](#disable-rate-limit) below for details.
+`disable_rate_limit` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `rate_limit` - (Optional) RateLimitConfigType. See [Rate Limit](#rate-limit) below for details.
 
@@ -105,19 +105,19 @@ resource "f5xc_http_loadbalancer" "example" {
 
 `api_specification` - (Optional) API Specification and Validation. Settings for API specification (API definition, OpenAPI validation, etc.). See [API Specification](#api-specification) below for details.
 
-`disable_api_definition` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable API Definition](#disable-api-definition) below for details.
+`disable_api_definition` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 > **Note:** One of the arguments from this list "api_testing, disable_api_testing" must be set.
 
 `api_testing` - (Optional) API Testing. See [API Testing](#api-testing) below for details.
 
-`disable_api_testing` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable API Testing](#disable-api-testing) below for details.
+`disable_api_testing` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 > **Note:** One of the arguments from this list "app_firewall, disable_waf" must be set.
 
 `app_firewall` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [App Firewall](#app-firewall) below for details.
 
-`disable_waf` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable WAF](#disable-waf) below for details.
+`disable_waf` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `blocked_clients` - (Optional) Client Blocking Rules. Define rules to block IP Prefixes or AS numbers. See [Blocked Clients](#blocked-clients) below for details.
 
@@ -127,13 +127,13 @@ resource "f5xc_http_loadbalancer" "example" {
 
 `bot_defense_advanced` - (Optional) Bot Defense Advanced. Bot Defense Advanced. See [Bot Defense Advanced](#bot-defense-advanced) below for details.
 
-`disable_bot_defense` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Bot Defense](#disable-bot-defense) below for details.
+`disable_bot_defense` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 > **Note:** One of the arguments from this list "caching_policy, disable_caching" must be set.
 
 `caching_policy` - (Optional) Caching Policies. x-required Caching Policies for the CDN. See [Caching Policy](#caching-policy) below for details.
 
-`disable_caching` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Caching](#disable-caching) below for details.
+`disable_caching` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 > **Note:** One of the arguments from this list "captcha_challenge, enable_challenge, js_challenge, no_challenge, policy_based_challenge" must be set.
 
@@ -143,7 +143,7 @@ resource "f5xc_http_loadbalancer" "example" {
 
 `js_challenge` - (Optional) Javascript Challenge Parameters. Enables loadbalancer to perform client browser compatibility test by redirecting to a page with Javascript. With this feature enabled, only clients that are capable of executing Javascript(mostly browsers) will be allowed to complete the HTTP request. When loadbalancer is configured to do Javascript Challenge, it will redirect the browser to an HTML page on every new HTTP request. This HTML page will have Javascript embedded in it. Loadbalancer chooses a set o. See [Js Challenge](#js-challenge) below for details.
 
-`no_challenge` - (Optional) Empty. This can be used for messages where no values are needed. See [No Challenge](#no-challenge) below for details.
+`no_challenge` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `policy_based_challenge` - (Optional) Policy Based Challenge. Specifies the settings for policy rule based challenge. See [Policy Based Challenge](#policy-based-challenge) below for details.
 
@@ -151,21 +151,21 @@ resource "f5xc_http_loadbalancer" "example" {
 
 `client_side_defense` - (Optional) Client-Side Defense. This defines various configuration options for Client-Side Defense Policy. See [Client Side Defense](#client-side-defense) below for details.
 
-`disable_client_side_defense` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Client Side Defense](#disable-client-side-defense) below for details.
+`disable_client_side_defense` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 > **Note:** One of the arguments from this list "cookie_stickiness, least_active, random, ring_hash, round_robin, source_ip_stickiness" must be set.
 
 `cookie_stickiness` - (Optional) Hashing using Cookie. Two types of cookie affinity: 1. Passive. Takes a cookie that's present in the cookies header and hashes on its value. 2. Generated. Generates and sets a cookie with an expiration (TTL) on the first request from the client in its response to the client, based on the endpoint the request gets sent to. The client then presents this on the next and all subsequent requests. The hash of this is sufficient to ensure these requests get sent to the same endpoint. The cookie is g. See [Cookie Stickiness](#cookie-stickiness) below for details.
 
-`least_active` - (Optional) Empty. This can be used for messages where no values are needed. See [Least Active](#least-active) below for details.
+`least_active` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`random` - (Optional) Empty. This can be used for messages where no values are needed. See [Random](#random) below for details.
+`random` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `ring_hash` - (Optional) Hash Policy List. List of hash policy rules. See [Ring Hash](#ring-hash) below for details.
 
-`round_robin` - (Optional) Empty. This can be used for messages where no values are needed. See [Round Robin](#round-robin) below for details.
+`round_robin` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`source_ip_stickiness` - (Optional) Empty. This can be used for messages where no values are needed. See [Source IP Stickiness](#source-ip-stickiness) below for details.
+`source_ip_stickiness` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `cors_policy` - (Optional) CORS Policy. Cross-Origin Resource Sharing requests configuration specified at Virtual-host or Route level. Route level configuration takes precedence. An example of an Cross origin HTTP request GET /resources/public-data/ HTTP/1.1 Host: bar.other User-Agent: Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.5; en-US; rv:1.9.1b3pre) Gecko/20081130 Minefield/3.1b3pre Accept: text/HTML,application/xhtml+XML,application/XML;q=0.9,*/*;q=0.8 Accept-Language: en-us,en;q=0.5 Accept-Encoding: gzip,deflate. See [CORS Policy](#cors-policy) below for details.
 
@@ -185,43 +185,43 @@ resource "f5xc_http_loadbalancer" "example" {
 
 > **Note:** One of the arguments from this list "default_sensitive_data_policy, sensitive_data_policy" must be set.
 
-`default_sensitive_data_policy` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Sensitive Data Policy](#default-sensitive-data-policy) below for details.
+`default_sensitive_data_policy` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `sensitive_data_policy` - (Optional) Sensitive Data Discovery. Settings for data type policy. See [Sensitive Data Policy](#sensitive-data-policy) below for details.
 
 > **Note:** One of the arguments from this list "disable_api_discovery, enable_api_discovery" must be set.
 
-`disable_api_discovery` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable API Discovery](#disable-api-discovery) below for details.
+`disable_api_discovery` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `enable_api_discovery` - (Optional) API Discovery Setting. Specifies the settings used for API discovery. See [Enable API Discovery](#enable-api-discovery) below for details.
 
 > **Note:** One of the arguments from this list "disable_ip_reputation, enable_ip_reputation" must be set.
 
-`disable_ip_reputation` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable IP Reputation](#disable-ip-reputation) below for details.
+`disable_ip_reputation` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `enable_ip_reputation` - (Optional) IP Threat Category List. List of IP threat categories. See [Enable IP Reputation](#enable-ip-reputation) below for details.
 
 > **Note:** One of the arguments from this list "disable_malicious_user_detection, enable_malicious_user_detection" must be set.
 
-`disable_malicious_user_detection` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Malicious User Detection](#disable-malicious-user-detection) below for details.
+`disable_malicious_user_detection` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`enable_malicious_user_detection` - (Optional) Empty. This can be used for messages where no values are needed. See [Enable Malicious User Detection](#enable-malicious-user-detection) below for details.
+`enable_malicious_user_detection` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 > **Note:** One of the arguments from this list "disable_malware_protection, malware_protection_settings" must be set.
 
-`disable_malware_protection` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Malware Protection](#disable-malware-protection) below for details.
+`disable_malware_protection` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `malware_protection_settings` - (Optional) Malware Protection Policy. Malware Protection protects Web Apps and APIs, from malicious file uploads by scanning files in real-time. See [Malware Protection Settings](#malware-protection-settings) below for details.
 
 > **Note:** One of the arguments from this list "disable_threat_mesh, enable_threat_mesh" must be set.
 
-`disable_threat_mesh` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Threat Mesh](#disable-threat-mesh) below for details.
+`disable_threat_mesh` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`enable_threat_mesh` - (Optional) Empty. This can be used for messages where no values are needed. See [Enable Threat Mesh](#enable-threat-mesh) below for details.
+`enable_threat_mesh` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 > **Note:** One of the arguments from this list "disable_trust_client_ip_headers, enable_trust_client_ip_headers" must be set.
 
-`disable_trust_client_ip_headers` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Trust Client IP Headers](#disable-trust-client-ip-headers) below for details.
+`disable_trust_client_ip_headers` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `enable_trust_client_ip_headers` - (Optional) Trust Client IP Headers List. List of Client IP Headers. See [Enable Trust Client IP Headers](#enable-trust-client-ip-headers) below for details.
 
@@ -241,9 +241,9 @@ resource "f5xc_http_loadbalancer" "example" {
 
 > **Note:** One of the arguments from this list "l7_ddos_action_block, l7_ddos_action_default, l7_ddos_action_js_challenge" must be set.
 
-`l7_ddos_action_block` - (Optional) Empty. This can be used for messages where no values are needed. See [L7 DDOS Action Block](#l7-ddos-action-block) below for details.
+`l7_ddos_action_block` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`l7_ddos_action_default` - (Optional) Empty. This can be used for messages where no values are needed. See [L7 DDOS Action Default](#l7-ddos-action-default) below for details.
+`l7_ddos_action_default` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `l7_ddos_action_js_challenge` - (Optional) Javascript Challenge Parameters. Enables loadbalancer to perform client browser compatibility test by redirecting to a page with Javascript. With this feature enabled, only clients that are capable of executing Javascript(mostly browsers) will be allowed to complete the HTTP request. When loadbalancer is configured to do Javascript Challenge, it will redirect the browser to an HTML page on every new HTTP request. This HTML page will have Javascript embedded in it. Loadbalancer chooses a set o. See [L7 DDOS Action Js Challenge](#l7-ddos-action-js-challenge) below for details.
 
@@ -253,11 +253,11 @@ resource "f5xc_http_loadbalancer" "example" {
 
 > **Note:** One of the arguments from this list "multi_lb_app, single_lb_app" must be set.
 
-`multi_lb_app` - (Optional) Empty. This can be used for messages where no values are needed. See [Multi LB App](#multi-lb-app) below for details.
+`multi_lb_app` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `single_lb_app` - (Optional) Single Load Balancer App Setting. Specific settings for Machine learning analysis on this HTTP LB, independently from other LBs. See [Single LB App](#single-lb-app) below for details.
 
-`no_service_policies` - (Optional) Empty. This can be used for messages where no values are needed. See [No Service Policies](#no-service-policies) below for details.
+`no_service_policies` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `origin_server_subset_rule_list` - (Optional) Origin Server Subset Rule List Type. List of Origin Pools. See [Origin Server Subset Rule List](#origin-server-subset-rule-list) below for details.
 
@@ -267,13 +267,13 @@ resource "f5xc_http_loadbalancer" "example" {
 
 `sensitive_data_disclosure_rules` - (Optional) Sensitive Data Exposure Rules. Sensitive Data Exposure Rules allows specifying rules to mask sensitive data fields in API responses. See [Sensitive Data Disclosure Rules](#sensitive-data-disclosure-rules) below for details.
 
-`service_policies_from_namespace` - (Optional) Empty. This can be used for messages where no values are needed. See [Service Policies From Namespace](#service-policies-from-namespace) below for details.
+`service_policies_from_namespace` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 > **Note:** One of the arguments from this list "slow_ddos_mitigation, system_default_timeouts" must be set.
 
 `slow_ddos_mitigation` - (Optional) Slow DDOS Mitigation. 'Slow and low' attacks tie up server resources, leaving none available for servicing requests from actual users. See [Slow DDOS Mitigation](#slow-ddos-mitigation) below for details.
 
-`system_default_timeouts` - (Optional) Empty. This can be used for messages where no values are needed. See [System Default Timeouts](#system-default-timeouts) below for details.
+`system_default_timeouts` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `timeouts` - (Optional) See [Timeouts](#timeouts) below for details.
 
@@ -281,7 +281,7 @@ resource "f5xc_http_loadbalancer" "example" {
 
 > **Note:** One of the arguments from this list "user_id_client_ip, user_identification" must be set.
 
-`user_id_client_ip` - (Optional) Empty. This can be used for messages where no values are needed. See [User Id Client IP](#user-id-client-ip) below for details.
+`user_id_client_ip` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `user_identification` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [User Identification](#user-identification) below for details.
 
@@ -329,7 +329,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `site` - (Optional) Site. This defines a reference to a CE site along with network type and an optional IP address where a load balancer could be advertised. See [Site](#advertise-custom-advertise-where-site) below.
 
-`use_default_port` - (Optional) Empty. This can be used for messages where no values are needed. See [Use Default Port](#advertise-custom-advertise-where-use-default-port) below.
+`use_default_port` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `virtual_network` - (Optional) Virtual Network. Parameters to advertise on a given virtual network. See [Virtual Network](#advertise-custom-advertise-where-virtual-network) below.
 
@@ -343,11 +343,7 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Advertise Custom Advertise Where Advertise On Public
 
-`public_ip` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Public IP](#advertise-custom-advertise-where-advertise-on-public-public-ip) below.
-
-<a id="advertise-custom-advertise-where-advertise-on-public-public-ip"></a>
-
-### Advertise Custom Advertise Where Advertise On Public Public IP
+`public_ip` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name (`Block`).
 
 <a id="advertise-custom-advertise-where-site"></a>
 
@@ -357,41 +353,21 @@ In addition to all arguments above, the following attributes are exported:
 
 `network` - (Optional) Site Network. This defines network types to be used on site All inside and outside networks. All inside and outside networks with internet VIP support. All inside networks. All outside networks. All outside networks with internet VIP support. vK8s service network. - SITE_NETWORK_IP_FABRIC: VER IP Fabric network for the site This Virtual network type is used for exposing virtual host on IP Fabric network on the VER site or for endpoint in IP Fabric network. Possible values are `SITE_NETWORK_INSIDE_AND_OUTSIDE`, `SITE_NETWORK_INSIDE`, `SITE_NETWORK_OUTSIDE`, `SITE_NETWORK_SERVICE`, `SITE_NETWORK_OUTSIDE_WITH_INTERNET_VIP`, `SITE_NETWORK_INSIDE_AND_OUTSIDE_WITH_INTERNET_VIP`, `SITE_NETWORK_IP_FABRIC`. Defaults to `SITE_NETWORK_INSIDE_AND_OUTSIDE` (`String`).
 
-`site` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Site](#advertise-custom-advertise-where-site-site) below.
-
-<a id="advertise-custom-advertise-where-site-site"></a>
-
-### Advertise Custom Advertise Where Site Site
-
-<a id="advertise-custom-advertise-where-use-default-port"></a>
-
-### Advertise Custom Advertise Where Use Default Port
+`site` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name (`Block`).
 
 <a id="advertise-custom-advertise-where-virtual-network"></a>
 
 ### Advertise Custom Advertise Where Virtual Network
 
-`default_v6_vip` - (Optional) Empty. This can be used for messages where no values are needed. See [Default V6 VIP](#advertise-custom-advertise-where-virtual-network-default-v6-vip) below.
+`default_v6_vip` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`default_vip` - (Optional) Empty. This can be used for messages where no values are needed. See [Default VIP](#advertise-custom-advertise-where-virtual-network-default-vip) below.
+`default_vip` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `specific_v6_vip` - (Optional) Specific V6 VIP. Use given IPv6 address as VIP on virtual Network (`String`).
 
 `specific_vip` - (Optional) Specific V4 VIP. Use given IPv4 address as VIP on virtual Network (`String`).
 
-`virtual_network` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Virtual Network](#advertise-custom-advertise-where-virtual-network-virtual-network) below.
-
-<a id="advertise-custom-advertise-where-virtual-network-default-v6-vip"></a>
-
-### Advertise Custom Advertise Where Virtual Network Default V6 VIP
-
-<a id="advertise-custom-advertise-where-virtual-network-default-vip"></a>
-
-### Advertise Custom Advertise Where Virtual Network Default VIP
-
-<a id="advertise-custom-advertise-where-virtual-network-virtual-network"></a>
-
-### Advertise Custom Advertise Where Virtual Network Virtual Network
+`virtual_network` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name (`Block`).
 
 <a id="advertise-custom-advertise-where-virtual-site"></a>
 
@@ -399,11 +375,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `network` - (Optional) Site Network. This defines network types to be used on site All inside and outside networks. All inside and outside networks with internet VIP support. All inside networks. All outside networks. All outside networks with internet VIP support. vK8s service network. - SITE_NETWORK_IP_FABRIC: VER IP Fabric network for the site This Virtual network type is used for exposing virtual host on IP Fabric network on the VER site or for endpoint in IP Fabric network. Possible values are `SITE_NETWORK_INSIDE_AND_OUTSIDE`, `SITE_NETWORK_INSIDE`, `SITE_NETWORK_OUTSIDE`, `SITE_NETWORK_SERVICE`, `SITE_NETWORK_OUTSIDE_WITH_INTERNET_VIP`, `SITE_NETWORK_INSIDE_AND_OUTSIDE_WITH_INTERNET_VIP`, `SITE_NETWORK_IP_FABRIC`. Defaults to `SITE_NETWORK_INSIDE_AND_OUTSIDE` (`String`).
 
-`virtual_site` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Virtual Site](#advertise-custom-advertise-where-virtual-site-virtual-site) below.
-
-<a id="advertise-custom-advertise-where-virtual-site-virtual-site"></a>
-
-### Advertise Custom Advertise Where Virtual Site Virtual Site
+`virtual_site` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name (`Block`).
 
 <a id="advertise-custom-advertise-where-virtual-site-with-vip"></a>
 
@@ -413,27 +385,15 @@ In addition to all arguments above, the following attributes are exported:
 
 `network` - (Optional) Site Network. This defines network types to be used on virtual-site with specified VIP All outside networks. All inside networks. Possible values are `SITE_NETWORK_SPECIFIED_VIP_OUTSIDE`, `SITE_NETWORK_SPECIFIED_VIP_INSIDE`. Defaults to `SITE_NETWORK_SPECIFIED_VIP_OUTSIDE` (`String`).
 
-`virtual_site` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Virtual Site](#advertise-custom-advertise-where-virtual-site-with-vip-virtual-site) below.
-
-<a id="advertise-custom-advertise-where-virtual-site-with-vip-virtual-site"></a>
-
-### Advertise Custom Advertise Where Virtual Site With VIP Virtual Site
+`virtual_site` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name (`Block`).
 
 <a id="advertise-custom-advertise-where-vk8s-service"></a>
 
 ### Advertise Custom Advertise Where Vk8s Service
 
-`site` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Site](#advertise-custom-advertise-where-vk8s-service-site) below.
+`site` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name (`Block`).
 
-`virtual_site` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Virtual Site](#advertise-custom-advertise-where-vk8s-service-virtual-site) below.
-
-<a id="advertise-custom-advertise-where-vk8s-service-site"></a>
-
-### Advertise Custom Advertise Where Vk8s Service Site
-
-<a id="advertise-custom-advertise-where-vk8s-service-virtual-site"></a>
-
-### Advertise Custom Advertise Where Vk8s Service Virtual Site
+`virtual_site` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name (`Block`).
 
 <a id="advertise-on-public"></a>
 
@@ -451,10 +411,6 @@ In addition to all arguments above, the following attributes are exported:
 
 `tenant` - (Optional) Tenant. When a configuration object(e.g. virtual_host) refers to another(e.g route) then tenant will hold the referred object's(e.g. route's) tenant (`String`).
 
-<a id="advertise-on-public-default-vip"></a>
-
-### Advertise On Public Default VIP
-
 <a id="api-protection-rules"></a>
 
 ### API Protection Rules
@@ -469,7 +425,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `action` - (Optional) API Protection Rule Action. The action to take if the input request matches the rule. See [Action](#api-protection-rules-api-endpoint-rules-action) below.
 
-`any_domain` - (Optional) Empty. This can be used for messages where no values are needed. See [Any Domain](#api-protection-rules-api-endpoint-rules-any-domain) below.
+`any_domain` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `api_endpoint_method` - (Optional) HTTP Method Matcher. A HTTP method matcher specifies a list of methods to match an input HTTP method. The match is considered successful if the input method is a member of the list. The result of the match based on the method list is inverted if invert_matcher is true. See [API Endpoint Method](#api-protection-rules-api-endpoint-rules-api-endpoint-method) below.
 
@@ -487,21 +443,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ### API Protection Rules API Endpoint Rules Action
 
-`allow` - (Optional) Empty. This can be used for messages where no values are needed. See [Allow](#api-protection-rules-api-endpoint-rules-action-allow) below.
+`allow` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`deny` - (Optional) Empty. This can be used for messages where no values are needed. See [Deny](#api-protection-rules-api-endpoint-rules-action-deny) below.
-
-<a id="api-protection-rules-api-endpoint-rules-action-allow"></a>
-
-### API Protection Rules API Endpoint Rules Action Allow
-
-<a id="api-protection-rules-api-endpoint-rules-action-deny"></a>
-
-### API Protection Rules API Endpoint Rules Action Deny
-
-<a id="api-protection-rules-api-endpoint-rules-any-domain"></a>
-
-### API Protection Rules API Endpoint Rules Any Domain
+`deny` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="api-protection-rules-api-endpoint-rules-api-endpoint-method"></a>
 
@@ -515,59 +459,23 @@ In addition to all arguments above, the following attributes are exported:
 
 ### API Protection Rules API Endpoint Rules Client Matcher
 
-`any_client` - (Optional) Empty. This can be used for messages where no values are needed. See [Any Client](#api-protection-rules-api-endpoint-rules-client-matcher-any-client) below.
+`any_client` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`any_ip` - (Optional) Empty. This can be used for messages where no values are needed. See [Any IP](#api-protection-rules-api-endpoint-rules-client-matcher-any-ip) below.
+`any_ip` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`asn_list` - (Optional) ASN Match List. An unordered set of RFC 6793 defined 4-byte AS numbers that can be used to create allow or deny lists for use in network policy or service policy. It can be used to create the allow list only for DNS Load Balancer. See [Asn List](#api-protection-rules-api-endpoint-rules-client-matcher-asn-list) below.
+`asn_list` - (Optional) ASN Match List. An unordered set of RFC 6793 defined 4-byte AS numbers that can be used to create allow or deny lists for use in network policy or service policy. It can be used to create the allow list only for DNS Load Balancer (`Block`).
 
-`asn_matcher` - (Optional) ASN Matcher. Match any AS number contained in the list of bgp_asn_sets. See [Asn Matcher](#api-protection-rules-api-endpoint-rules-client-matcher-asn-matcher) below.
+`asn_matcher` - (Optional) ASN Matcher. Match any AS number contained in the list of bgp_asn_sets (`Block`).
 
-`client_selector` - (Optional) Label Selector. This type can be used to establish a 'selector reference' from one object(called selector) to a set of other objects(called selectees) based on the value of expresssions. A label selector is a label query over a set of resources. An empty label selector matches all objects. A null label selector matches no objects. Label selector is immutable. expressions is a list of strings of label selection expression. Each string has ',' separated values which are 'AND' and all strings ar. See [Client Selector](#api-protection-rules-api-endpoint-rules-client-matcher-client-selector) below.
+`client_selector` - (Optional) Label Selector. This type can be used to establish a 'selector reference' from one object(called selector) to a set of other objects(called selectees) based on the value of expresssions. A label selector is a label query over a set of resources. An empty label selector matches all objects. A null label selector matches no objects. Label selector is immutable. expressions is a list of strings of label selection expression. Each string has ',' separated values which are 'AND' and all strings ar (`Block`).
 
-`ip_matcher` - (Optional) IP Prefix Matcher. Match any IP prefix contained in the list of ip_prefix_sets. The result of the match is inverted if invert_matcher is true. See [IP Matcher](#api-protection-rules-api-endpoint-rules-client-matcher-ip-matcher) below.
+`ip_matcher` - (Optional) IP Prefix Matcher. Match any IP prefix contained in the list of ip_prefix_sets. The result of the match is inverted if invert_matcher is true (`Block`).
 
-`ip_prefix_list` - (Optional) IP Prefix Match List. List of IP Prefix strings to match against. See [IP Prefix List](#api-protection-rules-api-endpoint-rules-client-matcher-ip-prefix-list) below.
+`ip_prefix_list` - (Optional) IP Prefix Match List. List of IP Prefix strings to match against (`Block`).
 
-`ip_threat_category_list` - (Optional) IP Threat Category List Type. List of IP threat categories. See [IP Threat Category List](#api-protection-rules-api-endpoint-rules-client-matcher-ip-threat-category-list) below.
+`ip_threat_category_list` - (Optional) IP Threat Category List Type. List of IP threat categories (`Block`).
 
-`tls_fingerprint_matcher` - (Optional) TLS Fingerprint Matcher. A TLS fingerprint matcher specifies multiple criteria for matching a TLS fingerprint. The set of supported positve match criteria includes a list of known classes of TLS fingerprints and a list of exact values. The match is considered successful if either of these positive criteria are satisfied and the input fingerprint is not one of the excluded values. See [TLS Fingerprint Matcher](#api-protection-rules-api-endpoint-rules-client-matcher-tls-fingerprint-matcher) below.
-
-<a id="api-protection-rules-api-endpoint-rules-client-matcher-any-client"></a>
-
-### API Protection Rules API Endpoint Rules Client Matcher Any Client
-
-<a id="api-protection-rules-api-endpoint-rules-client-matcher-any-ip"></a>
-
-### API Protection Rules API Endpoint Rules Client Matcher Any IP
-
-<a id="api-protection-rules-api-endpoint-rules-client-matcher-asn-list"></a>
-
-### API Protection Rules API Endpoint Rules Client Matcher Asn List
-
-<a id="api-protection-rules-api-endpoint-rules-client-matcher-asn-matcher"></a>
-
-### API Protection Rules API Endpoint Rules Client Matcher Asn Matcher
-
-<a id="api-protection-rules-api-endpoint-rules-client-matcher-client-selector"></a>
-
-### API Protection Rules API Endpoint Rules Client Matcher Client Selector
-
-<a id="api-protection-rules-api-endpoint-rules-client-matcher-ip-matcher"></a>
-
-### API Protection Rules API Endpoint Rules Client Matcher IP Matcher
-
-<a id="api-protection-rules-api-endpoint-rules-client-matcher-ip-prefix-list"></a>
-
-### API Protection Rules API Endpoint Rules Client Matcher IP Prefix List
-
-<a id="api-protection-rules-api-endpoint-rules-client-matcher-ip-threat-category-list"></a>
-
-### API Protection Rules API Endpoint Rules Client Matcher IP Threat Category List
-
-<a id="api-protection-rules-api-endpoint-rules-client-matcher-tls-fingerprint-matcher"></a>
-
-### API Protection Rules API Endpoint Rules Client Matcher TLS Fingerprint Matcher
+`tls_fingerprint_matcher` - (Optional) TLS Fingerprint Matcher. A TLS fingerprint matcher specifies multiple criteria for matching a TLS fingerprint. The set of supported positve match criteria includes a list of known classes of TLS fingerprints and a list of exact values. The match is considered successful if either of these positive criteria are satisfied and the input fingerprint is not one of the excluded values (`Block`).
 
 <a id="api-protection-rules-api-endpoint-rules-metadata"></a>
 
@@ -581,29 +489,13 @@ In addition to all arguments above, the following attributes are exported:
 
 ### API Protection Rules API Endpoint Rules Request Matcher
 
-`cookie_matchers` - (Optional) Cookie Matchers. A list of predicates for all cookies that need to be matched. The criteria for matching each cookie is described in individual instances of CookieMatcherType. The actual cookie values are extracted from the request API as a list of strings for each cookie name. Note that all specified cookie matcher predicates must evaluate to true. See [Cookie Matchers](#api-protection-rules-api-endpoint-rules-request-matcher-cookie-matchers) below.
+`cookie_matchers` - (Optional) Cookie Matchers. A list of predicates for all cookies that need to be matched. The criteria for matching each cookie is described in individual instances of CookieMatcherType. The actual cookie values are extracted from the request API as a list of strings for each cookie name. Note that all specified cookie matcher predicates must evaluate to true (`Block`).
 
-`headers` - (Optional) HTTP Headers. A list of predicates for various HTTP headers that need to match. The criteria for matching each HTTP header are described in individual HeaderMatcherType instances. The actual HTTP header values are extracted from the request API as a list of strings for each HTTP header type. Note that all specified header predicates must evaluate to true. See [Headers](#api-protection-rules-api-endpoint-rules-request-matcher-headers) below.
+`headers` - (Optional) HTTP Headers. A list of predicates for various HTTP headers that need to match. The criteria for matching each HTTP header are described in individual HeaderMatcherType instances. The actual HTTP header values are extracted from the request API as a list of strings for each HTTP header type. Note that all specified header predicates must evaluate to true (`Block`).
 
-`jwt_claims` - (Optional) JWT Claims. A list of predicates for various JWT claims that need to match. The criteria for matching each JWT claim are described in individual JWTClaimMatcherType instances. The actual JWT claims values are extracted from the JWT payload as a list of strings. Note that all specified JWT claim predicates must evaluate to true. Note that this feature only works on LBs with JWT Validation feature enabled. See [JWT Claims](#api-protection-rules-api-endpoint-rules-request-matcher-jwt-claims) below.
+`jwt_claims` - (Optional) JWT Claims. A list of predicates for various JWT claims that need to match. The criteria for matching each JWT claim are described in individual JWTClaimMatcherType instances. The actual JWT claims values are extracted from the JWT payload as a list of strings. Note that all specified JWT claim predicates must evaluate to true. Note that this feature only works on LBs with JWT Validation feature enabled (`Block`).
 
-`query_params` - (Optional) HTTP Query Parameters. A list of predicates for all query parameters that need to be matched. The criteria for matching each query parameter are described in individual instances of QueryParameterMatcherType. The actual query parameter values are extracted from the request API as a list of strings for each query parameter name. Note that all specified query parameter predicates must evaluate to true. See [Query Params](#api-protection-rules-api-endpoint-rules-request-matcher-query-params) below.
-
-<a id="api-protection-rules-api-endpoint-rules-request-matcher-cookie-matchers"></a>
-
-### API Protection Rules API Endpoint Rules Request Matcher Cookie Matchers
-
-<a id="api-protection-rules-api-endpoint-rules-request-matcher-headers"></a>
-
-### API Protection Rules API Endpoint Rules Request Matcher Headers
-
-<a id="api-protection-rules-api-endpoint-rules-request-matcher-jwt-claims"></a>
-
-### API Protection Rules API Endpoint Rules Request Matcher JWT Claims
-
-<a id="api-protection-rules-api-endpoint-rules-request-matcher-query-params"></a>
-
-### API Protection Rules API Endpoint Rules Request Matcher Query Params
+`query_params` - (Optional) HTTP Query Parameters. A list of predicates for all query parameters that need to be matched. The criteria for matching each query parameter are described in individual instances of QueryParameterMatcherType. The actual query parameter values are extracted from the request API as a list of strings for each query parameter name. Note that all specified query parameter predicates must evaluate to true (`Block`).
 
 <a id="api-protection-rules-api-groups-rules"></a>
 
@@ -611,7 +503,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `action` - (Optional) API Protection Rule Action. The action to take if the input request matches the rule. See [Action](#api-protection-rules-api-groups-rules-action) below.
 
-`any_domain` - (Optional) Empty. This can be used for messages where no values are needed. See [Any Domain](#api-protection-rules-api-groups-rules-any-domain) below.
+`any_domain` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `api_group` - (Optional) API Group. API groups derived from API Definition swaggers. For example oas-all-operations including all paths and methods from the swaggers, oas-base-urls covering all requests under base-paths from the swaggers. Custom groups can be created if user tags paths or operations with 'x-volterra-API-group' extensions inside swaggers (`String`).
 
@@ -629,79 +521,31 @@ In addition to all arguments above, the following attributes are exported:
 
 ### API Protection Rules API Groups Rules Action
 
-`allow` - (Optional) Empty. This can be used for messages where no values are needed. See [Allow](#api-protection-rules-api-groups-rules-action-allow) below.
+`allow` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`deny` - (Optional) Empty. This can be used for messages where no values are needed. See [Deny](#api-protection-rules-api-groups-rules-action-deny) below.
-
-<a id="api-protection-rules-api-groups-rules-action-allow"></a>
-
-### API Protection Rules API Groups Rules Action Allow
-
-<a id="api-protection-rules-api-groups-rules-action-deny"></a>
-
-### API Protection Rules API Groups Rules Action Deny
-
-<a id="api-protection-rules-api-groups-rules-any-domain"></a>
-
-### API Protection Rules API Groups Rules Any Domain
+`deny` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="api-protection-rules-api-groups-rules-client-matcher"></a>
 
 ### API Protection Rules API Groups Rules Client Matcher
 
-`any_client` - (Optional) Empty. This can be used for messages where no values are needed. See [Any Client](#api-protection-rules-api-groups-rules-client-matcher-any-client) below.
+`any_client` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`any_ip` - (Optional) Empty. This can be used for messages where no values are needed. See [Any IP](#api-protection-rules-api-groups-rules-client-matcher-any-ip) below.
+`any_ip` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`asn_list` - (Optional) ASN Match List. An unordered set of RFC 6793 defined 4-byte AS numbers that can be used to create allow or deny lists for use in network policy or service policy. It can be used to create the allow list only for DNS Load Balancer. See [Asn List](#api-protection-rules-api-groups-rules-client-matcher-asn-list) below.
+`asn_list` - (Optional) ASN Match List. An unordered set of RFC 6793 defined 4-byte AS numbers that can be used to create allow or deny lists for use in network policy or service policy. It can be used to create the allow list only for DNS Load Balancer (`Block`).
 
-`asn_matcher` - (Optional) ASN Matcher. Match any AS number contained in the list of bgp_asn_sets. See [Asn Matcher](#api-protection-rules-api-groups-rules-client-matcher-asn-matcher) below.
+`asn_matcher` - (Optional) ASN Matcher. Match any AS number contained in the list of bgp_asn_sets (`Block`).
 
-`client_selector` - (Optional) Label Selector. This type can be used to establish a 'selector reference' from one object(called selector) to a set of other objects(called selectees) based on the value of expresssions. A label selector is a label query over a set of resources. An empty label selector matches all objects. A null label selector matches no objects. Label selector is immutable. expressions is a list of strings of label selection expression. Each string has ',' separated values which are 'AND' and all strings ar. See [Client Selector](#api-protection-rules-api-groups-rules-client-matcher-client-selector) below.
+`client_selector` - (Optional) Label Selector. This type can be used to establish a 'selector reference' from one object(called selector) to a set of other objects(called selectees) based on the value of expresssions. A label selector is a label query over a set of resources. An empty label selector matches all objects. A null label selector matches no objects. Label selector is immutable. expressions is a list of strings of label selection expression. Each string has ',' separated values which are 'AND' and all strings ar (`Block`).
 
-`ip_matcher` - (Optional) IP Prefix Matcher. Match any IP prefix contained in the list of ip_prefix_sets. The result of the match is inverted if invert_matcher is true. See [IP Matcher](#api-protection-rules-api-groups-rules-client-matcher-ip-matcher) below.
+`ip_matcher` - (Optional) IP Prefix Matcher. Match any IP prefix contained in the list of ip_prefix_sets. The result of the match is inverted if invert_matcher is true (`Block`).
 
-`ip_prefix_list` - (Optional) IP Prefix Match List. List of IP Prefix strings to match against. See [IP Prefix List](#api-protection-rules-api-groups-rules-client-matcher-ip-prefix-list) below.
+`ip_prefix_list` - (Optional) IP Prefix Match List. List of IP Prefix strings to match against (`Block`).
 
-`ip_threat_category_list` - (Optional) IP Threat Category List Type. List of IP threat categories. See [IP Threat Category List](#api-protection-rules-api-groups-rules-client-matcher-ip-threat-category-list) below.
+`ip_threat_category_list` - (Optional) IP Threat Category List Type. List of IP threat categories (`Block`).
 
-`tls_fingerprint_matcher` - (Optional) TLS Fingerprint Matcher. A TLS fingerprint matcher specifies multiple criteria for matching a TLS fingerprint. The set of supported positve match criteria includes a list of known classes of TLS fingerprints and a list of exact values. The match is considered successful if either of these positive criteria are satisfied and the input fingerprint is not one of the excluded values. See [TLS Fingerprint Matcher](#api-protection-rules-api-groups-rules-client-matcher-tls-fingerprint-matcher) below.
-
-<a id="api-protection-rules-api-groups-rules-client-matcher-any-client"></a>
-
-### API Protection Rules API Groups Rules Client Matcher Any Client
-
-<a id="api-protection-rules-api-groups-rules-client-matcher-any-ip"></a>
-
-### API Protection Rules API Groups Rules Client Matcher Any IP
-
-<a id="api-protection-rules-api-groups-rules-client-matcher-asn-list"></a>
-
-### API Protection Rules API Groups Rules Client Matcher Asn List
-
-<a id="api-protection-rules-api-groups-rules-client-matcher-asn-matcher"></a>
-
-### API Protection Rules API Groups Rules Client Matcher Asn Matcher
-
-<a id="api-protection-rules-api-groups-rules-client-matcher-client-selector"></a>
-
-### API Protection Rules API Groups Rules Client Matcher Client Selector
-
-<a id="api-protection-rules-api-groups-rules-client-matcher-ip-matcher"></a>
-
-### API Protection Rules API Groups Rules Client Matcher IP Matcher
-
-<a id="api-protection-rules-api-groups-rules-client-matcher-ip-prefix-list"></a>
-
-### API Protection Rules API Groups Rules Client Matcher IP Prefix List
-
-<a id="api-protection-rules-api-groups-rules-client-matcher-ip-threat-category-list"></a>
-
-### API Protection Rules API Groups Rules Client Matcher IP Threat Category List
-
-<a id="api-protection-rules-api-groups-rules-client-matcher-tls-fingerprint-matcher"></a>
-
-### API Protection Rules API Groups Rules Client Matcher TLS Fingerprint Matcher
+`tls_fingerprint_matcher` - (Optional) TLS Fingerprint Matcher. A TLS fingerprint matcher specifies multiple criteria for matching a TLS fingerprint. The set of supported positve match criteria includes a list of known classes of TLS fingerprints and a list of exact values. The match is considered successful if either of these positive criteria are satisfied and the input fingerprint is not one of the excluded values (`Block`).
 
 <a id="api-protection-rules-api-groups-rules-metadata"></a>
 
@@ -715,29 +559,13 @@ In addition to all arguments above, the following attributes are exported:
 
 ### API Protection Rules API Groups Rules Request Matcher
 
-`cookie_matchers` - (Optional) Cookie Matchers. A list of predicates for all cookies that need to be matched. The criteria for matching each cookie is described in individual instances of CookieMatcherType. The actual cookie values are extracted from the request API as a list of strings for each cookie name. Note that all specified cookie matcher predicates must evaluate to true. See [Cookie Matchers](#api-protection-rules-api-groups-rules-request-matcher-cookie-matchers) below.
+`cookie_matchers` - (Optional) Cookie Matchers. A list of predicates for all cookies that need to be matched. The criteria for matching each cookie is described in individual instances of CookieMatcherType. The actual cookie values are extracted from the request API as a list of strings for each cookie name. Note that all specified cookie matcher predicates must evaluate to true (`Block`).
 
-`headers` - (Optional) HTTP Headers. A list of predicates for various HTTP headers that need to match. The criteria for matching each HTTP header are described in individual HeaderMatcherType instances. The actual HTTP header values are extracted from the request API as a list of strings for each HTTP header type. Note that all specified header predicates must evaluate to true. See [Headers](#api-protection-rules-api-groups-rules-request-matcher-headers) below.
+`headers` - (Optional) HTTP Headers. A list of predicates for various HTTP headers that need to match. The criteria for matching each HTTP header are described in individual HeaderMatcherType instances. The actual HTTP header values are extracted from the request API as a list of strings for each HTTP header type. Note that all specified header predicates must evaluate to true (`Block`).
 
-`jwt_claims` - (Optional) JWT Claims. A list of predicates for various JWT claims that need to match. The criteria for matching each JWT claim are described in individual JWTClaimMatcherType instances. The actual JWT claims values are extracted from the JWT payload as a list of strings. Note that all specified JWT claim predicates must evaluate to true. Note that this feature only works on LBs with JWT Validation feature enabled. See [JWT Claims](#api-protection-rules-api-groups-rules-request-matcher-jwt-claims) below.
+`jwt_claims` - (Optional) JWT Claims. A list of predicates for various JWT claims that need to match. The criteria for matching each JWT claim are described in individual JWTClaimMatcherType instances. The actual JWT claims values are extracted from the JWT payload as a list of strings. Note that all specified JWT claim predicates must evaluate to true. Note that this feature only works on LBs with JWT Validation feature enabled (`Block`).
 
-`query_params` - (Optional) HTTP Query Parameters. A list of predicates for all query parameters that need to be matched. The criteria for matching each query parameter are described in individual instances of QueryParameterMatcherType. The actual query parameter values are extracted from the request API as a list of strings for each query parameter name. Note that all specified query parameter predicates must evaluate to true. See [Query Params](#api-protection-rules-api-groups-rules-request-matcher-query-params) below.
-
-<a id="api-protection-rules-api-groups-rules-request-matcher-cookie-matchers"></a>
-
-### API Protection Rules API Groups Rules Request Matcher Cookie Matchers
-
-<a id="api-protection-rules-api-groups-rules-request-matcher-headers"></a>
-
-### API Protection Rules API Groups Rules Request Matcher Headers
-
-<a id="api-protection-rules-api-groups-rules-request-matcher-jwt-claims"></a>
-
-### API Protection Rules API Groups Rules Request Matcher JWT Claims
-
-<a id="api-protection-rules-api-groups-rules-request-matcher-query-params"></a>
-
-### API Protection Rules API Groups Rules Request Matcher Query Params
+`query_params` - (Optional) HTTP Query Parameters. A list of predicates for all query parameters that need to be matched. The criteria for matching each query parameter are described in individual instances of QueryParameterMatcherType. The actual query parameter values are extracted from the request API as a list of strings for each query parameter name. Note that all specified query parameter predicates must evaluate to true (`Block`).
 
 <a id="api-rate-limit"></a>
 
@@ -751,7 +579,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `ip_allowed_list` - (Optional) IPv4 Prefix List. x-example: '192.168.20.0/24' List of IPv4 prefixes that represent an endpoint. See [IP Allowed List](#api-rate-limit-ip-allowed-list) below.
 
-`no_ip_allowed_list` - (Optional) Empty. This can be used for messages where no values are needed. See [No IP Allowed List](#api-rate-limit-no-ip-allowed-list) below.
+`no_ip_allowed_list` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `server_url_rules` - (Optional) Server URLs. Set of rules for entire domain or base path that contain multiple endpoints. Order is matter as it uses first match policy. For matching also specific endpoints you can use the API endpoint rules set bellow. See [Server URL Rules](#api-rate-limit-server-url-rules) below.
 
@@ -759,7 +587,7 @@ In addition to all arguments above, the following attributes are exported:
 
 ### API Rate Limit API Endpoint Rules
 
-`any_domain` - (Optional) Empty. This can be used for messages where no values are needed. See [Any Domain](#api-rate-limit-api-endpoint-rules-any-domain) below.
+`any_domain` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `api_endpoint_method` - (Optional) HTTP Method Matcher. A HTTP method matcher specifies a list of methods to match an input HTTP method. The match is considered successful if the input method is a member of the list. The result of the match based on the method list is inverted if invert_matcher is true. See [API Endpoint Method](#api-rate-limit-api-endpoint-rules-api-endpoint-method) below.
 
@@ -775,10 +603,6 @@ In addition to all arguments above, the following attributes are exported:
 
 `specific_domain` - (Optional) Specific Domain. The rule will apply for a specific domain (`String`).
 
-<a id="api-rate-limit-api-endpoint-rules-any-domain"></a>
-
-### API Rate Limit API Endpoint Rules Any Domain
-
 <a id="api-rate-limit-api-endpoint-rules-api-endpoint-method"></a>
 
 ### API Rate Limit API Endpoint Rules API Endpoint Method
@@ -791,79 +615,35 @@ In addition to all arguments above, the following attributes are exported:
 
 ### API Rate Limit API Endpoint Rules Client Matcher
 
-`any_client` - (Optional) Empty. This can be used for messages where no values are needed. See [Any Client](#api-rate-limit-api-endpoint-rules-client-matcher-any-client) below.
+`any_client` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`any_ip` - (Optional) Empty. This can be used for messages where no values are needed. See [Any IP](#api-rate-limit-api-endpoint-rules-client-matcher-any-ip) below.
+`any_ip` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`asn_list` - (Optional) ASN Match List. An unordered set of RFC 6793 defined 4-byte AS numbers that can be used to create allow or deny lists for use in network policy or service policy. It can be used to create the allow list only for DNS Load Balancer. See [Asn List](#api-rate-limit-api-endpoint-rules-client-matcher-asn-list) below.
+`asn_list` - (Optional) ASN Match List. An unordered set of RFC 6793 defined 4-byte AS numbers that can be used to create allow or deny lists for use in network policy or service policy. It can be used to create the allow list only for DNS Load Balancer (`Block`).
 
-`asn_matcher` - (Optional) ASN Matcher. Match any AS number contained in the list of bgp_asn_sets. See [Asn Matcher](#api-rate-limit-api-endpoint-rules-client-matcher-asn-matcher) below.
+`asn_matcher` - (Optional) ASN Matcher. Match any AS number contained in the list of bgp_asn_sets (`Block`).
 
-`client_selector` - (Optional) Label Selector. This type can be used to establish a 'selector reference' from one object(called selector) to a set of other objects(called selectees) based on the value of expresssions. A label selector is a label query over a set of resources. An empty label selector matches all objects. A null label selector matches no objects. Label selector is immutable. expressions is a list of strings of label selection expression. Each string has ',' separated values which are 'AND' and all strings ar. See [Client Selector](#api-rate-limit-api-endpoint-rules-client-matcher-client-selector) below.
+`client_selector` - (Optional) Label Selector. This type can be used to establish a 'selector reference' from one object(called selector) to a set of other objects(called selectees) based on the value of expresssions. A label selector is a label query over a set of resources. An empty label selector matches all objects. A null label selector matches no objects. Label selector is immutable. expressions is a list of strings of label selection expression. Each string has ',' separated values which are 'AND' and all strings ar (`Block`).
 
-`ip_matcher` - (Optional) IP Prefix Matcher. Match any IP prefix contained in the list of ip_prefix_sets. The result of the match is inverted if invert_matcher is true. See [IP Matcher](#api-rate-limit-api-endpoint-rules-client-matcher-ip-matcher) below.
+`ip_matcher` - (Optional) IP Prefix Matcher. Match any IP prefix contained in the list of ip_prefix_sets. The result of the match is inverted if invert_matcher is true (`Block`).
 
-`ip_prefix_list` - (Optional) IP Prefix Match List. List of IP Prefix strings to match against. See [IP Prefix List](#api-rate-limit-api-endpoint-rules-client-matcher-ip-prefix-list) below.
+`ip_prefix_list` - (Optional) IP Prefix Match List. List of IP Prefix strings to match against (`Block`).
 
-`ip_threat_category_list` - (Optional) IP Threat Category List Type. List of IP threat categories. See [IP Threat Category List](#api-rate-limit-api-endpoint-rules-client-matcher-ip-threat-category-list) below.
+`ip_threat_category_list` - (Optional) IP Threat Category List Type. List of IP threat categories (`Block`).
 
-`tls_fingerprint_matcher` - (Optional) TLS Fingerprint Matcher. A TLS fingerprint matcher specifies multiple criteria for matching a TLS fingerprint. The set of supported positve match criteria includes a list of known classes of TLS fingerprints and a list of exact values. The match is considered successful if either of these positive criteria are satisfied and the input fingerprint is not one of the excluded values. See [TLS Fingerprint Matcher](#api-rate-limit-api-endpoint-rules-client-matcher-tls-fingerprint-matcher) below.
-
-<a id="api-rate-limit-api-endpoint-rules-client-matcher-any-client"></a>
-
-### API Rate Limit API Endpoint Rules Client Matcher Any Client
-
-<a id="api-rate-limit-api-endpoint-rules-client-matcher-any-ip"></a>
-
-### API Rate Limit API Endpoint Rules Client Matcher Any IP
-
-<a id="api-rate-limit-api-endpoint-rules-client-matcher-asn-list"></a>
-
-### API Rate Limit API Endpoint Rules Client Matcher Asn List
-
-<a id="api-rate-limit-api-endpoint-rules-client-matcher-asn-matcher"></a>
-
-### API Rate Limit API Endpoint Rules Client Matcher Asn Matcher
-
-<a id="api-rate-limit-api-endpoint-rules-client-matcher-client-selector"></a>
-
-### API Rate Limit API Endpoint Rules Client Matcher Client Selector
-
-<a id="api-rate-limit-api-endpoint-rules-client-matcher-ip-matcher"></a>
-
-### API Rate Limit API Endpoint Rules Client Matcher IP Matcher
-
-<a id="api-rate-limit-api-endpoint-rules-client-matcher-ip-prefix-list"></a>
-
-### API Rate Limit API Endpoint Rules Client Matcher IP Prefix List
-
-<a id="api-rate-limit-api-endpoint-rules-client-matcher-ip-threat-category-list"></a>
-
-### API Rate Limit API Endpoint Rules Client Matcher IP Threat Category List
-
-<a id="api-rate-limit-api-endpoint-rules-client-matcher-tls-fingerprint-matcher"></a>
-
-### API Rate Limit API Endpoint Rules Client Matcher TLS Fingerprint Matcher
+`tls_fingerprint_matcher` - (Optional) TLS Fingerprint Matcher. A TLS fingerprint matcher specifies multiple criteria for matching a TLS fingerprint. The set of supported positve match criteria includes a list of known classes of TLS fingerprints and a list of exact values. The match is considered successful if either of these positive criteria are satisfied and the input fingerprint is not one of the excluded values (`Block`).
 
 <a id="api-rate-limit-api-endpoint-rules-inline-rate-limiter"></a>
 
 ### API Rate Limit API Endpoint Rules Inline Rate Limiter
 
-`ref_user_id` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Ref User Id](#api-rate-limit-api-endpoint-rules-inline-rate-limiter-ref-user-id) below.
+`ref_user_id` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name (`Block`).
 
 `threshold` - (Optional) Threshold. The total number of allowed requests for 1 unit (e.g. SECOND/MINUTE/HOUR etc.) of the specified period (`Number`).
 
 `unit` - (Optional) Rate Limit Period Unit. Unit for the period per which the rate limit is applied. - SECOND: Second Rate limit period unit is seconds - MINUTE: Minute Rate limit period unit is minutes - HOUR: Hour Rate limit period unit is hours - DAY: Day Rate limit period unit is days. Possible values are `SECOND`, `MINUTE`, `HOUR`. Defaults to `SECOND` (`String`).
 
-`use_http_lb_user_id` - (Optional) Empty. This can be used for messages where no values are needed. See [Use HTTP LB User Id](#api-rate-limit-api-endpoint-rules-inline-rate-limiter-use-http-lb-user-id) below.
-
-<a id="api-rate-limit-api-endpoint-rules-inline-rate-limiter-ref-user-id"></a>
-
-### API Rate Limit API Endpoint Rules Inline Rate Limiter Ref User Id
-
-<a id="api-rate-limit-api-endpoint-rules-inline-rate-limiter-use-http-lb-user-id"></a>
-
-### API Rate Limit API Endpoint Rules Inline Rate Limiter Use HTTP LB User Id
+`use_http_lb_user_id` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="api-rate-limit-api-endpoint-rules-ref-rate-limiter"></a>
 
@@ -879,29 +659,13 @@ In addition to all arguments above, the following attributes are exported:
 
 ### API Rate Limit API Endpoint Rules Request Matcher
 
-`cookie_matchers` - (Optional) Cookie Matchers. A list of predicates for all cookies that need to be matched. The criteria for matching each cookie is described in individual instances of CookieMatcherType. The actual cookie values are extracted from the request API as a list of strings for each cookie name. Note that all specified cookie matcher predicates must evaluate to true. See [Cookie Matchers](#api-rate-limit-api-endpoint-rules-request-matcher-cookie-matchers) below.
+`cookie_matchers` - (Optional) Cookie Matchers. A list of predicates for all cookies that need to be matched. The criteria for matching each cookie is described in individual instances of CookieMatcherType. The actual cookie values are extracted from the request API as a list of strings for each cookie name. Note that all specified cookie matcher predicates must evaluate to true (`Block`).
 
-`headers` - (Optional) HTTP Headers. A list of predicates for various HTTP headers that need to match. The criteria for matching each HTTP header are described in individual HeaderMatcherType instances. The actual HTTP header values are extracted from the request API as a list of strings for each HTTP header type. Note that all specified header predicates must evaluate to true. See [Headers](#api-rate-limit-api-endpoint-rules-request-matcher-headers) below.
+`headers` - (Optional) HTTP Headers. A list of predicates for various HTTP headers that need to match. The criteria for matching each HTTP header are described in individual HeaderMatcherType instances. The actual HTTP header values are extracted from the request API as a list of strings for each HTTP header type. Note that all specified header predicates must evaluate to true (`Block`).
 
-`jwt_claims` - (Optional) JWT Claims. A list of predicates for various JWT claims that need to match. The criteria for matching each JWT claim are described in individual JWTClaimMatcherType instances. The actual JWT claims values are extracted from the JWT payload as a list of strings. Note that all specified JWT claim predicates must evaluate to true. Note that this feature only works on LBs with JWT Validation feature enabled. See [JWT Claims](#api-rate-limit-api-endpoint-rules-request-matcher-jwt-claims) below.
+`jwt_claims` - (Optional) JWT Claims. A list of predicates for various JWT claims that need to match. The criteria for matching each JWT claim are described in individual JWTClaimMatcherType instances. The actual JWT claims values are extracted from the JWT payload as a list of strings. Note that all specified JWT claim predicates must evaluate to true. Note that this feature only works on LBs with JWT Validation feature enabled (`Block`).
 
-`query_params` - (Optional) HTTP Query Parameters. A list of predicates for all query parameters that need to be matched. The criteria for matching each query parameter are described in individual instances of QueryParameterMatcherType. The actual query parameter values are extracted from the request API as a list of strings for each query parameter name. Note that all specified query parameter predicates must evaluate to true. See [Query Params](#api-rate-limit-api-endpoint-rules-request-matcher-query-params) below.
-
-<a id="api-rate-limit-api-endpoint-rules-request-matcher-cookie-matchers"></a>
-
-### API Rate Limit API Endpoint Rules Request Matcher Cookie Matchers
-
-<a id="api-rate-limit-api-endpoint-rules-request-matcher-headers"></a>
-
-### API Rate Limit API Endpoint Rules Request Matcher Headers
-
-<a id="api-rate-limit-api-endpoint-rules-request-matcher-jwt-claims"></a>
-
-### API Rate Limit API Endpoint Rules Request Matcher JWT Claims
-
-<a id="api-rate-limit-api-endpoint-rules-request-matcher-query-params"></a>
-
-### API Rate Limit API Endpoint Rules Request Matcher Query Params
+`query_params` - (Optional) HTTP Query Parameters. A list of predicates for all query parameters that need to be matched. The criteria for matching each query parameter are described in individual instances of QueryParameterMatcherType. The actual query parameter values are extracted from the request API as a list of strings for each query parameter name. Note that all specified query parameter predicates must evaluate to true (`Block`).
 
 <a id="api-rate-limit-bypass-rate-limiting-rules"></a>
 
@@ -913,45 +677,21 @@ In addition to all arguments above, the following attributes are exported:
 
 ### API Rate Limit Bypass Rate Limiting Rules Bypass Rate Limiting Rules
 
-`any_domain` - (Optional) Empty. This can be used for messages where no values are needed. See [Any Domain](#api-rate-limit-bypass-rate-limiting-rules-bypass-rate-limiting-rules-any-domain) below.
+`any_domain` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`any_url` - (Optional) Empty. This can be used for messages where no values are needed. See [Any URL](#api-rate-limit-bypass-rate-limiting-rules-bypass-rate-limiting-rules-any-url) below.
+`any_url` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`api_endpoint` - (Optional) API Endpoint. This defines API endpoint. See [API Endpoint](#api-rate-limit-bypass-rate-limiting-rules-bypass-rate-limiting-rules-api-endpoint) below.
+`api_endpoint` - (Optional) API Endpoint. This defines API endpoint (`Block`).
 
-`api_groups` - (Optional) API Groups. See [API Groups](#api-rate-limit-bypass-rate-limiting-rules-bypass-rate-limiting-rules-api-groups) below.
+`api_groups` - (Optional) API Groups (`Block`).
 
 `base_path` - (Optional) Base Path. The base path which this validation applies to (`String`).
 
-`client_matcher` - (Optional) Client Matcher. Client conditions for matching a rule. See [Client Matcher](#api-rate-limit-bypass-rate-limiting-rules-bypass-rate-limiting-rules-client-matcher) below.
+`client_matcher` - (Optional) Client Matcher. Client conditions for matching a rule (`Block`).
 
-`request_matcher` - (Optional) Request Matcher. Request conditions for matching a rule. See [Request Matcher](#api-rate-limit-bypass-rate-limiting-rules-bypass-rate-limiting-rules-request-matcher) below.
+`request_matcher` - (Optional) Request Matcher. Request conditions for matching a rule (`Block`).
 
 `specific_domain` - (Optional) Specific Domain. The rule will apply for a specific domain. For example: API.example.com (`String`).
-
-<a id="api-rate-limit-bypass-rate-limiting-rules-bypass-rate-limiting-rules-any-domain"></a>
-
-### API Rate Limit Bypass Rate Limiting Rules Bypass Rate Limiting Rules Any Domain
-
-<a id="api-rate-limit-bypass-rate-limiting-rules-bypass-rate-limiting-rules-any-url"></a>
-
-### API Rate Limit Bypass Rate Limiting Rules Bypass Rate Limiting Rules Any URL
-
-<a id="api-rate-limit-bypass-rate-limiting-rules-bypass-rate-limiting-rules-api-endpoint"></a>
-
-### API Rate Limit Bypass Rate Limiting Rules Bypass Rate Limiting Rules API Endpoint
-
-<a id="api-rate-limit-bypass-rate-limiting-rules-bypass-rate-limiting-rules-api-groups"></a>
-
-### API Rate Limit Bypass Rate Limiting Rules Bypass Rate Limiting Rules API Groups
-
-<a id="api-rate-limit-bypass-rate-limiting-rules-bypass-rate-limiting-rules-client-matcher"></a>
-
-### API Rate Limit Bypass Rate Limiting Rules Bypass Rate Limiting Rules Client Matcher
-
-<a id="api-rate-limit-bypass-rate-limiting-rules-bypass-rate-limiting-rules-request-matcher"></a>
-
-### API Rate Limit Bypass Rate Limiting Rules Bypass Rate Limiting Rules Request Matcher
 
 <a id="api-rate-limit-custom-ip-allowed-list"></a>
 
@@ -975,15 +715,11 @@ In addition to all arguments above, the following attributes are exported:
 
 `prefixes` - (Optional) IPv4 Prefix List. List of IPv4 prefixes that represent an endpoint (`List`).
 
-<a id="api-rate-limit-no-ip-allowed-list"></a>
-
-### API Rate Limit No IP Allowed List
-
 <a id="api-rate-limit-server-url-rules"></a>
 
 ### API Rate Limit Server URL Rules
 
-`any_domain` - (Optional) Empty. This can be used for messages where no values are needed. See [Any Domain](#api-rate-limit-server-url-rules-any-domain) below.
+`any_domain` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `api_group` - (Optional) API Group. API groups derived from API Definition swaggers. For example oas-all-operations including all paths and methods from the swaggers, oas-base-urls covering all requests under base-paths from the swaggers. Custom groups can be created if user tags paths or operations with 'x-volterra-API-group' extensions inside swaggers (`String`).
 
@@ -999,87 +735,39 @@ In addition to all arguments above, the following attributes are exported:
 
 `specific_domain` - (Optional) Specific Domain. The rule will apply for a specific domain (`String`).
 
-<a id="api-rate-limit-server-url-rules-any-domain"></a>
-
-### API Rate Limit Server URL Rules Any Domain
-
 <a id="api-rate-limit-server-url-rules-client-matcher"></a>
 
 ### API Rate Limit Server URL Rules Client Matcher
 
-`any_client` - (Optional) Empty. This can be used for messages where no values are needed. See [Any Client](#api-rate-limit-server-url-rules-client-matcher-any-client) below.
+`any_client` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`any_ip` - (Optional) Empty. This can be used for messages where no values are needed. See [Any IP](#api-rate-limit-server-url-rules-client-matcher-any-ip) below.
+`any_ip` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`asn_list` - (Optional) ASN Match List. An unordered set of RFC 6793 defined 4-byte AS numbers that can be used to create allow or deny lists for use in network policy or service policy. It can be used to create the allow list only for DNS Load Balancer. See [Asn List](#api-rate-limit-server-url-rules-client-matcher-asn-list) below.
+`asn_list` - (Optional) ASN Match List. An unordered set of RFC 6793 defined 4-byte AS numbers that can be used to create allow or deny lists for use in network policy or service policy. It can be used to create the allow list only for DNS Load Balancer (`Block`).
 
-`asn_matcher` - (Optional) ASN Matcher. Match any AS number contained in the list of bgp_asn_sets. See [Asn Matcher](#api-rate-limit-server-url-rules-client-matcher-asn-matcher) below.
+`asn_matcher` - (Optional) ASN Matcher. Match any AS number contained in the list of bgp_asn_sets (`Block`).
 
-`client_selector` - (Optional) Label Selector. This type can be used to establish a 'selector reference' from one object(called selector) to a set of other objects(called selectees) based on the value of expresssions. A label selector is a label query over a set of resources. An empty label selector matches all objects. A null label selector matches no objects. Label selector is immutable. expressions is a list of strings of label selection expression. Each string has ',' separated values which are 'AND' and all strings ar. See [Client Selector](#api-rate-limit-server-url-rules-client-matcher-client-selector) below.
+`client_selector` - (Optional) Label Selector. This type can be used to establish a 'selector reference' from one object(called selector) to a set of other objects(called selectees) based on the value of expresssions. A label selector is a label query over a set of resources. An empty label selector matches all objects. A null label selector matches no objects. Label selector is immutable. expressions is a list of strings of label selection expression. Each string has ',' separated values which are 'AND' and all strings ar (`Block`).
 
-`ip_matcher` - (Optional) IP Prefix Matcher. Match any IP prefix contained in the list of ip_prefix_sets. The result of the match is inverted if invert_matcher is true. See [IP Matcher](#api-rate-limit-server-url-rules-client-matcher-ip-matcher) below.
+`ip_matcher` - (Optional) IP Prefix Matcher. Match any IP prefix contained in the list of ip_prefix_sets. The result of the match is inverted if invert_matcher is true (`Block`).
 
-`ip_prefix_list` - (Optional) IP Prefix Match List. List of IP Prefix strings to match against. See [IP Prefix List](#api-rate-limit-server-url-rules-client-matcher-ip-prefix-list) below.
+`ip_prefix_list` - (Optional) IP Prefix Match List. List of IP Prefix strings to match against (`Block`).
 
-`ip_threat_category_list` - (Optional) IP Threat Category List Type. List of IP threat categories. See [IP Threat Category List](#api-rate-limit-server-url-rules-client-matcher-ip-threat-category-list) below.
+`ip_threat_category_list` - (Optional) IP Threat Category List Type. List of IP threat categories (`Block`).
 
-`tls_fingerprint_matcher` - (Optional) TLS Fingerprint Matcher. A TLS fingerprint matcher specifies multiple criteria for matching a TLS fingerprint. The set of supported positve match criteria includes a list of known classes of TLS fingerprints and a list of exact values. The match is considered successful if either of these positive criteria are satisfied and the input fingerprint is not one of the excluded values. See [TLS Fingerprint Matcher](#api-rate-limit-server-url-rules-client-matcher-tls-fingerprint-matcher) below.
-
-<a id="api-rate-limit-server-url-rules-client-matcher-any-client"></a>
-
-### API Rate Limit Server URL Rules Client Matcher Any Client
-
-<a id="api-rate-limit-server-url-rules-client-matcher-any-ip"></a>
-
-### API Rate Limit Server URL Rules Client Matcher Any IP
-
-<a id="api-rate-limit-server-url-rules-client-matcher-asn-list"></a>
-
-### API Rate Limit Server URL Rules Client Matcher Asn List
-
-<a id="api-rate-limit-server-url-rules-client-matcher-asn-matcher"></a>
-
-### API Rate Limit Server URL Rules Client Matcher Asn Matcher
-
-<a id="api-rate-limit-server-url-rules-client-matcher-client-selector"></a>
-
-### API Rate Limit Server URL Rules Client Matcher Client Selector
-
-<a id="api-rate-limit-server-url-rules-client-matcher-ip-matcher"></a>
-
-### API Rate Limit Server URL Rules Client Matcher IP Matcher
-
-<a id="api-rate-limit-server-url-rules-client-matcher-ip-prefix-list"></a>
-
-### API Rate Limit Server URL Rules Client Matcher IP Prefix List
-
-<a id="api-rate-limit-server-url-rules-client-matcher-ip-threat-category-list"></a>
-
-### API Rate Limit Server URL Rules Client Matcher IP Threat Category List
-
-<a id="api-rate-limit-server-url-rules-client-matcher-tls-fingerprint-matcher"></a>
-
-### API Rate Limit Server URL Rules Client Matcher TLS Fingerprint Matcher
+`tls_fingerprint_matcher` - (Optional) TLS Fingerprint Matcher. A TLS fingerprint matcher specifies multiple criteria for matching a TLS fingerprint. The set of supported positve match criteria includes a list of known classes of TLS fingerprints and a list of exact values. The match is considered successful if either of these positive criteria are satisfied and the input fingerprint is not one of the excluded values (`Block`).
 
 <a id="api-rate-limit-server-url-rules-inline-rate-limiter"></a>
 
 ### API Rate Limit Server URL Rules Inline Rate Limiter
 
-`ref_user_id` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Ref User Id](#api-rate-limit-server-url-rules-inline-rate-limiter-ref-user-id) below.
+`ref_user_id` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name (`Block`).
 
 `threshold` - (Optional) Threshold. The total number of allowed requests for 1 unit (e.g. SECOND/MINUTE/HOUR etc.) of the specified period (`Number`).
 
 `unit` - (Optional) Rate Limit Period Unit. Unit for the period per which the rate limit is applied. - SECOND: Second Rate limit period unit is seconds - MINUTE: Minute Rate limit period unit is minutes - HOUR: Hour Rate limit period unit is hours - DAY: Day Rate limit period unit is days. Possible values are `SECOND`, `MINUTE`, `HOUR`. Defaults to `SECOND` (`String`).
 
-`use_http_lb_user_id` - (Optional) Empty. This can be used for messages where no values are needed. See [Use HTTP LB User Id](#api-rate-limit-server-url-rules-inline-rate-limiter-use-http-lb-user-id) below.
-
-<a id="api-rate-limit-server-url-rules-inline-rate-limiter-ref-user-id"></a>
-
-### API Rate Limit Server URL Rules Inline Rate Limiter Ref User Id
-
-<a id="api-rate-limit-server-url-rules-inline-rate-limiter-use-http-lb-user-id"></a>
-
-### API Rate Limit Server URL Rules Inline Rate Limiter Use HTTP LB User Id
+`use_http_lb_user_id` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="api-rate-limit-server-url-rules-ref-rate-limiter"></a>
 
@@ -1095,29 +783,13 @@ In addition to all arguments above, the following attributes are exported:
 
 ### API Rate Limit Server URL Rules Request Matcher
 
-`cookie_matchers` - (Optional) Cookie Matchers. A list of predicates for all cookies that need to be matched. The criteria for matching each cookie is described in individual instances of CookieMatcherType. The actual cookie values are extracted from the request API as a list of strings for each cookie name. Note that all specified cookie matcher predicates must evaluate to true. See [Cookie Matchers](#api-rate-limit-server-url-rules-request-matcher-cookie-matchers) below.
+`cookie_matchers` - (Optional) Cookie Matchers. A list of predicates for all cookies that need to be matched. The criteria for matching each cookie is described in individual instances of CookieMatcherType. The actual cookie values are extracted from the request API as a list of strings for each cookie name. Note that all specified cookie matcher predicates must evaluate to true (`Block`).
 
-`headers` - (Optional) HTTP Headers. A list of predicates for various HTTP headers that need to match. The criteria for matching each HTTP header are described in individual HeaderMatcherType instances. The actual HTTP header values are extracted from the request API as a list of strings for each HTTP header type. Note that all specified header predicates must evaluate to true. See [Headers](#api-rate-limit-server-url-rules-request-matcher-headers) below.
+`headers` - (Optional) HTTP Headers. A list of predicates for various HTTP headers that need to match. The criteria for matching each HTTP header are described in individual HeaderMatcherType instances. The actual HTTP header values are extracted from the request API as a list of strings for each HTTP header type. Note that all specified header predicates must evaluate to true (`Block`).
 
-`jwt_claims` - (Optional) JWT Claims. A list of predicates for various JWT claims that need to match. The criteria for matching each JWT claim are described in individual JWTClaimMatcherType instances. The actual JWT claims values are extracted from the JWT payload as a list of strings. Note that all specified JWT claim predicates must evaluate to true. Note that this feature only works on LBs with JWT Validation feature enabled. See [JWT Claims](#api-rate-limit-server-url-rules-request-matcher-jwt-claims) below.
+`jwt_claims` - (Optional) JWT Claims. A list of predicates for various JWT claims that need to match. The criteria for matching each JWT claim are described in individual JWTClaimMatcherType instances. The actual JWT claims values are extracted from the JWT payload as a list of strings. Note that all specified JWT claim predicates must evaluate to true. Note that this feature only works on LBs with JWT Validation feature enabled (`Block`).
 
-`query_params` - (Optional) HTTP Query Parameters. A list of predicates for all query parameters that need to be matched. The criteria for matching each query parameter are described in individual instances of QueryParameterMatcherType. The actual query parameter values are extracted from the request API as a list of strings for each query parameter name. Note that all specified query parameter predicates must evaluate to true. See [Query Params](#api-rate-limit-server-url-rules-request-matcher-query-params) below.
-
-<a id="api-rate-limit-server-url-rules-request-matcher-cookie-matchers"></a>
-
-### API Rate Limit Server URL Rules Request Matcher Cookie Matchers
-
-<a id="api-rate-limit-server-url-rules-request-matcher-headers"></a>
-
-### API Rate Limit Server URL Rules Request Matcher Headers
-
-<a id="api-rate-limit-server-url-rules-request-matcher-jwt-claims"></a>
-
-### API Rate Limit Server URL Rules Request Matcher JWT Claims
-
-<a id="api-rate-limit-server-url-rules-request-matcher-query-params"></a>
-
-### API Rate Limit Server URL Rules Request Matcher Query Params
+`query_params` - (Optional) HTTP Query Parameters. A list of predicates for all query parameters that need to be matched. The criteria for matching each query parameter are described in individual instances of QueryParameterMatcherType. The actual query parameter values are extracted from the request API as a list of strings for each query parameter name. Note that all specified query parameter predicates must evaluate to true (`Block`).
 
 <a id="api-specification"></a>
 
@@ -1129,7 +801,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `validation_custom_list` - (Optional) Custom List. Define API groups, base paths, or API endpoints and their OpenAPI validation modes. Any other API-endpoint not listed will act according to 'Fall Through Mode'. See [Validation Custom List](#api-specification-validation-custom-list) below.
 
-`validation_disabled` - (Optional) Empty. This can be used for messages where no values are needed. See [Validation Disabled](#api-specification-validation-disabled) below.
+`validation_disabled` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="api-specification-api-definition"></a>
 
@@ -1155,73 +827,33 @@ In addition to all arguments above, the following attributes are exported:
 
 ### API Specification Validation All Spec Endpoints Fall Through Mode
 
-`fall_through_mode_allow` - (Optional) Empty. This can be used for messages where no values are needed. See [Fall Through Mode Allow](#api-specification-validation-all-spec-endpoints-fall-through-mode-fall-through-mode-allow) below.
+`fall_through_mode_allow` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`fall_through_mode_custom` - (Optional) Custom Fall Through Mode. Define the fall through settings. See [Fall Through Mode Custom](#api-specification-validation-all-spec-endpoints-fall-through-mode-fall-through-mode-custom) below.
-
-<a id="api-specification-validation-all-spec-endpoints-fall-through-mode-fall-through-mode-allow"></a>
-
-### API Specification Validation All Spec Endpoints Fall Through Mode Fall Through Mode Allow
-
-<a id="api-specification-validation-all-spec-endpoints-fall-through-mode-fall-through-mode-custom"></a>
-
-### API Specification Validation All Spec Endpoints Fall Through Mode Fall Through Mode Custom
+`fall_through_mode_custom` - (Optional) Custom Fall Through Mode. Define the fall through settings (`Block`).
 
 <a id="api-specification-validation-all-spec-endpoints-settings"></a>
 
 ### API Specification Validation All Spec Endpoints Settings
 
-`oversized_body_fail_validation` - (Optional) Empty. This can be used for messages where no values are needed. See [Oversized Body Fail Validation](#api-specification-validation-all-spec-endpoints-settings-oversized-body-fail-validation) below.
+`oversized_body_fail_validation` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`oversized_body_skip_validation` - (Optional) Empty. This can be used for messages where no values are needed. See [Oversized Body Skip Validation](#api-specification-validation-all-spec-endpoints-settings-oversized-body-skip-validation) below.
+`oversized_body_skip_validation` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`property_validation_settings_custom` - (Optional) Validation Property Settings. Custom property validation settings. See [Property Validation Settings Custom](#api-specification-validation-all-spec-endpoints-settings-property-validation-settings-custom) below.
+`property_validation_settings_custom` - (Optional) Validation Property Settings. Custom property validation settings (`Block`).
 
-`property_validation_settings_default` - (Optional) Empty. This can be used for messages where no values are needed. See [Property Validation Settings Default](#api-specification-validation-all-spec-endpoints-settings-property-validation-settings-default) below.
-
-<a id="api-specification-validation-all-spec-endpoints-settings-oversized-body-fail-validation"></a>
-
-### API Specification Validation All Spec Endpoints Settings Oversized Body Fail Validation
-
-<a id="api-specification-validation-all-spec-endpoints-settings-oversized-body-skip-validation"></a>
-
-### API Specification Validation All Spec Endpoints Settings Oversized Body Skip Validation
-
-<a id="api-specification-validation-all-spec-endpoints-settings-property-validation-settings-custom"></a>
-
-### API Specification Validation All Spec Endpoints Settings Property Validation Settings Custom
-
-<a id="api-specification-validation-all-spec-endpoints-settings-property-validation-settings-default"></a>
-
-### API Specification Validation All Spec Endpoints Settings Property Validation Settings Default
+`property_validation_settings_default` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="api-specification-validation-all-spec-endpoints-validation-mode"></a>
 
 ### API Specification Validation All Spec Endpoints Validation Mode
 
-`response_validation_mode_active` - (Optional) Open API Validation Mode Active. Validation mode properties of response. See [Response Validation Mode Active](#api-specification-validation-all-spec-endpoints-validation-mode-response-validation-mode-active) below.
+`response_validation_mode_active` - (Optional) Open API Validation Mode Active. Validation mode properties of response (`Block`).
 
-`skip_response_validation` - (Optional) Empty. This can be used for messages where no values are needed. See [Skip Response Validation](#api-specification-validation-all-spec-endpoints-validation-mode-skip-response-validation) below.
+`skip_response_validation` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`skip_validation` - (Optional) Empty. This can be used for messages where no values are needed. See [Skip Validation](#api-specification-validation-all-spec-endpoints-validation-mode-skip-validation) below.
+`skip_validation` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`validation_mode_active` - (Optional) Open API Validation Mode Active. Validation mode properties of request. See [Validation Mode Active](#api-specification-validation-all-spec-endpoints-validation-mode-validation-mode-active) below.
-
-<a id="api-specification-validation-all-spec-endpoints-validation-mode-response-validation-mode-active"></a>
-
-### API Specification Validation All Spec Endpoints Validation Mode Response Validation Mode Active
-
-<a id="api-specification-validation-all-spec-endpoints-validation-mode-skip-response-validation"></a>
-
-### API Specification Validation All Spec Endpoints Validation Mode Skip Response Validation
-
-<a id="api-specification-validation-all-spec-endpoints-validation-mode-skip-validation"></a>
-
-### API Specification Validation All Spec Endpoints Validation Mode Skip Validation
-
-<a id="api-specification-validation-all-spec-endpoints-validation-mode-validation-mode-active"></a>
-
-### API Specification Validation All Spec Endpoints Validation Mode Validation Mode Active
+`validation_mode_active` - (Optional) Open API Validation Mode Active. Validation mode properties of request (`Block`).
 
 <a id="api-specification-validation-custom-list"></a>
 
@@ -1237,83 +869,39 @@ In addition to all arguments above, the following attributes are exported:
 
 ### API Specification Validation Custom List Fall Through Mode
 
-`fall_through_mode_allow` - (Optional) Empty. This can be used for messages where no values are needed. See [Fall Through Mode Allow](#api-specification-validation-custom-list-fall-through-mode-fall-through-mode-allow) below.
+`fall_through_mode_allow` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`fall_through_mode_custom` - (Optional) Custom Fall Through Mode. Define the fall through settings. See [Fall Through Mode Custom](#api-specification-validation-custom-list-fall-through-mode-fall-through-mode-custom) below.
-
-<a id="api-specification-validation-custom-list-fall-through-mode-fall-through-mode-allow"></a>
-
-### API Specification Validation Custom List Fall Through Mode Fall Through Mode Allow
-
-<a id="api-specification-validation-custom-list-fall-through-mode-fall-through-mode-custom"></a>
-
-### API Specification Validation Custom List Fall Through Mode Fall Through Mode Custom
+`fall_through_mode_custom` - (Optional) Custom Fall Through Mode. Define the fall through settings (`Block`).
 
 <a id="api-specification-validation-custom-list-open-api-validation-rules"></a>
 
 ### API Specification Validation Custom List Open API Validation Rules
 
-`any_domain` - (Optional) Empty. This can be used for messages where no values are needed. See [Any Domain](#api-specification-validation-custom-list-open-api-validation-rules-any-domain) below.
+`any_domain` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`api_endpoint` - (Optional) API Endpoint. This defines API endpoint. See [API Endpoint](#api-specification-validation-custom-list-open-api-validation-rules-api-endpoint) below.
+`api_endpoint` - (Optional) API Endpoint. This defines API endpoint (`Block`).
 
 `api_group` - (Optional) API Group. The API group which this validation applies to (`String`).
 
 `base_path` - (Optional) Base Path. The base path which this validation applies to (`String`).
 
-`metadata` - (Optional) Message Metadata. MessageMetaType is metadata (common attributes) of a message that only certain messages have. This information is propagated to the metadata of a child object that gets created from the containing message during view processing. The information in this type can be specified by user during create and replace APIs. See [Metadata](#api-specification-validation-custom-list-open-api-validation-rules-metadata) below.
+`metadata` - (Optional) Message Metadata. MessageMetaType is metadata (common attributes) of a message that only certain messages have. This information is propagated to the metadata of a child object that gets created from the containing message during view processing. The information in this type can be specified by user during create and replace APIs (`Block`).
 
 `specific_domain` - (Optional) Specific Domain. The rule will apply for a specific domain (`String`).
 
-`validation_mode` - (Optional) Validation Mode. x-required Validation mode of OpenAPI specification. When a validation mismatch occurs on a request to one of the endpoints listed on the OpenAPI specification file (a.k.a. swagger). See [Validation Mode](#api-specification-validation-custom-list-open-api-validation-rules-validation-mode) below.
-
-<a id="api-specification-validation-custom-list-open-api-validation-rules-any-domain"></a>
-
-### API Specification Validation Custom List Open API Validation Rules Any Domain
-
-<a id="api-specification-validation-custom-list-open-api-validation-rules-api-endpoint"></a>
-
-### API Specification Validation Custom List Open API Validation Rules API Endpoint
-
-<a id="api-specification-validation-custom-list-open-api-validation-rules-metadata"></a>
-
-### API Specification Validation Custom List Open API Validation Rules Metadata
-
-<a id="api-specification-validation-custom-list-open-api-validation-rules-validation-mode"></a>
-
-### API Specification Validation Custom List Open API Validation Rules Validation Mode
+`validation_mode` - (Optional) Validation Mode. x-required Validation mode of OpenAPI specification. When a validation mismatch occurs on a request to one of the endpoints listed on the OpenAPI specification file (a.k.a. swagger) (`Block`).
 
 <a id="api-specification-validation-custom-list-settings"></a>
 
 ### API Specification Validation Custom List Settings
 
-`oversized_body_fail_validation` - (Optional) Empty. This can be used for messages where no values are needed. See [Oversized Body Fail Validation](#api-specification-validation-custom-list-settings-oversized-body-fail-validation) below.
+`oversized_body_fail_validation` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`oversized_body_skip_validation` - (Optional) Empty. This can be used for messages where no values are needed. See [Oversized Body Skip Validation](#api-specification-validation-custom-list-settings-oversized-body-skip-validation) below.
+`oversized_body_skip_validation` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`property_validation_settings_custom` - (Optional) Validation Property Settings. Custom property validation settings. See [Property Validation Settings Custom](#api-specification-validation-custom-list-settings-property-validation-settings-custom) below.
+`property_validation_settings_custom` - (Optional) Validation Property Settings. Custom property validation settings (`Block`).
 
-`property_validation_settings_default` - (Optional) Empty. This can be used for messages where no values are needed. See [Property Validation Settings Default](#api-specification-validation-custom-list-settings-property-validation-settings-default) below.
-
-<a id="api-specification-validation-custom-list-settings-oversized-body-fail-validation"></a>
-
-### API Specification Validation Custom List Settings Oversized Body Fail Validation
-
-<a id="api-specification-validation-custom-list-settings-oversized-body-skip-validation"></a>
-
-### API Specification Validation Custom List Settings Oversized Body Skip Validation
-
-<a id="api-specification-validation-custom-list-settings-property-validation-settings-custom"></a>
-
-### API Specification Validation Custom List Settings Property Validation Settings Custom
-
-<a id="api-specification-validation-custom-list-settings-property-validation-settings-default"></a>
-
-### API Specification Validation Custom List Settings Property Validation Settings Default
-
-<a id="api-specification-validation-disabled"></a>
-
-### API Specification Validation Disabled
+`property_validation_settings_default` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="api-testing"></a>
 
@@ -1323,11 +911,11 @@ In addition to all arguments above, the following attributes are exported:
 
 `domains` - (Optional) Testing Environments. Add and configure testing domains and credentials. See [Domains](#api-testing-domains) below.
 
-`every_day` - (Optional) Empty. This can be used for messages where no values are needed. See [Every Day](#api-testing-every-day) below.
+`every_day` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`every_month` - (Optional) Empty. This can be used for messages where no values are needed. See [Every Month](#api-testing-every-month) below.
+`every_month` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`every_week` - (Optional) Empty. This can be used for messages where no values are needed. See [Every Week](#api-testing-every-week) below.
+`every_week` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="api-testing-domains"></a>
 
@@ -1343,55 +931,19 @@ In addition to all arguments above, the following attributes are exported:
 
 ### API Testing Domains Credentials
 
-`admin` - (Optional) Empty. This can be used for messages where no values are needed. See [Admin](#api-testing-domains-credentials-admin) below.
+`admin` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`api_key` - (Optional) API Key. See [API Key](#api-testing-domains-credentials-api-key) below.
+`api_key` - (Optional) API Key (`Block`).
 
-`basic_auth` - (Optional) Basic Authentication. See [Basic Auth](#api-testing-domains-credentials-basic-auth) below.
+`basic_auth` - (Optional) Basic Authentication (`Block`).
 
-`bearer_token` - (Optional) Bearer. See [Bearer Token](#api-testing-domains-credentials-bearer-token) below.
+`bearer_token` - (Optional) Bearer (`Block`).
 
 `credential_name` - (Optional) Name. Enter a unique name for the credentials used in API testing (`String`).
 
-`login_endpoint` - (Optional) Login Endpoint. See [Login Endpoint](#api-testing-domains-credentials-login-endpoint) below.
+`login_endpoint` - (Optional) Login Endpoint (`Block`).
 
-`standard` - (Optional) Empty. This can be used for messages where no values are needed. See [Standard](#api-testing-domains-credentials-standard) below.
-
-<a id="api-testing-domains-credentials-admin"></a>
-
-### API Testing Domains Credentials Admin
-
-<a id="api-testing-domains-credentials-api-key"></a>
-
-### API Testing Domains Credentials API Key
-
-<a id="api-testing-domains-credentials-basic-auth"></a>
-
-### API Testing Domains Credentials Basic Auth
-
-<a id="api-testing-domains-credentials-bearer-token"></a>
-
-### API Testing Domains Credentials Bearer Token
-
-<a id="api-testing-domains-credentials-login-endpoint"></a>
-
-### API Testing Domains Credentials Login Endpoint
-
-<a id="api-testing-domains-credentials-standard"></a>
-
-### API Testing Domains Credentials Standard
-
-<a id="api-testing-every-day"></a>
-
-### API Testing Every Day
-
-<a id="api-testing-every-month"></a>
-
-### API Testing Every Month
-
-<a id="api-testing-every-week"></a>
-
-### API Testing Every Week
+`standard` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="app-firewall"></a>
 
@@ -1411,7 +963,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `as_number` - (Optional) AS Number. RFC 6793 defined 4-byte AS number (`Number`).
 
-`bot_skip_processing` - (Optional) Empty. This can be used for messages where no values are needed. See [Bot Skip Processing](#blocked-clients-bot-skip-processing) below.
+`bot_skip_processing` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `expiration_timestamp` - (Optional) Expiration Timestamp. The expiration_timestamp is the RFC 3339 format timestamp at which the containing rule is considered to be logically expired. The rule continues to exist in the configuration but is not applied anymore (`String`).
 
@@ -1423,15 +975,11 @@ In addition to all arguments above, the following attributes are exported:
 
 `metadata` - (Optional) Message Metadata. MessageMetaType is metadata (common attributes) of a message that only certain messages have. This information is propagated to the metadata of a child object that gets created from the containing message during view processing. The information in this type can be specified by user during create and replace APIs. See [Metadata](#blocked-clients-metadata) below.
 
-`skip_processing` - (Optional) Empty. This can be used for messages where no values are needed. See [Skip Processing](#blocked-clients-skip-processing) below.
+`skip_processing` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `user_identifier` - (Optional) User Identifier. Identify user based on user identifier. User identifier value needs to be copied from security event (`String`).
 
-`waf_skip_processing` - (Optional) Empty. This can be used for messages where no values are needed. See [WAF Skip Processing](#blocked-clients-waf-skip-processing) below.
-
-<a id="blocked-clients-bot-skip-processing"></a>
-
-### Blocked Clients Bot Skip Processing
+`waf_skip_processing` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="blocked-clients-http-header"></a>
 
@@ -1461,21 +1009,13 @@ In addition to all arguments above, the following attributes are exported:
 
 `name` - (Optional) Name. This is the name of the message. The value of name has to follow DNS-1035 format (`String`).
 
-<a id="blocked-clients-skip-processing"></a>
-
-### Blocked Clients Skip Processing
-
-<a id="blocked-clients-waf-skip-processing"></a>
-
-### Blocked Clients WAF Skip Processing
-
 <a id="bot-defense"></a>
 
 ### Bot Defense
 
-`disable_cors_support` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable CORS Support](#bot-defense-disable-cors-support) below.
+`disable_cors_support` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`enable_cors_support` - (Optional) Empty. This can be used for messages where no values are needed. See [Enable CORS Support](#bot-defense-enable-cors-support) below.
+`enable_cors_support` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `policy` - (Optional) Bot Defense Policy. This defines various configuration options for Bot Defense policy. See [Policy](#bot-defense-policy) below.
 
@@ -1483,21 +1023,13 @@ In addition to all arguments above, the following attributes are exported:
 
 `timeout` - (Optional) Timeout. The timeout for the inference check, in milliseconds (`Number`).
 
-<a id="bot-defense-disable-cors-support"></a>
-
-### Bot Defense Disable CORS Support
-
-<a id="bot-defense-enable-cors-support"></a>
-
-### Bot Defense Enable CORS Support
-
 <a id="bot-defense-policy"></a>
 
 ### Bot Defense Policy
 
-`disable_js_insert` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Js Insert](#bot-defense-policy-disable-js-insert) below.
+`disable_js_insert` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`disable_mobile_sdk` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Mobile Sdk](#bot-defense-policy-disable-mobile-sdk) below.
+`disable_mobile_sdk` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `javascript_mode` - (Optional) Web Client JavaScript Mode. Web Client JavaScript Mode. Bot Defense JavaScript for telemetry collection is requested asynchronously, and it is non-cacheable Bot Defense JavaScript for telemetry collection is requested asynchronously, and it is cacheable Bot Defense JavaScript for telemetry collection is requested synchronously, and it is non-cacheable Bot Defense JavaScript for telemetry collection is requested synchronously, and it is cacheable. Possible values are `ASYNC_JS_NO_CACHING`, `ASYNC_JS_CACHING`, `SYNC_JS_NO_CACHING`, `SYNC_JS_CACHING`. Defaults to `ASYNC_JS_NO_CACHING` (`String`).
 
@@ -1513,14 +1045,6 @@ In addition to all arguments above, the following attributes are exported:
 
 `protected_app_endpoints` - (Optional) App Endpoint Type. List of protected endpoints. Limit: Approx '128 endpoints per Load Balancer (LB)' upto 4 LBs, '32 endpoints per LB' after 4 LBs. See [Protected App Endpoints](#bot-defense-policy-protected-app-endpoints) below.
 
-<a id="bot-defense-policy-disable-js-insert"></a>
-
-### Bot Defense Policy Disable Js Insert
-
-<a id="bot-defense-policy-disable-mobile-sdk"></a>
-
-### Bot Defense Policy Disable Mobile Sdk
-
 <a id="bot-defense-policy-js-insert-all-pages"></a>
 
 ### Bot Defense Policy Js Insert All Pages
@@ -1531,139 +1055,67 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Bot Defense Policy Js Insert All Pages Except
 
-`exclude_list` - (Optional) Exclude Pages. Optional JavaScript insertions exclude list of domain and path matchers. See [Exclude List](#bot-defense-policy-js-insert-all-pages-except-exclude-list) below.
+`exclude_list` - (Optional) Exclude Pages. Optional JavaScript insertions exclude list of domain and path matchers (`Block`).
 
 `javascript_location` - (Optional) JavaScript Location. All inside networks. Insert JavaScript after <head> tag Insert JavaScript after </title> tag. Insert JavaScript before first <script> tag. Possible values are `AFTER_HEAD`, `AFTER_TITLE_END`, `BEFORE_SCRIPT`. Defaults to `AFTER_HEAD` (`String`).
-
-<a id="bot-defense-policy-js-insert-all-pages-except-exclude-list"></a>
-
-### Bot Defense Policy Js Insert All Pages Except Exclude List
 
 <a id="bot-defense-policy-js-insertion-rules"></a>
 
 ### Bot Defense Policy Js Insertion Rules
 
-`exclude_list` - (Optional) Exclude Paths. Optional JavaScript insertions exclude list of domain and path matchers. See [Exclude List](#bot-defense-policy-js-insertion-rules-exclude-list) below.
+`exclude_list` - (Optional) Exclude Paths. Optional JavaScript insertions exclude list of domain and path matchers (`Block`).
 
-`rules` - (Optional) JavaScript Insertions. Required list of pages to insert Bot Defense client JavaScript. See [Rules](#bot-defense-policy-js-insertion-rules-rules) below.
-
-<a id="bot-defense-policy-js-insertion-rules-exclude-list"></a>
-
-### Bot Defense Policy Js Insertion Rules Exclude List
-
-<a id="bot-defense-policy-js-insertion-rules-rules"></a>
-
-### Bot Defense Policy Js Insertion Rules Rules
+`rules` - (Optional) JavaScript Insertions. Required list of pages to insert Bot Defense client JavaScript (`Block`).
 
 <a id="bot-defense-policy-mobile-sdk-config"></a>
 
 ### Bot Defense Policy Mobile Sdk Config
 
-`mobile_identifier` - (Optional) Mobile Traffic Identifier. Mobile traffic identifier type. See [Mobile Identifier](#bot-defense-policy-mobile-sdk-config-mobile-identifier) below.
-
-<a id="bot-defense-policy-mobile-sdk-config-mobile-identifier"></a>
-
-### Bot Defense Policy Mobile Sdk Config Mobile Identifier
+`mobile_identifier` - (Optional) Mobile Traffic Identifier. Mobile traffic identifier type (`Block`).
 
 <a id="bot-defense-policy-protected-app-endpoints"></a>
 
 ### Bot Defense Policy Protected App Endpoints
 
-`allow_good_bots` - (Optional) Empty. This can be used for messages where no values are needed. See [Allow Good Bots](#bot-defense-policy-protected-app-endpoints-allow-good-bots) below.
+`allow_good_bots` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`any_domain` - (Optional) Empty. This can be used for messages where no values are needed. See [Any Domain](#bot-defense-policy-protected-app-endpoints-any-domain) below.
+`any_domain` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`domain` - (Optional) Configuration for domain. See [Domain](#bot-defense-policy-protected-app-endpoints-domain) below.
+`domain` - (Optional) Configuration for domain (`Block`).
 
-`flow_label` - (Optional) Bot Defense Flow Label Category. Bot Defense Flow Label Category allows to associate traffic with selected category. See [Flow Label](#bot-defense-policy-protected-app-endpoints-flow-label) below.
+`flow_label` - (Optional) Bot Defense Flow Label Category. Bot Defense Flow Label Category allows to associate traffic with selected category (`Block`).
 
-`headers` - (Optional) HTTP Headers. A list of predicates for various HTTP headers that need to match. The criteria for matching each HTTP header are described in individual HeaderMatcherType instances. The actual HTTP header values are extracted from the request API as a list of strings for each HTTP header type. Note that all specified header predicates must evaluate to true. See [Headers](#bot-defense-policy-protected-app-endpoints-headers) below.
+`headers` - (Optional) HTTP Headers. A list of predicates for various HTTP headers that need to match. The criteria for matching each HTTP header are described in individual HeaderMatcherType instances. The actual HTTP header values are extracted from the request API as a list of strings for each HTTP header type. Note that all specified header predicates must evaluate to true (`Block`).
 
 `http_methods` - (Optional) HTTP Methods. List of HTTP methods (`List`).
 
-`metadata` - (Optional) Message Metadata. MessageMetaType is metadata (common attributes) of a message that only certain messages have. This information is propagated to the metadata of a child object that gets created from the containing message during view processing. The information in this type can be specified by user during create and replace APIs. See [Metadata](#bot-defense-policy-protected-app-endpoints-metadata) below.
+`metadata` - (Optional) Message Metadata. MessageMetaType is metadata (common attributes) of a message that only certain messages have. This information is propagated to the metadata of a child object that gets created from the containing message during view processing. The information in this type can be specified by user during create and replace APIs (`Block`).
 
-`mitigate_good_bots` - (Optional) Empty. This can be used for messages where no values are needed. See [Mitigate Good Bots](#bot-defense-policy-protected-app-endpoints-mitigate-good-bots) below.
+`mitigate_good_bots` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`mitigation` - (Optional) Bot Mitigation Action. Modify Bot Defense behavior for a matching request. See [Mitigation](#bot-defense-policy-protected-app-endpoints-mitigation) below.
+`mitigation` - (Optional) Bot Mitigation Action. Modify Bot Defense behavior for a matching request (`Block`).
 
-`mobile` - (Optional) Empty. This can be used for messages where no values are needed. See [Mobile](#bot-defense-policy-protected-app-endpoints-mobile) below.
+`mobile` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`path` - (Optional) Path to Match. Path match of the URI can be either be, Prefix match or exact match or regular expression match. See [Path](#bot-defense-policy-protected-app-endpoints-path) below.
+`path` - (Optional) Path to Match. Path match of the URI can be either be, Prefix match or exact match or regular expression match (`Block`).
 
 `protocol` - (Optional) URL Scheme. SchemeType is used to indicate URL scheme. - BOTH: BOTH URL scheme for HTTPS:// or `HTTP://.` - HTTP: HTTP URL scheme HTTP:// only. - HTTPS: HTTPS URL scheme HTTPS:// only. Possible values are `BOTH`, `HTTP`, `HTTPS`. Defaults to `BOTH` (`String`).
 
-`query_params` - (Optional) HTTP Query Parameters. A list of predicates for all query parameters that need to be matched. The criteria for matching each query parameter are described in individual instances of QueryParameterMatcherType. The actual query parameter values are extracted from the request API as a list of strings for each query parameter name. Note that all specified query parameter predicates must evaluate to true. See [Query Params](#bot-defense-policy-protected-app-endpoints-query-params) below.
+`query_params` - (Optional) HTTP Query Parameters. A list of predicates for all query parameters that need to be matched. The criteria for matching each query parameter are described in individual instances of QueryParameterMatcherType. The actual query parameter values are extracted from the request API as a list of strings for each query parameter name. Note that all specified query parameter predicates must evaluate to true (`Block`).
 
-`undefined_flow_label` - (Optional) Empty. This can be used for messages where no values are needed. See [Undefined Flow Label](#bot-defense-policy-protected-app-endpoints-undefined-flow-label) below.
+`undefined_flow_label` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`web` - (Optional) Empty. This can be used for messages where no values are needed. See [Web](#bot-defense-policy-protected-app-endpoints-web) below.
+`web` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`web_mobile` - (Optional) Web and Mobile traffic type. Web and Mobile traffic type. See [Web Mobile](#bot-defense-policy-protected-app-endpoints-web-mobile) below.
-
-<a id="bot-defense-policy-protected-app-endpoints-allow-good-bots"></a>
-
-### Bot Defense Policy Protected App Endpoints Allow Good Bots
-
-<a id="bot-defense-policy-protected-app-endpoints-any-domain"></a>
-
-### Bot Defense Policy Protected App Endpoints Any Domain
-
-<a id="bot-defense-policy-protected-app-endpoints-domain"></a>
-
-### Bot Defense Policy Protected App Endpoints Domain
-
-<a id="bot-defense-policy-protected-app-endpoints-flow-label"></a>
-
-### Bot Defense Policy Protected App Endpoints Flow Label
-
-<a id="bot-defense-policy-protected-app-endpoints-headers"></a>
-
-### Bot Defense Policy Protected App Endpoints Headers
-
-<a id="bot-defense-policy-protected-app-endpoints-metadata"></a>
-
-### Bot Defense Policy Protected App Endpoints Metadata
-
-<a id="bot-defense-policy-protected-app-endpoints-mitigate-good-bots"></a>
-
-### Bot Defense Policy Protected App Endpoints Mitigate Good Bots
-
-<a id="bot-defense-policy-protected-app-endpoints-mitigation"></a>
-
-### Bot Defense Policy Protected App Endpoints Mitigation
-
-<a id="bot-defense-policy-protected-app-endpoints-mobile"></a>
-
-### Bot Defense Policy Protected App Endpoints Mobile
-
-<a id="bot-defense-policy-protected-app-endpoints-path"></a>
-
-### Bot Defense Policy Protected App Endpoints Path
-
-<a id="bot-defense-policy-protected-app-endpoints-query-params"></a>
-
-### Bot Defense Policy Protected App Endpoints Query Params
-
-<a id="bot-defense-policy-protected-app-endpoints-undefined-flow-label"></a>
-
-### Bot Defense Policy Protected App Endpoints Undefined Flow Label
-
-<a id="bot-defense-policy-protected-app-endpoints-web"></a>
-
-### Bot Defense Policy Protected App Endpoints Web
-
-<a id="bot-defense-policy-protected-app-endpoints-web-mobile"></a>
-
-### Bot Defense Policy Protected App Endpoints Web Mobile
+`web_mobile` - (Optional) Web and Mobile traffic type. Web and Mobile traffic type (`Block`).
 
 <a id="bot-defense-advanced"></a>
 
 ### Bot Defense Advanced
 
-`disable_js_insert` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Js Insert](#bot-defense-advanced-disable-js-insert) below.
+`disable_js_insert` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`disable_mobile_sdk` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Mobile Sdk](#bot-defense-advanced-disable-mobile-sdk) below.
+`disable_mobile_sdk` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `js_insert_all_pages` - (Optional) Insert Bot Defense JavaScript in All Pages. Insert Bot Defense JavaScript in all pages. See [Js Insert All Pages](#bot-defense-advanced-js-insert-all-pages) below.
 
@@ -1676,14 +1128,6 @@ In addition to all arguments above, the following attributes are exported:
 `mobile_sdk_config` - (Optional) Mobile Request Identifier Headers. Mobile Request Identifier Headers. See [Mobile Sdk Config](#bot-defense-advanced-mobile-sdk-config) below.
 
 `web` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Web](#bot-defense-advanced-web) below.
-
-<a id="bot-defense-advanced-disable-js-insert"></a>
-
-### Bot Defense Advanced Disable Js Insert
-
-<a id="bot-defense-advanced-disable-mobile-sdk"></a>
-
-### Bot Defense Advanced Disable Mobile Sdk
 
 <a id="bot-defense-advanced-js-insert-all-pages"></a>
 
@@ -1703,29 +1147,13 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Bot Defense Advanced Js Insert All Pages Except Exclude List
 
-`any_domain` - (Optional) Empty. This can be used for messages where no values are needed. See [Any Domain](#bot-defense-advanced-js-insert-all-pages-except-exclude-list-any-domain) below.
+`any_domain` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`domain` - (Optional) Configuration for domain. See [Domain](#bot-defense-advanced-js-insert-all-pages-except-exclude-list-domain) below.
+`domain` - (Optional) Configuration for domain (`Block`).
 
-`metadata` - (Optional) Message Metadata. MessageMetaType is metadata (common attributes) of a message that only certain messages have. This information is propagated to the metadata of a child object that gets created from the containing message during view processing. The information in this type can be specified by user during create and replace APIs. See [Metadata](#bot-defense-advanced-js-insert-all-pages-except-exclude-list-metadata) below.
+`metadata` - (Optional) Message Metadata. MessageMetaType is metadata (common attributes) of a message that only certain messages have. This information is propagated to the metadata of a child object that gets created from the containing message during view processing. The information in this type can be specified by user during create and replace APIs (`Block`).
 
-`path` - (Optional) Path to Match. Path match of the URI can be either be, Prefix match or exact match or regular expression match. See [Path](#bot-defense-advanced-js-insert-all-pages-except-exclude-list-path) below.
-
-<a id="bot-defense-advanced-js-insert-all-pages-except-exclude-list-any-domain"></a>
-
-### Bot Defense Advanced Js Insert All Pages Except Exclude List Any Domain
-
-<a id="bot-defense-advanced-js-insert-all-pages-except-exclude-list-domain"></a>
-
-### Bot Defense Advanced Js Insert All Pages Except Exclude List Domain
-
-<a id="bot-defense-advanced-js-insert-all-pages-except-exclude-list-metadata"></a>
-
-### Bot Defense Advanced Js Insert All Pages Except Exclude List Metadata
-
-<a id="bot-defense-advanced-js-insert-all-pages-except-exclude-list-path"></a>
-
-### Bot Defense Advanced Js Insert All Pages Except Exclude List Path
+`path` - (Optional) Path to Match. Path match of the URI can be either be, Prefix match or exact match or regular expression match (`Block`).
 
 <a id="bot-defense-advanced-js-insertion-rules"></a>
 
@@ -1739,59 +1167,27 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Bot Defense Advanced Js Insertion Rules Exclude List
 
-`any_domain` - (Optional) Empty. This can be used for messages where no values are needed. See [Any Domain](#bot-defense-advanced-js-insertion-rules-exclude-list-any-domain) below.
+`any_domain` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`domain` - (Optional) Configuration for domain. See [Domain](#bot-defense-advanced-js-insertion-rules-exclude-list-domain) below.
+`domain` - (Optional) Configuration for domain (`Block`).
 
-`metadata` - (Optional) Message Metadata. MessageMetaType is metadata (common attributes) of a message that only certain messages have. This information is propagated to the metadata of a child object that gets created from the containing message during view processing. The information in this type can be specified by user during create and replace APIs. See [Metadata](#bot-defense-advanced-js-insertion-rules-exclude-list-metadata) below.
+`metadata` - (Optional) Message Metadata. MessageMetaType is metadata (common attributes) of a message that only certain messages have. This information is propagated to the metadata of a child object that gets created from the containing message during view processing. The information in this type can be specified by user during create and replace APIs (`Block`).
 
-`path` - (Optional) Path to Match. Path match of the URI can be either be, Prefix match or exact match or regular expression match. See [Path](#bot-defense-advanced-js-insertion-rules-exclude-list-path) below.
-
-<a id="bot-defense-advanced-js-insertion-rules-exclude-list-any-domain"></a>
-
-### Bot Defense Advanced Js Insertion Rules Exclude List Any Domain
-
-<a id="bot-defense-advanced-js-insertion-rules-exclude-list-domain"></a>
-
-### Bot Defense Advanced Js Insertion Rules Exclude List Domain
-
-<a id="bot-defense-advanced-js-insertion-rules-exclude-list-metadata"></a>
-
-### Bot Defense Advanced Js Insertion Rules Exclude List Metadata
-
-<a id="bot-defense-advanced-js-insertion-rules-exclude-list-path"></a>
-
-### Bot Defense Advanced Js Insertion Rules Exclude List Path
+`path` - (Optional) Path to Match. Path match of the URI can be either be, Prefix match or exact match or regular expression match (`Block`).
 
 <a id="bot-defense-advanced-js-insertion-rules-rules"></a>
 
 ### Bot Defense Advanced Js Insertion Rules Rules
 
-`any_domain` - (Optional) Empty. This can be used for messages where no values are needed. See [Any Domain](#bot-defense-advanced-js-insertion-rules-rules-any-domain) below.
+`any_domain` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`domain` - (Optional) Configuration for domain. See [Domain](#bot-defense-advanced-js-insertion-rules-rules-domain) below.
+`domain` - (Optional) Configuration for domain (`Block`).
 
 `javascript_location` - (Optional) JavaScript Location. All inside networks. Insert JavaScript after <head> tag Insert JavaScript after </title> tag. Insert JavaScript before first <script> tag. Possible values are `AFTER_HEAD`, `AFTER_TITLE_END`, `BEFORE_SCRIPT`. Defaults to `AFTER_HEAD` (`String`).
 
-`metadata` - (Optional) Message Metadata. MessageMetaType is metadata (common attributes) of a message that only certain messages have. This information is propagated to the metadata of a child object that gets created from the containing message during view processing. The information in this type can be specified by user during create and replace APIs. See [Metadata](#bot-defense-advanced-js-insertion-rules-rules-metadata) below.
+`metadata` - (Optional) Message Metadata. MessageMetaType is metadata (common attributes) of a message that only certain messages have. This information is propagated to the metadata of a child object that gets created from the containing message during view processing. The information in this type can be specified by user during create and replace APIs (`Block`).
 
-`path` - (Optional) Path to Match. Path match of the URI can be either be, Prefix match or exact match or regular expression match. See [Path](#bot-defense-advanced-js-insertion-rules-rules-path) below.
-
-<a id="bot-defense-advanced-js-insertion-rules-rules-any-domain"></a>
-
-### Bot Defense Advanced Js Insertion Rules Rules Any Domain
-
-<a id="bot-defense-advanced-js-insertion-rules-rules-domain"></a>
-
-### Bot Defense Advanced Js Insertion Rules Rules Domain
-
-<a id="bot-defense-advanced-js-insertion-rules-rules-metadata"></a>
-
-### Bot Defense Advanced Js Insertion Rules Rules Metadata
-
-<a id="bot-defense-advanced-js-insertion-rules-rules-path"></a>
-
-### Bot Defense Advanced Js Insertion Rules Rules Path
+`path` - (Optional) Path to Match. Path match of the URI can be either be, Prefix match or exact match or regular expression match (`Block`).
 
 <a id="bot-defense-advanced-mobile"></a>
 
@@ -1813,11 +1209,7 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Bot Defense Advanced Mobile Sdk Config Mobile Identifier
 
-`headers` - (Optional) Headers. Headers that can be used to identify mobile traffic. See [Headers](#bot-defense-advanced-mobile-sdk-config-mobile-identifier-headers) below.
-
-<a id="bot-defense-advanced-mobile-sdk-config-mobile-identifier-headers"></a>
-
-### Bot Defense Advanced Mobile Sdk Config Mobile Identifier Headers
+`headers` - (Optional) Headers. Headers that can be used to identify mobile traffic (`Block`).
 
 <a id="bot-defense-advanced-web"></a>
 
@@ -1857,15 +1249,11 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Caching Policy Default Cache Action
 
-`cache_disabled` - (Optional) Empty. This can be used for messages where no values are needed. See [Cache Disabled](#caching-policy-default-cache-action-cache-disabled) below.
+`cache_disabled` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `cache_ttl_default` - (Optional) Fallback Cache TTL (d/ h/ m). Use Cache TTL Provided by Origin, and set a contigency TTL value in case one is not provided (`String`).
 
 `cache_ttl_override` - (Optional) Override Cache TTL (d/ h/ m/ s). Always override the Cahce TTL provided by Origin (`String`).
-
-<a id="caching-policy-default-cache-action-cache-disabled"></a>
-
-### Caching Policy Default Cache Action Cache Disabled
 
 <a id="captcha-challenge"></a>
 
@@ -1885,105 +1273,53 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Client Side Defense Policy
 
-`disable_js_insert` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Js Insert](#client-side-defense-policy-disable-js-insert) below.
+`disable_js_insert` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`js_insert_all_pages` - (Optional) Empty. This can be used for messages where no values are needed. See [Js Insert All Pages](#client-side-defense-policy-js-insert-all-pages) below.
+`js_insert_all_pages` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `js_insert_all_pages_except` - (Optional) Insert JavaScript in All Pages with the Exceptions. Insert Client-Side Defense JavaScript in all pages with the exceptions. See [Js Insert All Pages Except](#client-side-defense-policy-js-insert-all-pages-except) below.
 
 `js_insertion_rules` - (Optional) JavaScript Custom Insertion Rules. This defines custom JavaScript insertion rules for Client-Side Defense Policy. See [Js Insertion Rules](#client-side-defense-policy-js-insertion-rules) below.
 
-<a id="client-side-defense-policy-disable-js-insert"></a>
-
-### Client Side Defense Policy Disable Js Insert
-
-<a id="client-side-defense-policy-js-insert-all-pages"></a>
-
-### Client Side Defense Policy Js Insert All Pages
-
 <a id="client-side-defense-policy-js-insert-all-pages-except"></a>
 
 ### Client Side Defense Policy Js Insert All Pages Except
 
-`exclude_list` - (Optional) Exclude Pages. Optional JavaScript insertions exclude list of domain and path matchers. See [Exclude List](#client-side-defense-policy-js-insert-all-pages-except-exclude-list) below.
-
-<a id="client-side-defense-policy-js-insert-all-pages-except-exclude-list"></a>
-
-### Client Side Defense Policy Js Insert All Pages Except Exclude List
+`exclude_list` - (Optional) Exclude Pages. Optional JavaScript insertions exclude list of domain and path matchers (`Block`).
 
 <a id="client-side-defense-policy-js-insertion-rules"></a>
 
 ### Client Side Defense Policy Js Insertion Rules
 
-`exclude_list` - (Optional) Exclude Paths. Optional JavaScript insertions exclude list of domain and path matchers. See [Exclude List](#client-side-defense-policy-js-insertion-rules-exclude-list) below.
+`exclude_list` - (Optional) Exclude Paths. Optional JavaScript insertions exclude list of domain and path matchers (`Block`).
 
-`rules` - (Optional) JavaScript Insertions. Required list of pages to insert Client-Side Defense client JavaScript. See [Rules](#client-side-defense-policy-js-insertion-rules-rules) below.
-
-<a id="client-side-defense-policy-js-insertion-rules-exclude-list"></a>
-
-### Client Side Defense Policy Js Insertion Rules Exclude List
-
-<a id="client-side-defense-policy-js-insertion-rules-rules"></a>
-
-### Client Side Defense Policy Js Insertion Rules Rules
+`rules` - (Optional) JavaScript Insertions. Required list of pages to insert Client-Side Defense client JavaScript (`Block`).
 
 <a id="cookie-stickiness"></a>
 
 ### Cookie Stickiness
 
-`add_httponly` - (Optional) Empty. This can be used for messages where no values are needed. See [Add Httponly](#cookie-stickiness-add-httponly) below.
+`add_httponly` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`add_secure` - (Optional) Empty. This can be used for messages where no values are needed. See [Add Secure](#cookie-stickiness-add-secure) below.
+`add_secure` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`ignore_httponly` - (Optional) Empty. This can be used for messages where no values are needed. See [Ignore Httponly](#cookie-stickiness-ignore-httponly) below.
+`ignore_httponly` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`ignore_samesite` - (Optional) Empty. This can be used for messages where no values are needed. See [Ignore Samesite](#cookie-stickiness-ignore-samesite) below.
+`ignore_samesite` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`ignore_secure` - (Optional) Empty. This can be used for messages where no values are needed. See [Ignore Secure](#cookie-stickiness-ignore-secure) below.
+`ignore_secure` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `name` - (Optional) Name. The name of the cookie that will be used to obtain the hash key. If the cookie is not present and TTL below is not set, no hash will be produced (`String`).
 
 `path` - (Optional) Path. The name of the path for the cookie. If no path is specified here, no path will be set for the cookie (`String`).
 
-`samesite_lax` - (Optional) Empty. This can be used for messages where no values are needed. See [Samesite Lax](#cookie-stickiness-samesite-lax) below.
+`samesite_lax` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`samesite_none` - (Optional) Empty. This can be used for messages where no values are needed. See [Samesite None](#cookie-stickiness-samesite-none) below.
+`samesite_none` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`samesite_strict` - (Optional) Empty. This can be used for messages where no values are needed. See [Samesite Strict](#cookie-stickiness-samesite-strict) below.
+`samesite_strict` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `ttl` - (Optional) TTL. If specified, a cookie with the TTL will be generated if the cookie is not present. If the TTL is present and zero, the generated cookie will be a session cookie. TTL value is in milliseconds (`Number`).
-
-<a id="cookie-stickiness-add-httponly"></a>
-
-### Cookie Stickiness Add Httponly
-
-<a id="cookie-stickiness-add-secure"></a>
-
-### Cookie Stickiness Add Secure
-
-<a id="cookie-stickiness-ignore-httponly"></a>
-
-### Cookie Stickiness Ignore Httponly
-
-<a id="cookie-stickiness-ignore-samesite"></a>
-
-### Cookie Stickiness Ignore Samesite
-
-<a id="cookie-stickiness-ignore-secure"></a>
-
-### Cookie Stickiness Ignore Secure
-
-<a id="cookie-stickiness-samesite-lax"></a>
-
-### Cookie Stickiness Samesite Lax
-
-<a id="cookie-stickiness-samesite-none"></a>
-
-### Cookie Stickiness Samesite None
-
-<a id="cookie-stickiness-samesite-strict"></a>
-
-### Cookie Stickiness Samesite Strict
 
 <a id="cors-policy"></a>
 
@@ -2009,15 +1345,11 @@ In addition to all arguments above, the following attributes are exported:
 
 ### CSRF Policy
 
-`all_load_balancer_domains` - (Optional) Empty. This can be used for messages where no values are needed. See [All Load Balancer Domains](#csrf-policy-all-load-balancer-domains) below.
+`all_load_balancer_domains` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `custom_domain_list` - (Optional) Domain name list. List of domain names used for Host header matching. See [Custom Domain List](#csrf-policy-custom-domain-list) below.
 
-`disabled` - (Optional) Empty. This can be used for messages where no values are needed. See [Disabled](#csrf-policy-disabled) below.
-
-<a id="csrf-policy-all-load-balancer-domains"></a>
-
-### CSRF Policy All Load Balancer Domains
+`disabled` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="csrf-policy-custom-domain-list"></a>
 
@@ -2025,17 +1357,13 @@ In addition to all arguments above, the following attributes are exported:
 
 `domains` - (Optional) Domain names. A list of domain names that will be matched to loadbalancer. These domains are not used for SNI match. Wildcard names are supported in the suffix or prefix form (`List`).
 
-<a id="csrf-policy-disabled"></a>
-
-### CSRF Policy Disabled
-
 <a id="data-guard-rules"></a>
 
 ### Data Guard Rules
 
-`any_domain` - (Optional) Empty. This can be used for messages where no values are needed. See [Any Domain](#data-guard-rules-any-domain) below.
+`any_domain` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`apply_data_guard` - (Optional) Empty. This can be used for messages where no values are needed. See [Apply Data Guard](#data-guard-rules-apply-data-guard) below.
+`apply_data_guard` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `exact_value` - (Optional) Exact Value. Exact domain name (`String`).
 
@@ -2043,17 +1371,9 @@ In addition to all arguments above, the following attributes are exported:
 
 `path` - (Optional) Path to Match. Path match of the URI can be either be, Prefix match or exact match or regular expression match. See [Path](#data-guard-rules-path) below.
 
-`skip_data_guard` - (Optional) Empty. This can be used for messages where no values are needed. See [Skip Data Guard](#data-guard-rules-skip-data-guard) below.
+`skip_data_guard` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `suffix_value` - (Optional) Suffix Value. Suffix of domain name e.g 'xyz.com' will match '*.xyz.com' and 'xyz.com' (`String`).
-
-<a id="data-guard-rules-any-domain"></a>
-
-### Data Guard Rules Any Domain
-
-<a id="data-guard-rules-apply-data-guard"></a>
-
-### Data Guard Rules Apply Data Guard
 
 <a id="data-guard-rules-metadata"></a>
 
@@ -2073,15 +1393,11 @@ In addition to all arguments above, the following attributes are exported:
 
 `regex` - (Optional) Regex. Regular expression of path match (e.g. the value .* will match on all paths) (`String`).
 
-<a id="data-guard-rules-skip-data-guard"></a>
-
-### Data Guard Rules Skip Data Guard
-
 <a id="ddos-mitigation-rules"></a>
 
 ### DDOS Mitigation Rules
 
-`block` - (Optional) Empty. This can be used for messages where no values are needed. See [Block](#ddos-mitigation-rules-block) below.
+`block` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `ddos_client_source` - (Optional) DDOS Client Source Choice. DDOS Mitigation sources to be blocked. See [DDOS Client Source](#ddos-mitigation-rules-ddos-client-source) below.
 
@@ -2090,10 +1406,6 @@ In addition to all arguments above, the following attributes are exported:
 `ip_prefix_list` - (Optional) IP Prefix Match List. List of IP Prefix strings to match against. See [IP Prefix List](#ddos-mitigation-rules-ip-prefix-list) below.
 
 `metadata` - (Optional) Message Metadata. MessageMetaType is metadata (common attributes) of a message that only certain messages have. This information is propagated to the metadata of a child object that gets created from the containing message during view processing. The information in this type can be specified by user during create and replace APIs. See [Metadata](#ddos-mitigation-rules-metadata) below.
-
-<a id="ddos-mitigation-rules-block"></a>
-
-### DDOS Mitigation Rules Block
 
 <a id="ddos-mitigation-rules-ddos-client-source"></a>
 
@@ -2151,7 +1463,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `advanced_options` - (Optional) Origin Pool Advanced Options. Configure Advanced options for origin pool. See [Advanced Options](#default-pool-advanced-options) below.
 
-`automatic_port` - (Optional) Empty. This can be used for messages where no values are needed. See [Automatic Port](#default-pool-automatic-port) below.
+`automatic_port` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `endpoint_selection` - (Optional) Endpoint Selection Policy. Policy for selection of endpoints from local site/remote site/both Consider both remote and local endpoints for load balancing LOCAL_ONLY: Consider only local endpoints for load balancing Enable this policy to load balance ONLY among locally discovered endpoints Prefer the local endpoints for load balancing. If local endpoints are not present remote endpoints will be considered. Possible values are `DISTRIBUTED`, `LOCAL_ONLY`, `LOCAL_PREFERRED`. Defaults to `DISTRIBUTED` (`String`).
 
@@ -2159,17 +1471,17 @@ In addition to all arguments above, the following attributes are exported:
 
 `healthcheck` - (Optional) Health Check object. Reference to healthcheck configuration objects. See [Healthcheck](#default-pool-healthcheck) below.
 
-`lb_port` - (Optional) Empty. This can be used for messages where no values are needed. See [LB Port](#default-pool-lb-port) below.
+`lb_port` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `loadbalancer_algorithm` - (Optional) Load Balancer Algorithm. Different load balancing algorithms supported When a connection to a endpoint in an upstream cluster is required, the load balancer uses loadbalancer_algorithm to determine which host is selected. - ROUND_ROBIN: ROUND_ROBIN Policy in which each healthy/available upstream endpoint is selected in round robin order. - LEAST_REQUEST: LEAST_REQUEST Policy in which loadbalancer picks the upstream endpoint which has the fewest active requests - RING_HASH: RING_HASH Policy im... Possible values are `ROUND_ROBIN`, `LEAST_REQUEST`, `RING_HASH`, `RANDOM`, `LB_OVERRIDE`. Defaults to `ROUND_ROBIN` (`String`).
 
-`no_tls` - (Optional) Empty. This can be used for messages where no values are needed. See [No TLS](#default-pool-no-tls) below.
+`no_tls` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `origin_servers` - (Optional) Origin Servers. List of origin servers in this pool. See [Origin Servers](#default-pool-origin-servers) below.
 
 `port` - (Optional) Port. Endpoint service is available on this port (`Number`).
 
-`same_as_endpoint_port` - (Optional) Empty. This can be used for messages where no values are needed. See [Same As Endpoint Port](#default-pool-same-as-endpoint-port) below.
+`same_as_endpoint_port` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `upstream_conn_pool_reuse_type` - (Optional) Select upstream connection pool reuse state. Select upstream connection pool reuse state for every downstream connection. This configuration choice is for HTTP(S) LB only. See [Upstream Conn Pool Reuse Type](#default-pool-upstream-conn-pool-reuse-type) below.
 
@@ -2181,25 +1493,25 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Default Pool Advanced Options
 
-`auto_http_config` - (Optional) Empty. This can be used for messages where no values are needed. See [Auto HTTP Config](#default-pool-advanced-options-auto-http-config) below.
+`auto_http_config` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `circuit_breaker` - (Optional) Circuit Breaker. CircuitBreaker provides a mechanism for watching failures in upstream connections or requests and if the failures reach a certain threshold, automatically fail subsequent requests which allows to apply back pressure on downstream quickly. See [Circuit Breaker](#default-pool-advanced-options-circuit-breaker) below.
 
 `connection_timeout` - (Optional) Connection Timeout. The timeout for new network connections to endpoints in the cluster. This is specified in milliseconds. The default value is 2 seconds (`Number`).
 
-`default_circuit_breaker` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Circuit Breaker](#default-pool-advanced-options-default-circuit-breaker) below.
+`default_circuit_breaker` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`disable_circuit_breaker` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Circuit Breaker](#default-pool-advanced-options-disable-circuit-breaker) below.
+`disable_circuit_breaker` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`disable_lb_source_ip_persistance` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable LB Source IP Persistance](#default-pool-advanced-options-disable-lb-source-ip-persistance) below.
+`disable_lb_source_ip_persistance` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`disable_outlier_detection` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Outlier Detection](#default-pool-advanced-options-disable-outlier-detection) below.
+`disable_outlier_detection` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`disable_proxy_protocol` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Proxy Protocol](#default-pool-advanced-options-disable-proxy-protocol) below.
+`disable_proxy_protocol` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`disable_subsets` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Subsets](#default-pool-advanced-options-disable-subsets) below.
+`disable_subsets` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`enable_lb_source_ip_persistance` - (Optional) Empty. This can be used for messages where no values are needed. See [Enable LB Source IP Persistance](#default-pool-advanced-options-enable-lb-source-ip-persistance) below.
+`enable_lb_source_ip_persistance` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `enable_subsets` - (Optional) Origin Pool Subset Options. Configure subset options for origin pool. See [Enable Subsets](#default-pool-advanced-options-enable-subsets) below.
 
@@ -2209,19 +1521,15 @@ In addition to all arguments above, the following attributes are exported:
 
 `http_idle_timeout` - (Optional) HTTP Idle Timeout. The idle timeout for upstream connection pool connections. The idle timeout is defined as the period in which there are no active requests. When the idle timeout is reached the connection will be closed. Note that request based timeouts mean that HTTP/2 PINGs will not keep the connection alive. This is specified in milliseconds. The default value is 5 minutes (`Number`).
 
-`no_panic_threshold` - (Optional) Empty. This can be used for messages where no values are needed. See [No Panic Threshold](#default-pool-advanced-options-no-panic-threshold) below.
+`no_panic_threshold` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `outlier_detection` - (Optional) Outlier Detection. Outlier detection and ejection is the process of dynamically determining whether some number of hosts in an upstream cluster are performing unlike the others and removing them from the healthy load balancing set. Outlier detection is a form of passive health checking. Algorithm 1. A endpoint is determined to be an outlier (based on configured number of consecutive_5xx or consecutive_gateway_failures) . 2. If no endpoints have been ejected, loadbalancer will eject the host i. See [Outlier Detection](#default-pool-advanced-options-outlier-detection) below.
 
 `panic_threshold` - (Optional) Panic threshold. x-example:'25' Configure a threshold (percentage of unhealthy endpoints) below which all endpoints will be considered for load balancing ignoring its health status (`Number`).
 
-`proxy_protocol_v1` - (Optional) Empty. This can be used for messages where no values are needed. See [Proxy Protocol V1](#default-pool-advanced-options-proxy-protocol-v1) below.
+`proxy_protocol_v1` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`proxy_protocol_v2` - (Optional) Empty. This can be used for messages where no values are needed. See [Proxy Protocol V2](#default-pool-advanced-options-proxy-protocol-v2) below.
-
-<a id="default-pool-advanced-options-auto-http-config"></a>
-
-### Default Pool Advanced Options Auto HTTP Config
+`proxy_protocol_v2` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="default-pool-advanced-options-circuit-breaker"></a>
 
@@ -2237,81 +1545,29 @@ In addition to all arguments above, the following attributes are exported:
 
 `retries` - (Optional) Retry Count. The maximum number of retries that can be outstanding to all hosts in a cluster at any given time. Remove endpoint out of load balancing decision, if retries for request exceed this count (`Number`).
 
-<a id="default-pool-advanced-options-default-circuit-breaker"></a>
-
-### Default Pool Advanced Options Default Circuit Breaker
-
-<a id="default-pool-advanced-options-disable-circuit-breaker"></a>
-
-### Default Pool Advanced Options Disable Circuit Breaker
-
-<a id="default-pool-advanced-options-disable-lb-source-ip-persistance"></a>
-
-### Default Pool Advanced Options Disable LB Source IP Persistance
-
-<a id="default-pool-advanced-options-disable-outlier-detection"></a>
-
-### Default Pool Advanced Options Disable Outlier Detection
-
-<a id="default-pool-advanced-options-disable-proxy-protocol"></a>
-
-### Default Pool Advanced Options Disable Proxy Protocol
-
-<a id="default-pool-advanced-options-disable-subsets"></a>
-
-### Default Pool Advanced Options Disable Subsets
-
-<a id="default-pool-advanced-options-enable-lb-source-ip-persistance"></a>
-
-### Default Pool Advanced Options Enable LB Source IP Persistance
-
 <a id="default-pool-advanced-options-enable-subsets"></a>
 
 ### Default Pool Advanced Options Enable Subsets
 
-`any_endpoint` - (Optional) Empty. This can be used for messages where no values are needed. See [Any Endpoint](#default-pool-advanced-options-enable-subsets-any-endpoint) below.
+`any_endpoint` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`default_subset` - (Optional) Origin Pool Default Subset. Default Subset definition. See [Default Subset](#default-pool-advanced-options-enable-subsets-default-subset) below.
+`default_subset` - (Optional) Origin Pool Default Subset. Default Subset definition (`Block`).
 
-`endpoint_subsets` - (Optional) Origin Server Subsets Classes. List of subset class. Subsets class is defined using list of keys. Every unique combination of values of these keys form a subset withing the class. See [Endpoint Subsets](#default-pool-advanced-options-enable-subsets-endpoint-subsets) below.
+`endpoint_subsets` - (Optional) Origin Server Subsets Classes. List of subset class. Subsets class is defined using list of keys. Every unique combination of values of these keys form a subset withing the class (`Block`).
 
-`fail_request` - (Optional) Empty. This can be used for messages where no values are needed. See [Fail Request](#default-pool-advanced-options-enable-subsets-fail-request) below.
-
-<a id="default-pool-advanced-options-enable-subsets-any-endpoint"></a>
-
-### Default Pool Advanced Options Enable Subsets Any Endpoint
-
-<a id="default-pool-advanced-options-enable-subsets-default-subset"></a>
-
-### Default Pool Advanced Options Enable Subsets Default Subset
-
-<a id="default-pool-advanced-options-enable-subsets-endpoint-subsets"></a>
-
-### Default Pool Advanced Options Enable Subsets Endpoint Subsets
-
-<a id="default-pool-advanced-options-enable-subsets-fail-request"></a>
-
-### Default Pool Advanced Options Enable Subsets Fail Request
+`fail_request` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="default-pool-advanced-options-http1-config"></a>
 
 ### Default Pool Advanced Options Http1 Config
 
-`header_transformation` - (Optional) Header Transformation. Header Transformation options for HTTP/1.1 request/response headers. See [Header Transformation](#default-pool-advanced-options-http1-config-header-transformation) below.
-
-<a id="default-pool-advanced-options-http1-config-header-transformation"></a>
-
-### Default Pool Advanced Options Http1 Config Header Transformation
+`header_transformation` - (Optional) Header Transformation. Header Transformation options for HTTP/1.1 request/response headers (`Block`).
 
 <a id="default-pool-advanced-options-http2-options"></a>
 
 ### Default Pool Advanced Options Http2 Options
 
 `enabled` - (Optional) HTTP2 Enabled. Enable/disable HTTP2 Protocol for upstream connections (`Bool`).
-
-<a id="default-pool-advanced-options-no-panic-threshold"></a>
-
-### Default Pool Advanced Options No Panic Threshold
 
 <a id="default-pool-advanced-options-outlier-detection"></a>
 
@@ -2327,18 +1583,6 @@ In addition to all arguments above, the following attributes are exported:
 
 `max_ejection_percent` - (Optional) Max Ejection Percentage. The maximum % of an upstream cluster that can be ejected due to outlier detection. Defaults to 10% but will eject at least one host regardless of the value (`Number`).
 
-<a id="default-pool-advanced-options-proxy-protocol-v1"></a>
-
-### Default Pool Advanced Options Proxy Protocol V1
-
-<a id="default-pool-advanced-options-proxy-protocol-v2"></a>
-
-### Default Pool Advanced Options Proxy Protocol V2
-
-<a id="default-pool-automatic-port"></a>
-
-### Default Pool Automatic Port
-
 <a id="default-pool-healthcheck"></a>
 
 ### Default Pool Healthcheck
@@ -2348,14 +1592,6 @@ In addition to all arguments above, the following attributes are exported:
 `namespace` - (Optional) Namespace. When a configuration object(e.g. virtual_host) refers to another(e.g route) then namespace will hold the referred object's(e.g. route's) namespace (`String`).
 
 `tenant` - (Optional) Tenant. When a configuration object(e.g. virtual_host) refers to another(e.g route) then tenant will hold the referred object's(e.g. route's) tenant (`String`).
-
-<a id="default-pool-lb-port"></a>
-
-### Default Pool LB Port
-
-<a id="default-pool-no-tls"></a>
-
-### Default Pool No TLS
 
 <a id="default-pool-origin-servers"></a>
 
@@ -2369,7 +1605,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `k8s_service` - (Optional) K8s Service Name on given Sites. Specify origin server with K8s service name and site information. See [K8s Service](#default-pool-origin-servers-k8s-service) below.
 
-`labels` - (Optional) Origin Server Labels. Add Labels for this origin server, these labels can be used to form subset. See [Labels](#default-pool-origin-servers-labels) below.
+`labels` - (Optional) Origin Server Labels. Add Labels for this origin server, these labels can be used to form subset (`Block`).
 
 `private_ip` - (Optional) IP address on given Sites. Specify origin server with private or public IP address and site information. See [Private IP](#default-pool-origin-servers-private-ip) below.
 
@@ -2393,119 +1629,55 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Default Pool Origin Servers Consul Service
 
-`inside_network` - (Optional) Empty. This can be used for messages where no values are needed. See [Inside Network](#default-pool-origin-servers-consul-service-inside-network) below.
+`inside_network` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`outside_network` - (Optional) Empty. This can be used for messages where no values are needed. See [Outside Network](#default-pool-origin-servers-consul-service-outside-network) below.
+`outside_network` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `service_name` - (Optional) Service Name. Consul service name of this origin server will be listed, including cluster-id. The format is servicename:cluster-id (`String`).
 
-`site_locator` - (Optional) Site or Virtual Site. This message defines a reference to a site or virtual site object. See [Site Locator](#default-pool-origin-servers-consul-service-site-locator) below.
+`site_locator` - (Optional) Site or Virtual Site. This message defines a reference to a site or virtual site object (`Block`).
 
-`snat_pool` - (Optional) Snat Pool. Snat Pool configuration. See [Snat Pool](#default-pool-origin-servers-consul-service-snat-pool) below.
-
-<a id="default-pool-origin-servers-consul-service-inside-network"></a>
-
-### Default Pool Origin Servers Consul Service Inside Network
-
-<a id="default-pool-origin-servers-consul-service-outside-network"></a>
-
-### Default Pool Origin Servers Consul Service Outside Network
-
-<a id="default-pool-origin-servers-consul-service-site-locator"></a>
-
-### Default Pool Origin Servers Consul Service Site Locator
-
-<a id="default-pool-origin-servers-consul-service-snat-pool"></a>
-
-### Default Pool Origin Servers Consul Service Snat Pool
+`snat_pool` - (Optional) Snat Pool. Snat Pool configuration (`Block`).
 
 <a id="default-pool-origin-servers-custom-endpoint-object"></a>
 
 ### Default Pool Origin Servers Custom Endpoint Object
 
-`endpoint` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Endpoint](#default-pool-origin-servers-custom-endpoint-object-endpoint) below.
-
-<a id="default-pool-origin-servers-custom-endpoint-object-endpoint"></a>
-
-### Default Pool Origin Servers Custom Endpoint Object Endpoint
+`endpoint` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name (`Block`).
 
 <a id="default-pool-origin-servers-k8s-service"></a>
 
 ### Default Pool Origin Servers K8s Service
 
-`inside_network` - (Optional) Empty. This can be used for messages where no values are needed. See [Inside Network](#default-pool-origin-servers-k8s-service-inside-network) below.
+`inside_network` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`outside_network` - (Optional) Empty. This can be used for messages where no values are needed. See [Outside Network](#default-pool-origin-servers-k8s-service-outside-network) below.
+`outside_network` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `protocol` - (Optional) Protocol Type. Type of protocol - PROTOCOL_TCP: TCP - PROTOCOL_UDP: UDP. Possible values are `PROTOCOL_TCP`, `PROTOCOL_UDP`. Defaults to `PROTOCOL_TCP` (`String`).
 
 `service_name` - (Optional) Service Name. K8s service name of the origin server will be listed, including the namespace and cluster-id. For vK8s services, you need to enter a string with the format servicename.namespace:cluster-id. If the servicename is 'frontend', namespace is 'speedtest' and cluster-id is 'prod', then you will enter 'frontend.speedtest:prod'. Both namespace and cluster-id are optional (`String`).
 
-`site_locator` - (Optional) Site or Virtual Site. This message defines a reference to a site or virtual site object. See [Site Locator](#default-pool-origin-servers-k8s-service-site-locator) below.
+`site_locator` - (Optional) Site or Virtual Site. This message defines a reference to a site or virtual site object (`Block`).
 
-`snat_pool` - (Optional) Snat Pool. Snat Pool configuration. See [Snat Pool](#default-pool-origin-servers-k8s-service-snat-pool) below.
+`snat_pool` - (Optional) Snat Pool. Snat Pool configuration (`Block`).
 
-`vk8s_networks` - (Optional) Empty. This can be used for messages where no values are needed. See [Vk8s Networks](#default-pool-origin-servers-k8s-service-vk8s-networks) below.
-
-<a id="default-pool-origin-servers-k8s-service-inside-network"></a>
-
-### Default Pool Origin Servers K8s Service Inside Network
-
-<a id="default-pool-origin-servers-k8s-service-outside-network"></a>
-
-### Default Pool Origin Servers K8s Service Outside Network
-
-<a id="default-pool-origin-servers-k8s-service-site-locator"></a>
-
-### Default Pool Origin Servers K8s Service Site Locator
-
-<a id="default-pool-origin-servers-k8s-service-snat-pool"></a>
-
-### Default Pool Origin Servers K8s Service Snat Pool
-
-<a id="default-pool-origin-servers-k8s-service-vk8s-networks"></a>
-
-### Default Pool Origin Servers K8s Service Vk8s Networks
-
-<a id="default-pool-origin-servers-labels"></a>
-
-### Default Pool Origin Servers Labels
+`vk8s_networks` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="default-pool-origin-servers-private-ip"></a>
 
 ### Default Pool Origin Servers Private IP
 
-`inside_network` - (Optional) Empty. This can be used for messages where no values are needed. See [Inside Network](#default-pool-origin-servers-private-ip-inside-network) below.
+`inside_network` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `ip` - (Optional) IP. Private IPv4 address (`String`).
 
-`outside_network` - (Optional) Empty. This can be used for messages where no values are needed. See [Outside Network](#default-pool-origin-servers-private-ip-outside-network) below.
+`outside_network` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`segment` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Segment](#default-pool-origin-servers-private-ip-segment) below.
+`segment` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name (`Block`).
 
-`site_locator` - (Optional) Site or Virtual Site. This message defines a reference to a site or virtual site object. See [Site Locator](#default-pool-origin-servers-private-ip-site-locator) below.
+`site_locator` - (Optional) Site or Virtual Site. This message defines a reference to a site or virtual site object (`Block`).
 
-`snat_pool` - (Optional) Snat Pool. Snat Pool configuration. See [Snat Pool](#default-pool-origin-servers-private-ip-snat-pool) below.
-
-<a id="default-pool-origin-servers-private-ip-inside-network"></a>
-
-### Default Pool Origin Servers Private IP Inside Network
-
-<a id="default-pool-origin-servers-private-ip-outside-network"></a>
-
-### Default Pool Origin Servers Private IP Outside Network
-
-<a id="default-pool-origin-servers-private-ip-segment"></a>
-
-### Default Pool Origin Servers Private IP Segment
-
-<a id="default-pool-origin-servers-private-ip-site-locator"></a>
-
-### Default Pool Origin Servers Private IP Site Locator
-
-<a id="default-pool-origin-servers-private-ip-snat-pool"></a>
-
-### Default Pool Origin Servers Private IP Snat Pool
+`snat_pool` - (Optional) Snat Pool. Snat Pool configuration (`Block`).
 
 <a id="default-pool-origin-servers-private-name"></a>
 
@@ -2513,37 +1685,17 @@ In addition to all arguments above, the following attributes are exported:
 
 `dns_name` - (Optional) DNS Name. DNS Name (`String`).
 
-`inside_network` - (Optional) Empty. This can be used for messages where no values are needed. See [Inside Network](#default-pool-origin-servers-private-name-inside-network) below.
+`inside_network` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`outside_network` - (Optional) Empty. This can be used for messages where no values are needed. See [Outside Network](#default-pool-origin-servers-private-name-outside-network) below.
+`outside_network` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `refresh_interval` - (Optional) DNS Refresh Interval. Interval for DNS refresh in seconds. Max value is 7 days as per `HTTPS://datatracker.ietf.org/doc/HTML/rfc8767` (`Number`).
 
-`segment` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Segment](#default-pool-origin-servers-private-name-segment) below.
+`segment` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name (`Block`).
 
-`site_locator` - (Optional) Site or Virtual Site. This message defines a reference to a site or virtual site object. See [Site Locator](#default-pool-origin-servers-private-name-site-locator) below.
+`site_locator` - (Optional) Site or Virtual Site. This message defines a reference to a site or virtual site object (`Block`).
 
-`snat_pool` - (Optional) Snat Pool. Snat Pool configuration. See [Snat Pool](#default-pool-origin-servers-private-name-snat-pool) below.
-
-<a id="default-pool-origin-servers-private-name-inside-network"></a>
-
-### Default Pool Origin Servers Private Name Inside Network
-
-<a id="default-pool-origin-servers-private-name-outside-network"></a>
-
-### Default Pool Origin Servers Private Name Outside Network
-
-<a id="default-pool-origin-servers-private-name-segment"></a>
-
-### Default Pool Origin Servers Private Name Segment
-
-<a id="default-pool-origin-servers-private-name-site-locator"></a>
-
-### Default Pool Origin Servers Private Name Site Locator
-
-<a id="default-pool-origin-servers-private-name-snat-pool"></a>
-
-### Default Pool Origin Servers Private Name Snat Pool
+`snat_pool` - (Optional) Snat Pool. Snat Pool configuration (`Block`).
 
 <a id="default-pool-origin-servers-public-ip"></a>
 
@@ -2565,11 +1717,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `ip` - (Optional) IPv4. IPv4 address (`String`).
 
-`virtual_network` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Virtual Network](#default-pool-origin-servers-vn-private-ip-virtual-network) below.
-
-<a id="default-pool-origin-servers-vn-private-ip-virtual-network"></a>
-
-### Default Pool Origin Servers Vn Private IP Virtual Network
+`virtual_network` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name (`Block`).
 
 <a id="default-pool-origin-servers-vn-private-name"></a>
 
@@ -2577,53 +1725,37 @@ In addition to all arguments above, the following attributes are exported:
 
 `dns_name` - (Optional) DNS Name. DNS Name (`String`).
 
-`private_network` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Private Network](#default-pool-origin-servers-vn-private-name-private-network) below.
-
-<a id="default-pool-origin-servers-vn-private-name-private-network"></a>
-
-### Default Pool Origin Servers Vn Private Name Private Network
-
-<a id="default-pool-same-as-endpoint-port"></a>
-
-### Default Pool Same As Endpoint Port
+`private_network` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name (`Block`).
 
 <a id="default-pool-upstream-conn-pool-reuse-type"></a>
 
 ### Default Pool Upstream Conn Pool Reuse Type
 
-`disable_conn_pool_reuse` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Conn Pool Reuse](#default-pool-upstream-conn-pool-reuse-type-disable-conn-pool-reuse) below.
+`disable_conn_pool_reuse` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`enable_conn_pool_reuse` - (Optional) Empty. This can be used for messages where no values are needed. See [Enable Conn Pool Reuse](#default-pool-upstream-conn-pool-reuse-type-enable-conn-pool-reuse) below.
-
-<a id="default-pool-upstream-conn-pool-reuse-type-disable-conn-pool-reuse"></a>
-
-### Default Pool Upstream Conn Pool Reuse Type Disable Conn Pool Reuse
-
-<a id="default-pool-upstream-conn-pool-reuse-type-enable-conn-pool-reuse"></a>
-
-### Default Pool Upstream Conn Pool Reuse Type Enable Conn Pool Reuse
+`enable_conn_pool_reuse` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="default-pool-use-tls"></a>
 
 ### Default Pool Use TLS
 
-`default_session_key_caching` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Session Key Caching](#default-pool-use-tls-default-session-key-caching) below.
+`default_session_key_caching` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`disable_session_key_caching` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Session Key Caching](#default-pool-use-tls-disable-session-key-caching) below.
+`disable_session_key_caching` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`disable_sni` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Sni](#default-pool-use-tls-disable-sni) below.
+`disable_sni` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `max_session_keys` - (Optional) Max Session Keys Cached. x-example:'25' Number of session keys that are cached (`Number`).
 
-`no_mtls` - (Optional) Empty. This can be used for messages where no values are needed. See [No mTLS](#default-pool-use-tls-no-mtls) below.
+`no_mtls` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`skip_server_verification` - (Optional) Empty. This can be used for messages where no values are needed. See [Skip Server Verification](#default-pool-use-tls-skip-server-verification) below.
+`skip_server_verification` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `sni` - (Optional) SNI Value. SNI value to be used (`String`).
 
 `tls_config` - (Optional) TLS Config. This defines various options to configure TLS configuration parameters. See [TLS Config](#default-pool-use-tls-tls-config) below.
 
-`use_host_header_as_sni` - (Optional) Empty. This can be used for messages where no values are needed. See [Use Host Header As Sni](#default-pool-use-tls-use-host-header-as-sni) below.
+`use_host_header_as_sni` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `use_mtls` - (Optional) mTLS Certificate. mTLS Client Certificate. See [Use mTLS](#default-pool-use-tls-use-mtls) below.
 
@@ -2631,69 +1763,25 @@ In addition to all arguments above, the following attributes are exported:
 
 `use_server_verification` - (Optional) TLS Validation Context for Origin Servers. Upstream TLS Validation Context. See [Use Server Verification](#default-pool-use-tls-use-server-verification) below.
 
-`volterra_trusted_ca` - (Optional) Empty. This can be used for messages where no values are needed. See [Volterra Trusted CA](#default-pool-use-tls-volterra-trusted-ca) below.
-
-<a id="default-pool-use-tls-default-session-key-caching"></a>
-
-### Default Pool Use TLS Default Session Key Caching
-
-<a id="default-pool-use-tls-disable-session-key-caching"></a>
-
-### Default Pool Use TLS Disable Session Key Caching
-
-<a id="default-pool-use-tls-disable-sni"></a>
-
-### Default Pool Use TLS Disable Sni
-
-<a id="default-pool-use-tls-no-mtls"></a>
-
-### Default Pool Use TLS No mTLS
-
-<a id="default-pool-use-tls-skip-server-verification"></a>
-
-### Default Pool Use TLS Skip Server Verification
+`volterra_trusted_ca` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="default-pool-use-tls-tls-config"></a>
 
 ### Default Pool Use TLS TLS Config
 
-`custom_security` - (Optional) Custom Ciphers. This defines TLS protocol config including min/max versions and allowed ciphers. See [Custom Security](#default-pool-use-tls-tls-config-custom-security) below.
+`custom_security` - (Optional) Custom Ciphers. This defines TLS protocol config including min/max versions and allowed ciphers (`Block`).
 
-`default_security` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Security](#default-pool-use-tls-tls-config-default-security) below.
+`default_security` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`low_security` - (Optional) Empty. This can be used for messages where no values are needed. See [Low Security](#default-pool-use-tls-tls-config-low-security) below.
+`low_security` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`medium_security` - (Optional) Empty. This can be used for messages where no values are needed. See [Medium Security](#default-pool-use-tls-tls-config-medium-security) below.
-
-<a id="default-pool-use-tls-tls-config-custom-security"></a>
-
-### Default Pool Use TLS TLS Config Custom Security
-
-<a id="default-pool-use-tls-tls-config-default-security"></a>
-
-### Default Pool Use TLS TLS Config Default Security
-
-<a id="default-pool-use-tls-tls-config-low-security"></a>
-
-### Default Pool Use TLS TLS Config Low Security
-
-<a id="default-pool-use-tls-tls-config-medium-security"></a>
-
-### Default Pool Use TLS TLS Config Medium Security
-
-<a id="default-pool-use-tls-use-host-header-as-sni"></a>
-
-### Default Pool Use TLS Use Host Header As Sni
+`medium_security` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="default-pool-use-tls-use-mtls"></a>
 
 ### Default Pool Use TLS Use mTLS
 
-`tls_certificates` - (Optional) mTLS Client Certificate. mTLS Client Certificate. See [TLS Certificates](#default-pool-use-tls-use-mtls-tls-certificates) below.
-
-<a id="default-pool-use-tls-use-mtls-tls-certificates"></a>
-
-### Default Pool Use TLS Use mTLS TLS Certificates
+`tls_certificates` - (Optional) mTLS Client Certificate. mTLS Client Certificate (`Block`).
 
 <a id="default-pool-use-tls-use-mtls-obj"></a>
 
@@ -2709,17 +1797,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Default Pool Use TLS Use Server Verification
 
-`trusted_ca` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Trusted CA](#default-pool-use-tls-use-server-verification-trusted-ca) below.
+`trusted_ca` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name (`Block`).
 
 `trusted_ca_url` - (Optional) Inline Root CA Certificate (legacy). Upload a Root CA Certificate specifically for this Origin Pool for verification of server's certificate (`String`).
-
-<a id="default-pool-use-tls-use-server-verification-trusted-ca"></a>
-
-### Default Pool Use TLS Use Server Verification Trusted CA
-
-<a id="default-pool-use-tls-volterra-trusted-ca"></a>
-
-### Default Pool Use TLS Volterra Trusted CA
 
 <a id="default-pool-view-internal"></a>
 
@@ -2743,7 +1823,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `cluster` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Cluster](#default-pool-list-pools-cluster) below.
 
-`endpoint_subsets` - (Optional) Origin Servers Subsets. Upstream origin pool may be configured to divide its origin servers into subsets based on metadata attached to the origin servers. Routes may then specify the metadata that a endpoint must match in order to be selected by the load balancer For origin servers which are discovered in K8S or Consul cluster, the label of the service is merged with endpoint's labels. In case of Consul, the label is derived from the 'Tag' field. For labels that are common between configured. See [Endpoint Subsets](#default-pool-list-pools-endpoint-subsets) below.
+`endpoint_subsets` - (Optional) Origin Servers Subsets. Upstream origin pool may be configured to divide its origin servers into subsets based on metadata attached to the origin servers. Routes may then specify the metadata that a endpoint must match in order to be selected by the load balancer For origin servers which are discovered in K8S or Consul cluster, the label of the service is merged with endpoint's labels. In case of Consul, the label is derived from the 'Tag' field. For labels that are common between configured (`Block`).
 
 `pool` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Pool](#default-pool-list-pools-pool) below.
 
@@ -2761,10 +1841,6 @@ In addition to all arguments above, the following attributes are exported:
 
 `tenant` - (Optional) Tenant. When a configuration object(e.g. virtual_host) refers to another(e.g route) then tenant will hold the referred object's(e.g. route's) tenant (`String`).
 
-<a id="default-pool-list-pools-endpoint-subsets"></a>
-
-### Default Pool List Pools Endpoint Subsets
-
 <a id="default-pool-list-pools-pool"></a>
 
 ### Default Pool List Pools Pool
@@ -2781,7 +1857,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `cluster` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Cluster](#default-route-pools-cluster) below.
 
-`endpoint_subsets` - (Optional) Origin Servers Subsets. Upstream origin pool may be configured to divide its origin servers into subsets based on metadata attached to the origin servers. Routes may then specify the metadata that a endpoint must match in order to be selected by the load balancer For origin servers which are discovered in K8S or Consul cluster, the label of the service is merged with endpoint's labels. In case of Consul, the label is derived from the 'Tag' field. For labels that are common between configured. See [Endpoint Subsets](#default-route-pools-endpoint-subsets) below.
+`endpoint_subsets` - (Optional) Origin Servers Subsets. Upstream origin pool may be configured to divide its origin servers into subsets based on metadata attached to the origin servers. Routes may then specify the metadata that a endpoint must match in order to be selected by the load balancer For origin servers which are discovered in K8S or Consul cluster, the label of the service is merged with endpoint's labels. In case of Consul, the label is derived from the 'Tag' field. For labels that are common between configured (`Block`).
 
 `pool` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Pool](#default-route-pools-pool) below.
 
@@ -2799,10 +1875,6 @@ In addition to all arguments above, the following attributes are exported:
 
 `tenant` - (Optional) Tenant. When a configuration object(e.g. virtual_host) refers to another(e.g route) then tenant will hold the referred object's(e.g. route's) tenant (`String`).
 
-<a id="default-route-pools-endpoint-subsets"></a>
-
-### Default Route Pools Endpoint Subsets
-
 <a id="default-route-pools-pool"></a>
 
 ### Default Route Pools Pool
@@ -2812,66 +1884,6 @@ In addition to all arguments above, the following attributes are exported:
 `namespace` - (Optional) Namespace. When a configuration object(e.g. virtual_host) refers to another(e.g route) then namespace will hold the referred object's(e.g. route's) namespace (`String`).
 
 `tenant` - (Optional) Tenant. When a configuration object(e.g. virtual_host) refers to another(e.g route) then tenant will hold the referred object's(e.g. route's) tenant (`String`).
-
-<a id="default-sensitive-data-policy"></a>
-
-### Default Sensitive Data Policy
-
-<a id="disable-api-definition"></a>
-
-### Disable API Definition
-
-<a id="disable-api-discovery"></a>
-
-### Disable API Discovery
-
-<a id="disable-api-testing"></a>
-
-### Disable API Testing
-
-<a id="disable-bot-defense"></a>
-
-### Disable Bot Defense
-
-<a id="disable-caching"></a>
-
-### Disable Caching
-
-<a id="disable-client-side-defense"></a>
-
-### Disable Client Side Defense
-
-<a id="disable-ip-reputation"></a>
-
-### Disable IP Reputation
-
-<a id="disable-malicious-user-detection"></a>
-
-### Disable Malicious User Detection
-
-<a id="disable-malware-protection"></a>
-
-### Disable Malware Protection
-
-<a id="disable-rate-limit"></a>
-
-### Disable Rate Limit
-
-<a id="disable-threat-mesh"></a>
-
-### Disable Threat Mesh
-
-<a id="disable-trust-client-ip-headers"></a>
-
-### Disable Trust Client IP Headers
-
-<a id="disable-waf"></a>
-
-### Disable WAF
-
-<a id="do-not-advertise"></a>
-
-### Do Not Advertise
 
 <a id="enable-api-discovery"></a>
 
@@ -2883,13 +1895,13 @@ In addition to all arguments above, the following attributes are exported:
 
 `custom_api_auth_discovery` - (Optional) API Discovery Advanced Settings. API Discovery Advanced settings. See [Custom API Auth Discovery](#enable-api-discovery-custom-api-auth-discovery) below.
 
-`default_api_auth_discovery` - (Optional) Empty. This can be used for messages where no values are needed. See [Default API Auth Discovery](#enable-api-discovery-default-api-auth-discovery) below.
+`default_api_auth_discovery` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`disable_learn_from_redirect_traffic` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Learn From Redirect Traffic](#enable-api-discovery-disable-learn-from-redirect-traffic) below.
+`disable_learn_from_redirect_traffic` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `discovered_api_settings` - (Optional) Discovered API Settings. x-example: '2' Configure Discovered API Settings. See [Discovered API Settings](#enable-api-discovery-discovered-api-settings) below.
 
-`enable_learn_from_redirect_traffic` - (Optional) Empty. This can be used for messages where no values are needed. See [Enable Learn From Redirect Traffic](#enable-api-discovery-enable-learn-from-redirect-traffic) below.
+`enable_learn_from_redirect_traffic` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="enable-api-discovery-api-crawler"></a>
 
@@ -2897,21 +1909,13 @@ In addition to all arguments above, the following attributes are exported:
 
 `api_crawler_config` - (Optional) Crawler Configure. See [API Crawler Config](#enable-api-discovery-api-crawler-api-crawler-config) below.
 
-`disable_api_crawler` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable API Crawler](#enable-api-discovery-api-crawler-disable-api-crawler) below.
+`disable_api_crawler` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="enable-api-discovery-api-crawler-api-crawler-config"></a>
 
 ### Enable API Discovery API Crawler API Crawler Config
 
-`domains` - (Optional) Domains to Crawl. Enter domains and their credentials to allow authenticated API crawling. You can only include domains you own that are associated with this Load Balancer. See [Domains](#enable-api-discovery-api-crawler-api-crawler-config-domains) below.
-
-<a id="enable-api-discovery-api-crawler-api-crawler-config-domains"></a>
-
-### Enable API Discovery API Crawler API Crawler Config Domains
-
-<a id="enable-api-discovery-api-crawler-disable-api-crawler"></a>
-
-### Enable API Discovery API Crawler Disable API Crawler
+`domains` - (Optional) Domains to Crawl. Enter domains and their credentials to allow authenticated API crawling. You can only include domains you own that are associated with this Load Balancer (`Block`).
 
 <a id="enable-api-discovery-api-discovery-from-code-scan"></a>
 
@@ -2923,23 +1927,11 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Enable API Discovery API Discovery From Code Scan Code Base Integrations
 
-`all_repos` - (Optional) Empty. This can be used for messages where no values are needed. See [All Repos](#enable-api-discovery-api-discovery-from-code-scan-code-base-integrations-all-repos) below.
+`all_repos` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`code_base_integration` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Code Base Integration](#enable-api-discovery-api-discovery-from-code-scan-code-base-integrations-code-base-integration) below.
+`code_base_integration` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name (`Block`).
 
-`selected_repos` - (Optional) API Code Repositories. Select which API repositories represent the LB applications. See [Selected Repos](#enable-api-discovery-api-discovery-from-code-scan-code-base-integrations-selected-repos) below.
-
-<a id="enable-api-discovery-api-discovery-from-code-scan-code-base-integrations-all-repos"></a>
-
-### Enable API Discovery API Discovery From Code Scan Code Base Integrations All Repos
-
-<a id="enable-api-discovery-api-discovery-from-code-scan-code-base-integrations-code-base-integration"></a>
-
-### Enable API Discovery API Discovery From Code Scan Code Base Integrations Code Base Integration
-
-<a id="enable-api-discovery-api-discovery-from-code-scan-code-base-integrations-selected-repos"></a>
-
-### Enable API Discovery API Discovery From Code Scan Code Base Integrations Selected Repos
+`selected_repos` - (Optional) API Code Repositories. Select which API repositories represent the LB applications (`Block`).
 
 <a id="enable-api-discovery-custom-api-auth-discovery"></a>
 
@@ -2957,23 +1949,11 @@ In addition to all arguments above, the following attributes are exported:
 
 `tenant` - (Optional) Tenant. When a configuration object(e.g. virtual_host) refers to another(e.g route) then tenant will hold the referred object's(e.g. route's) tenant (`String`).
 
-<a id="enable-api-discovery-default-api-auth-discovery"></a>
-
-### Enable API Discovery Default API Auth Discovery
-
-<a id="enable-api-discovery-disable-learn-from-redirect-traffic"></a>
-
-### Enable API Discovery Disable Learn From Redirect Traffic
-
 <a id="enable-api-discovery-discovered-api-settings"></a>
 
 ### Enable API Discovery Discovered API Settings
 
 `purge_duration_for_inactive_discovered_apis` - (Optional) Purge Duration for Inactive Discovered APIs from Traffic. Inactive discovered API will be deleted after configured duration (`Number`).
-
-<a id="enable-api-discovery-enable-learn-from-redirect-traffic"></a>
-
-### Enable API Discovery Enable Learn From Redirect Traffic
 
 <a id="enable-challenge"></a>
 
@@ -2981,11 +1961,11 @@ In addition to all arguments above, the following attributes are exported:
 
 `captcha_challenge_parameters` - (Optional) Captcha Challenge Parameters. Enables loadbalancer to perform captcha challenge Captcha challenge will be based on Google Recaptcha. With this feature enabled, only clients that pass the captcha challenge will be allowed to complete the HTTP request. When loadbalancer is configured to do Captcha Challenge, it will redirect the browser to an HTML page on every new HTTP request. This HTML page will have captcha challenge embedded in it. Client will be allowed to make the request only if the cap. See [Captcha Challenge Parameters](#enable-challenge-captcha-challenge-parameters) below.
 
-`default_captcha_challenge_parameters` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Captcha Challenge Parameters](#enable-challenge-default-captcha-challenge-parameters) below.
+`default_captcha_challenge_parameters` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`default_js_challenge_parameters` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Js Challenge Parameters](#enable-challenge-default-js-challenge-parameters) below.
+`default_js_challenge_parameters` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`default_mitigation_settings` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Mitigation Settings](#enable-challenge-default-mitigation-settings) below.
+`default_mitigation_settings` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `js_challenge_parameters` - (Optional) Javascript Challenge Parameters. Enables loadbalancer to perform client browser compatibility test by redirecting to a page with Javascript. With this feature enabled, only clients that are capable of executing Javascript(mostly browsers) will be allowed to complete the HTTP request. When loadbalancer is configured to do Javascript Challenge, it will redirect the browser to an HTML page on every new HTTP request. This HTML page will have Javascript embedded in it. Loadbalancer chooses a set o. See [Js Challenge Parameters](#enable-challenge-js-challenge-parameters) below.
 
@@ -2998,18 +1978,6 @@ In addition to all arguments above, the following attributes are exported:
 `cookie_expiry` - (Optional) Cookie Expiration Period. Cookie expiration period, in seconds. An expired cookie causes the loadbalancer to issue a new challenge (`Number`).
 
 `custom_page` - (Optional) Custom message for Captcha Challenge. Custom message is of type uri_ref. Currently supported URL schemes is string:///. For string:/// scheme, message needs to be encoded in Base64 format. You can specify this message as base64 encoded plain text message e.g. 'Please Wait.' or it can be HTML paragraph or a body string encoded as base64 string E.g. '<p> Please Wait </p>'. Base64 encoded string for this HTML is 'PHA+IFBsZWFzZSBXYWl0IDwvcD4=' (`String`).
-
-<a id="enable-challenge-default-captcha-challenge-parameters"></a>
-
-### Enable Challenge Default Captcha Challenge Parameters
-
-<a id="enable-challenge-default-js-challenge-parameters"></a>
-
-### Enable Challenge Default Js Challenge Parameters
-
-<a id="enable-challenge-default-mitigation-settings"></a>
-
-### Enable Challenge Default Mitigation Settings
 
 <a id="enable-challenge-js-challenge-parameters"></a>
 
@@ -3037,14 +2005,6 @@ In addition to all arguments above, the following attributes are exported:
 
 `ip_threat_categories` - (Optional) List of IP Threat Categories to choose. If the source IP matches on atleast one of the enabled IP threat categories, the request will be denied (`List`).
 
-<a id="enable-malicious-user-detection"></a>
-
-### Enable Malicious User Detection
-
-<a id="enable-threat-mesh"></a>
-
-### Enable Threat Mesh
-
 <a id="enable-trust-client-ip-headers"></a>
 
 ### Enable Trust Client IP Headers
@@ -3055,7 +2015,7 @@ In addition to all arguments above, the following attributes are exported:
 
 ### GraphQL Rules
 
-`any_domain` - (Optional) Empty. This can be used for messages where no values are needed. See [Any Domain](#graphql-rules-any-domain) below.
+`any_domain` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `exact_path` - (Optional) Path. Specifies the exact path to GraphQL endpoint. Default value is /GraphQL (`String`).
 
@@ -3065,37 +2025,25 @@ In addition to all arguments above, the following attributes are exported:
 
 `metadata` - (Optional) Message Metadata. MessageMetaType is metadata (common attributes) of a message that only certain messages have. This information is propagated to the metadata of a child object that gets created from the containing message during view processing. The information in this type can be specified by user during create and replace APIs. See [Metadata](#graphql-rules-metadata) below.
 
-`method_get` - (Optional) Empty. This can be used for messages where no values are needed. See [Method Get](#graphql-rules-method-get) below.
+`method_get` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`method_post` - (Optional) Empty. This can be used for messages where no values are needed. See [Method Post](#graphql-rules-method-post) below.
+`method_post` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `suffix_value` - (Optional) Suffix Value. Suffix of domain name e.g 'xyz.com' will match '*.xyz.com' and 'xyz.com' (`String`).
-
-<a id="graphql-rules-any-domain"></a>
-
-### GraphQL Rules Any Domain
 
 <a id="graphql-rules-graphql-settings"></a>
 
 ### GraphQL Rules GraphQL Settings
 
-`disable_introspection` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Introspection](#graphql-rules-graphql-settings-disable-introspection) below.
+`disable_introspection` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`enable_introspection` - (Optional) Empty. This can be used for messages where no values are needed. See [Enable Introspection](#graphql-rules-graphql-settings-enable-introspection) below.
+`enable_introspection` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `max_batched_queries` - (Optional) Maximum Batched Queries. Specify maximum number of queries in a single batched request (`Number`).
 
 `max_depth` - (Optional) Maximum Structure Depth. Specify maximum depth for the GraphQL query (`Number`).
 
 `max_total_length` - (Optional) Maximum Total Length. Specify maximum length in bytes for the GraphQL query (`Number`).
-
-<a id="graphql-rules-graphql-settings-disable-introspection"></a>
-
-### GraphQL Rules GraphQL Settings Disable Introspection
-
-<a id="graphql-rules-graphql-settings-enable-introspection"></a>
-
-### GraphQL Rules GraphQL Settings Enable Introspection
 
 <a id="graphql-rules-metadata"></a>
 
@@ -3104,14 +2052,6 @@ In addition to all arguments above, the following attributes are exported:
 `description` - (Optional) Description. Human readable description (`String`).
 
 `name` - (Optional) Name. This is the name of the message. The value of name has to follow DNS-1035 format (`String`).
-
-<a id="graphql-rules-method-get"></a>
-
-### GraphQL Rules Method Get
-
-<a id="graphql-rules-method-post"></a>
-
-### GraphQL Rules Method Post
 
 <a id="http"></a>
 
@@ -3135,21 +2075,21 @@ In addition to all arguments above, the following attributes are exported:
 
 `connection_idle_timeout` - (Optional) Connection Idle Timeout. The idle timeout for downstream connections. The idle timeout is defined as the period in which there are no active requests. When the idle timeout is reached the connection will be closed. Note that request based timeouts mean that HTTP/2 PINGs will not keep the connection alive. This is specified in milliseconds. The default value is 2 minutes (`Number`).
 
-`default_header` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Header](#https-default-header) below.
+`default_header` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`default_loadbalancer` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Loadbalancer](#https-default-loadbalancer) below.
+`default_loadbalancer` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`disable_path_normalize` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Path Normalize](#https-disable-path-normalize) below.
+`disable_path_normalize` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`enable_path_normalize` - (Optional) Empty. This can be used for messages where no values are needed. See [Enable Path Normalize](#https-enable-path-normalize) below.
+`enable_path_normalize` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `http_protocol_options` - (Optional) HTTP Protocol Configuration Options. HTTP protocol configuration options for downstream connections. See [HTTP Protocol Options](#https-http-protocol-options) below.
 
 `http_redirect` - (Optional) HTTP Redirect to HTTPS. Redirect HTTP traffic to HTTPS (`Bool`).
 
-`non_default_loadbalancer` - (Optional) Empty. This can be used for messages where no values are needed. See [Non Default Loadbalancer](#https-non-default-loadbalancer) below.
+`non_default_loadbalancer` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`pass_through` - (Optional) Empty. This can be used for messages where no values are needed. See [Pass Through](#https-pass-through) below.
+`pass_through` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `port` - (Optional) HTTPS Port. HTTPS port to Listen (`Number`).
 
@@ -3165,33 +2105,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ### HTTPS Coalescing Options
 
-`default_coalescing` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Coalescing](#https-coalescing-options-default-coalescing) below.
+`default_coalescing` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`strict_coalescing` - (Optional) Empty. This can be used for messages where no values are needed. See [Strict Coalescing](#https-coalescing-options-strict-coalescing) below.
-
-<a id="https-coalescing-options-default-coalescing"></a>
-
-### HTTPS Coalescing Options Default Coalescing
-
-<a id="https-coalescing-options-strict-coalescing"></a>
-
-### HTTPS Coalescing Options Strict Coalescing
-
-<a id="https-default-header"></a>
-
-### HTTPS Default Header
-
-<a id="https-default-loadbalancer"></a>
-
-### HTTPS Default Loadbalancer
-
-<a id="https-disable-path-normalize"></a>
-
-### HTTPS Disable Path Normalize
-
-<a id="https-enable-path-normalize"></a>
-
-### HTTPS Enable Path Normalize
+`strict_coalescing` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="https-http-protocol-options"></a>
 
@@ -3199,35 +2115,15 @@ In addition to all arguments above, the following attributes are exported:
 
 `http_protocol_enable_v1_only` - (Optional) HTTP/1.1 Protocol Options. HTTP/1.1 Protocol options for downstream connections. See [HTTP Protocol Enable V1 Only](#https-http-protocol-options-http-protocol-enable-v1-only) below.
 
-`http_protocol_enable_v1_v2` - (Optional) Empty. This can be used for messages where no values are needed. See [HTTP Protocol Enable V1 V2](#https-http-protocol-options-http-protocol-enable-v1-v2) below.
+`http_protocol_enable_v1_v2` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`http_protocol_enable_v2_only` - (Optional) Empty. This can be used for messages where no values are needed. See [HTTP Protocol Enable V2 Only](#https-http-protocol-options-http-protocol-enable-v2-only) below.
+`http_protocol_enable_v2_only` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="https-http-protocol-options-http-protocol-enable-v1-only"></a>
 
 ### HTTPS HTTP Protocol Options HTTP Protocol Enable V1 Only
 
-`header_transformation` - (Optional) Header Transformation. Header Transformation options for HTTP/1.1 request/response headers. See [Header Transformation](#https-http-protocol-options-http-protocol-enable-v1-only-header-transformation) below.
-
-<a id="https-http-protocol-options-http-protocol-enable-v1-only-header-transformation"></a>
-
-### HTTPS HTTP Protocol Options HTTP Protocol Enable V1 Only Header Transformation
-
-<a id="https-http-protocol-options-http-protocol-enable-v1-v2"></a>
-
-### HTTPS HTTP Protocol Options HTTP Protocol Enable V1 V2
-
-<a id="https-http-protocol-options-http-protocol-enable-v2-only"></a>
-
-### HTTPS HTTP Protocol Options HTTP Protocol Enable V2 Only
-
-<a id="https-non-default-loadbalancer"></a>
-
-### HTTPS Non Default Loadbalancer
-
-<a id="https-pass-through"></a>
-
-### HTTPS Pass Through
+`header_transformation` - (Optional) Header Transformation. Header Transformation options for HTTP/1.1 request/response headers (`Block`).
 
 <a id="https-tls-cert-params"></a>
 
@@ -3235,7 +2131,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `certificates` - (Optional) Certificates. Select one or more certificates with any domain names. See [Certificates](#https-tls-cert-params-certificates) below.
 
-`no_mtls` - (Optional) Empty. This can be used for messages where no values are needed. See [No mTLS](#https-tls-cert-params-no-mtls) below.
+`no_mtls` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `tls_config` - (Optional) TLS Config. This defines various options to configure TLS configuration parameters. See [TLS Config](#https-tls-cert-params-tls-config) below.
 
@@ -3251,37 +2147,17 @@ In addition to all arguments above, the following attributes are exported:
 
 `tenant` - (Optional) Tenant. When a configuration object(e.g. virtual_host) refers to another(e.g route) then tenant will hold the referred object's(e.g. route's) tenant (`String`).
 
-<a id="https-tls-cert-params-no-mtls"></a>
-
-### HTTPS TLS Cert Params No mTLS
-
 <a id="https-tls-cert-params-tls-config"></a>
 
 ### HTTPS TLS Cert Params TLS Config
 
-`custom_security` - (Optional) Custom Ciphers. This defines TLS protocol config including min/max versions and allowed ciphers. See [Custom Security](#https-tls-cert-params-tls-config-custom-security) below.
+`custom_security` - (Optional) Custom Ciphers. This defines TLS protocol config including min/max versions and allowed ciphers (`Block`).
 
-`default_security` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Security](#https-tls-cert-params-tls-config-default-security) below.
+`default_security` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`low_security` - (Optional) Empty. This can be used for messages where no values are needed. See [Low Security](#https-tls-cert-params-tls-config-low-security) below.
+`low_security` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`medium_security` - (Optional) Empty. This can be used for messages where no values are needed. See [Medium Security](#https-tls-cert-params-tls-config-medium-security) below.
-
-<a id="https-tls-cert-params-tls-config-custom-security"></a>
-
-### HTTPS TLS Cert Params TLS Config Custom Security
-
-<a id="https-tls-cert-params-tls-config-default-security"></a>
-
-### HTTPS TLS Cert Params TLS Config Default Security
-
-<a id="https-tls-cert-params-tls-config-low-security"></a>
-
-### HTTPS TLS Cert Params TLS Config Low Security
-
-<a id="https-tls-cert-params-tls-config-medium-security"></a>
-
-### HTTPS TLS Cert Params TLS Config Medium Security
+`medium_security` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="https-tls-cert-params-use-mtls"></a>
 
@@ -3289,43 +2165,23 @@ In addition to all arguments above, the following attributes are exported:
 
 `client_certificate_optional` - (Optional) Client Certificate Optional. Client certificate is optional. If the client has provided a certificate, the load balancer will verify it. If certification verification fails, the connection will be terminated. If the client does not provide a certificate, the connection will be accepted (`Bool`).
 
-`crl` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [CRL](#https-tls-cert-params-use-mtls-crl) below.
+`crl` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name (`Block`).
 
-`no_crl` - (Optional) Empty. This can be used for messages where no values are needed. See [No CRL](#https-tls-cert-params-use-mtls-no-crl) below.
+`no_crl` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`trusted_ca` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Trusted CA](#https-tls-cert-params-use-mtls-trusted-ca) below.
+`trusted_ca` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name (`Block`).
 
 `trusted_ca_url` - (Optional) Inline Root CA Certificate (legacy). Upload a Root CA Certificate specifically for this Load Balancer (`String`).
 
-`xfcc_disabled` - (Optional) Empty. This can be used for messages where no values are needed. See [Xfcc Disabled](#https-tls-cert-params-use-mtls-xfcc-disabled) below.
+`xfcc_disabled` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`xfcc_options` - (Optional) XFCC Header Elements. X-Forwarded-Client-Cert header elements to be added to requests. See [Xfcc Options](#https-tls-cert-params-use-mtls-xfcc-options) below.
-
-<a id="https-tls-cert-params-use-mtls-crl"></a>
-
-### HTTPS TLS Cert Params Use mTLS CRL
-
-<a id="https-tls-cert-params-use-mtls-no-crl"></a>
-
-### HTTPS TLS Cert Params Use mTLS No CRL
-
-<a id="https-tls-cert-params-use-mtls-trusted-ca"></a>
-
-### HTTPS TLS Cert Params Use mTLS Trusted CA
-
-<a id="https-tls-cert-params-use-mtls-xfcc-disabled"></a>
-
-### HTTPS TLS Cert Params Use mTLS Xfcc Disabled
-
-<a id="https-tls-cert-params-use-mtls-xfcc-options"></a>
-
-### HTTPS TLS Cert Params Use mTLS Xfcc Options
+`xfcc_options` - (Optional) XFCC Header Elements. X-Forwarded-Client-Cert header elements to be added to requests (`Block`).
 
 <a id="https-tls-parameters"></a>
 
 ### HTTPS TLS Parameters
 
-`no_mtls` - (Optional) Empty. This can be used for messages where no values are needed. See [No mTLS](#https-tls-parameters-no-mtls) below.
+`no_mtls` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `tls_certificates` - (Optional) TLS Certificates. Users can add one or more certificates that share the same set of domains. for example, domain.com and *.domain.com - but use different signature algorithms. See [TLS Certificates](#https-tls-parameters-tls-certificates) below.
 
@@ -3333,69 +2189,33 @@ In addition to all arguments above, the following attributes are exported:
 
 `use_mtls` - (Optional) Clients TLS validation context. Validation context for downstream client TLS connections. See [Use mTLS](#https-tls-parameters-use-mtls) below.
 
-<a id="https-tls-parameters-no-mtls"></a>
-
-### HTTPS TLS Parameters No mTLS
-
 <a id="https-tls-parameters-tls-certificates"></a>
 
 ### HTTPS TLS Parameters TLS Certificates
 
 `certificate_url` - (Optional) Certificate. TLS certificate. Certificate or certificate chain in PEM format including the PEM headers (`String`).
 
-`custom_hash_algorithms` - (Optional) Hash Algorithms. Specifies the hash algorithms to be used. See [Custom Hash Algorithms](#https-tls-parameters-tls-certificates-custom-hash-algorithms) below.
+`custom_hash_algorithms` - (Optional) Hash Algorithms. Specifies the hash algorithms to be used (`Block`).
 
 `description` - (Optional) Configuration for description (`String`).
 
-`disable_ocsp_stapling` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable OCSP Stapling](#https-tls-parameters-tls-certificates-disable-ocsp-stapling) below.
+`disable_ocsp_stapling` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`private_key` - (Optional) Secret. SecretType is used in an object to indicate a sensitive/confidential field. See [Private Key](#https-tls-parameters-tls-certificates-private-key) below.
+`private_key` - (Optional) Secret. SecretType is used in an object to indicate a sensitive/confidential field (`Block`).
 
-`use_system_defaults` - (Optional) Empty. This can be used for messages where no values are needed. See [Use System Defaults](#https-tls-parameters-tls-certificates-use-system-defaults) below.
-
-<a id="https-tls-parameters-tls-certificates-custom-hash-algorithms"></a>
-
-### HTTPS TLS Parameters TLS Certificates Custom Hash Algorithms
-
-<a id="https-tls-parameters-tls-certificates-disable-ocsp-stapling"></a>
-
-### HTTPS TLS Parameters TLS Certificates Disable OCSP Stapling
-
-<a id="https-tls-parameters-tls-certificates-private-key"></a>
-
-### HTTPS TLS Parameters TLS Certificates Private Key
-
-<a id="https-tls-parameters-tls-certificates-use-system-defaults"></a>
-
-### HTTPS TLS Parameters TLS Certificates Use System Defaults
+`use_system_defaults` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="https-tls-parameters-tls-config"></a>
 
 ### HTTPS TLS Parameters TLS Config
 
-`custom_security` - (Optional) Custom Ciphers. This defines TLS protocol config including min/max versions and allowed ciphers. See [Custom Security](#https-tls-parameters-tls-config-custom-security) below.
+`custom_security` - (Optional) Custom Ciphers. This defines TLS protocol config including min/max versions and allowed ciphers (`Block`).
 
-`default_security` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Security](#https-tls-parameters-tls-config-default-security) below.
+`default_security` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`low_security` - (Optional) Empty. This can be used for messages where no values are needed. See [Low Security](#https-tls-parameters-tls-config-low-security) below.
+`low_security` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`medium_security` - (Optional) Empty. This can be used for messages where no values are needed. See [Medium Security](#https-tls-parameters-tls-config-medium-security) below.
-
-<a id="https-tls-parameters-tls-config-custom-security"></a>
-
-### HTTPS TLS Parameters TLS Config Custom Security
-
-<a id="https-tls-parameters-tls-config-default-security"></a>
-
-### HTTPS TLS Parameters TLS Config Default Security
-
-<a id="https-tls-parameters-tls-config-low-security"></a>
-
-### HTTPS TLS Parameters TLS Config Low Security
-
-<a id="https-tls-parameters-tls-config-medium-security"></a>
-
-### HTTPS TLS Parameters TLS Config Medium Security
+`medium_security` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="https-tls-parameters-use-mtls"></a>
 
@@ -3403,37 +2223,17 @@ In addition to all arguments above, the following attributes are exported:
 
 `client_certificate_optional` - (Optional) Client Certificate Optional. Client certificate is optional. If the client has provided a certificate, the load balancer will verify it. If certification verification fails, the connection will be terminated. If the client does not provide a certificate, the connection will be accepted (`Bool`).
 
-`crl` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [CRL](#https-tls-parameters-use-mtls-crl) below.
+`crl` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name (`Block`).
 
-`no_crl` - (Optional) Empty. This can be used for messages where no values are needed. See [No CRL](#https-tls-parameters-use-mtls-no-crl) below.
+`no_crl` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`trusted_ca` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Trusted CA](#https-tls-parameters-use-mtls-trusted-ca) below.
+`trusted_ca` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name (`Block`).
 
 `trusted_ca_url` - (Optional) Inline Root CA Certificate (legacy). Upload a Root CA Certificate specifically for this Load Balancer (`String`).
 
-`xfcc_disabled` - (Optional) Empty. This can be used for messages where no values are needed. See [Xfcc Disabled](#https-tls-parameters-use-mtls-xfcc-disabled) below.
+`xfcc_disabled` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`xfcc_options` - (Optional) XFCC Header Elements. X-Forwarded-Client-Cert header elements to be added to requests. See [Xfcc Options](#https-tls-parameters-use-mtls-xfcc-options) below.
-
-<a id="https-tls-parameters-use-mtls-crl"></a>
-
-### HTTPS TLS Parameters Use mTLS CRL
-
-<a id="https-tls-parameters-use-mtls-no-crl"></a>
-
-### HTTPS TLS Parameters Use mTLS No CRL
-
-<a id="https-tls-parameters-use-mtls-trusted-ca"></a>
-
-### HTTPS TLS Parameters Use mTLS Trusted CA
-
-<a id="https-tls-parameters-use-mtls-xfcc-disabled"></a>
-
-### HTTPS TLS Parameters Use mTLS Xfcc Disabled
-
-<a id="https-tls-parameters-use-mtls-xfcc-options"></a>
-
-### HTTPS TLS Parameters Use mTLS Xfcc Options
+`xfcc_options` - (Optional) XFCC Header Elements. X-Forwarded-Client-Cert header elements to be added to requests (`Block`).
 
 <a id="https-auto-cert"></a>
 
@@ -3447,23 +2247,23 @@ In addition to all arguments above, the following attributes are exported:
 
 `connection_idle_timeout` - (Optional) Connection Idle Timeout. The idle timeout for downstream connections. The idle timeout is defined as the period in which there are no active requests. When the idle timeout is reached the connection will be closed. Note that request based timeouts mean that HTTP/2 PINGs will not keep the connection alive. This is specified in milliseconds. The default value is 2 minutes (`Number`).
 
-`default_header` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Header](#https-auto-cert-default-header) below.
+`default_header` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`default_loadbalancer` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Loadbalancer](#https-auto-cert-default-loadbalancer) below.
+`default_loadbalancer` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`disable_path_normalize` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Path Normalize](#https-auto-cert-disable-path-normalize) below.
+`disable_path_normalize` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`enable_path_normalize` - (Optional) Empty. This can be used for messages where no values are needed. See [Enable Path Normalize](#https-auto-cert-enable-path-normalize) below.
+`enable_path_normalize` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `http_protocol_options` - (Optional) HTTP Protocol Configuration Options. HTTP protocol configuration options for downstream connections. See [HTTP Protocol Options](#https-auto-cert-http-protocol-options) below.
 
 `http_redirect` - (Optional) HTTP Redirect to HTTPS. Redirect HTTP traffic to HTTPS (`Bool`).
 
-`no_mtls` - (Optional) Empty. This can be used for messages where no values are needed. See [No mTLS](#https-auto-cert-no-mtls) below.
+`no_mtls` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`non_default_loadbalancer` - (Optional) Empty. This can be used for messages where no values are needed. See [Non Default Loadbalancer](#https-auto-cert-non-default-loadbalancer) below.
+`non_default_loadbalancer` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`pass_through` - (Optional) Empty. This can be used for messages where no values are needed. See [Pass Through](#https-auto-cert-pass-through) below.
+`pass_through` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `port` - (Optional) HTTPS Listen Port. HTTPS port to Listen (`Number`).
 
@@ -3479,33 +2279,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ### HTTPS Auto Cert Coalescing Options
 
-`default_coalescing` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Coalescing](#https-auto-cert-coalescing-options-default-coalescing) below.
+`default_coalescing` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`strict_coalescing` - (Optional) Empty. This can be used for messages where no values are needed. See [Strict Coalescing](#https-auto-cert-coalescing-options-strict-coalescing) below.
-
-<a id="https-auto-cert-coalescing-options-default-coalescing"></a>
-
-### HTTPS Auto Cert Coalescing Options Default Coalescing
-
-<a id="https-auto-cert-coalescing-options-strict-coalescing"></a>
-
-### HTTPS Auto Cert Coalescing Options Strict Coalescing
-
-<a id="https-auto-cert-default-header"></a>
-
-### HTTPS Auto Cert Default Header
-
-<a id="https-auto-cert-default-loadbalancer"></a>
-
-### HTTPS Auto Cert Default Loadbalancer
-
-<a id="https-auto-cert-disable-path-normalize"></a>
-
-### HTTPS Auto Cert Disable Path Normalize
-
-<a id="https-auto-cert-enable-path-normalize"></a>
-
-### HTTPS Auto Cert Enable Path Normalize
+`strict_coalescing` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="https-auto-cert-http-protocol-options"></a>
 
@@ -3513,39 +2289,15 @@ In addition to all arguments above, the following attributes are exported:
 
 `http_protocol_enable_v1_only` - (Optional) HTTP/1.1 Protocol Options. HTTP/1.1 Protocol options for downstream connections. See [HTTP Protocol Enable V1 Only](#https-auto-cert-http-protocol-options-http-protocol-enable-v1-only) below.
 
-`http_protocol_enable_v1_v2` - (Optional) Empty. This can be used for messages where no values are needed. See [HTTP Protocol Enable V1 V2](#https-auto-cert-http-protocol-options-http-protocol-enable-v1-v2) below.
+`http_protocol_enable_v1_v2` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`http_protocol_enable_v2_only` - (Optional) Empty. This can be used for messages where no values are needed. See [HTTP Protocol Enable V2 Only](#https-auto-cert-http-protocol-options-http-protocol-enable-v2-only) below.
+`http_protocol_enable_v2_only` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="https-auto-cert-http-protocol-options-http-protocol-enable-v1-only"></a>
 
 ### HTTPS Auto Cert HTTP Protocol Options HTTP Protocol Enable V1 Only
 
-`header_transformation` - (Optional) Header Transformation. Header Transformation options for HTTP/1.1 request/response headers. See [Header Transformation](#https-auto-cert-http-protocol-options-http-protocol-enable-v1-only-header-transformation) below.
-
-<a id="https-auto-cert-http-protocol-options-http-protocol-enable-v1-only-header-transformation"></a>
-
-### HTTPS Auto Cert HTTP Protocol Options HTTP Protocol Enable V1 Only Header Transformation
-
-<a id="https-auto-cert-http-protocol-options-http-protocol-enable-v1-v2"></a>
-
-### HTTPS Auto Cert HTTP Protocol Options HTTP Protocol Enable V1 V2
-
-<a id="https-auto-cert-http-protocol-options-http-protocol-enable-v2-only"></a>
-
-### HTTPS Auto Cert HTTP Protocol Options HTTP Protocol Enable V2 Only
-
-<a id="https-auto-cert-no-mtls"></a>
-
-### HTTPS Auto Cert No mTLS
-
-<a id="https-auto-cert-non-default-loadbalancer"></a>
-
-### HTTPS Auto Cert Non Default Loadbalancer
-
-<a id="https-auto-cert-pass-through"></a>
-
-### HTTPS Auto Cert Pass Through
+`header_transformation` - (Optional) Header Transformation. Header Transformation options for HTTP/1.1 request/response headers (`Block`).
 
 <a id="https-auto-cert-tls-config"></a>
 
@@ -3553,11 +2305,11 @@ In addition to all arguments above, the following attributes are exported:
 
 `custom_security` - (Optional) Custom Ciphers. This defines TLS protocol config including min/max versions and allowed ciphers. See [Custom Security](#https-auto-cert-tls-config-custom-security) below.
 
-`default_security` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Security](#https-auto-cert-tls-config-default-security) below.
+`default_security` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`low_security` - (Optional) Empty. This can be used for messages where no values are needed. See [Low Security](#https-auto-cert-tls-config-low-security) below.
+`low_security` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`medium_security` - (Optional) Empty. This can be used for messages where no values are needed. See [Medium Security](#https-auto-cert-tls-config-medium-security) below.
+`medium_security` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="https-auto-cert-tls-config-custom-security"></a>
 
@@ -3569,18 +2321,6 @@ In addition to all arguments above, the following attributes are exported:
 
 `min_version` - (Optional) TLS Protocol. TlsProtocol is enumeration of supported TLS versions F5 Distributed Cloud will choose the optimal TLS version. Possible values are `TLS_AUTO`, `TLSv1_0`, `TLSv1_1`, `TLSv1_2`, `TLSv1_3`. Defaults to `TLS_AUTO` (`String`).
 
-<a id="https-auto-cert-tls-config-default-security"></a>
-
-### HTTPS Auto Cert TLS Config Default Security
-
-<a id="https-auto-cert-tls-config-low-security"></a>
-
-### HTTPS Auto Cert TLS Config Low Security
-
-<a id="https-auto-cert-tls-config-medium-security"></a>
-
-### HTTPS Auto Cert TLS Config Medium Security
-
 <a id="https-auto-cert-use-mtls"></a>
 
 ### HTTPS Auto Cert Use mTLS
@@ -3589,13 +2329,13 @@ In addition to all arguments above, the following attributes are exported:
 
 `crl` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [CRL](#https-auto-cert-use-mtls-crl) below.
 
-`no_crl` - (Optional) Empty. This can be used for messages where no values are needed. See [No CRL](#https-auto-cert-use-mtls-no-crl) below.
+`no_crl` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `trusted_ca` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Trusted CA](#https-auto-cert-use-mtls-trusted-ca) below.
 
 `trusted_ca_url` - (Optional) Inline Root CA Certificate (legacy). Upload a Root CA Certificate specifically for this Load Balancer (`String`).
 
-`xfcc_disabled` - (Optional) Empty. This can be used for messages where no values are needed. See [Xfcc Disabled](#https-auto-cert-use-mtls-xfcc-disabled) below.
+`xfcc_disabled` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `xfcc_options` - (Optional) XFCC Header Elements. X-Forwarded-Client-Cert header elements to be added to requests. See [Xfcc Options](#https-auto-cert-use-mtls-xfcc-options) below.
 
@@ -3609,10 +2349,6 @@ In addition to all arguments above, the following attributes are exported:
 
 `tenant` - (Optional) Tenant. When a configuration object(e.g. virtual_host) refers to another(e.g route) then tenant will hold the referred object's(e.g. route's) tenant (`String`).
 
-<a id="https-auto-cert-use-mtls-no-crl"></a>
-
-### HTTPS Auto Cert Use mTLS No CRL
-
 <a id="https-auto-cert-use-mtls-trusted-ca"></a>
 
 ### HTTPS Auto Cert Use mTLS Trusted CA
@@ -3622,10 +2358,6 @@ In addition to all arguments above, the following attributes are exported:
 `namespace` - (Optional) Namespace. When a configuration object(e.g. virtual_host) refers to another(e.g route) then namespace will hold the referred object's(e.g. route's) namespace (`String`).
 
 `tenant` - (Optional) Tenant. When a configuration object(e.g. virtual_host) refers to another(e.g route) then tenant will hold the referred object's(e.g. route's) tenant (`String`).
-
-<a id="https-auto-cert-use-mtls-xfcc-disabled"></a>
-
-### HTTPS Auto Cert Use mTLS Xfcc Disabled
 
 <a id="https-auto-cert-use-mtls-xfcc-options"></a>
 
@@ -3663,17 +2395,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ### JWT Validation Action
 
-`block` - (Optional) Empty. This can be used for messages where no values are needed. See [Block](#jwt-validation-action-block) below.
+`block` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`report` - (Optional) Empty. This can be used for messages where no values are needed. See [Report](#jwt-validation-action-report) below.
-
-<a id="jwt-validation-action-block"></a>
-
-### JWT Validation Action Block
-
-<a id="jwt-validation-action-report"></a>
-
-### JWT Validation Action Report
+`report` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="jwt-validation-jwks-config"></a>
 
@@ -3693,15 +2417,15 @@ In addition to all arguments above, the following attributes are exported:
 
 `audience` - (Optional) Audiences. See [Audience](#jwt-validation-reserved-claims-audience) below.
 
-`audience_disable` - (Optional) Empty. This can be used for messages where no values are needed. See [Audience Disable](#jwt-validation-reserved-claims-audience-disable) below.
+`audience_disable` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `issuer` - (Optional) Exact Match (`String`).
 
-`issuer_disable` - (Optional) Empty. This can be used for messages where no values are needed. See [Issuer Disable](#jwt-validation-reserved-claims-issuer-disable) below.
+`issuer_disable` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`validate_period_disable` - (Optional) Empty. This can be used for messages where no values are needed. See [Validate Period Disable](#jwt-validation-reserved-claims-validate-period-disable) below.
+`validate_period_disable` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`validate_period_enable` - (Optional) Empty. This can be used for messages where no values are needed. See [Validate Period Enable](#jwt-validation-reserved-claims-validate-period-enable) below.
+`validate_period_enable` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="jwt-validation-reserved-claims-audience"></a>
 
@@ -3709,35 +2433,15 @@ In addition to all arguments above, the following attributes are exported:
 
 `audiences` - (Optional) Values (`List`).
 
-<a id="jwt-validation-reserved-claims-audience-disable"></a>
-
-### JWT Validation Reserved Claims Audience Disable
-
-<a id="jwt-validation-reserved-claims-issuer-disable"></a>
-
-### JWT Validation Reserved Claims Issuer Disable
-
-<a id="jwt-validation-reserved-claims-validate-period-disable"></a>
-
-### JWT Validation Reserved Claims Validate Period Disable
-
-<a id="jwt-validation-reserved-claims-validate-period-enable"></a>
-
-### JWT Validation Reserved Claims Validate Period Enable
-
 <a id="jwt-validation-target"></a>
 
 ### JWT Validation Target
 
-`all_endpoint` - (Optional) Empty. This can be used for messages where no values are needed. See [All Endpoint](#jwt-validation-target-all-endpoint) below.
+`all_endpoint` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `api_groups` - (Optional) API Groups. See [API Groups](#jwt-validation-target-api-groups) below.
 
 `base_paths` - (Optional) Base Paths. See [Base Paths](#jwt-validation-target-base-paths) below.
-
-<a id="jwt-validation-target-all-endpoint"></a>
-
-### JWT Validation Target All Endpoint
 
 <a id="jwt-validation-target-api-groups"></a>
 
@@ -3755,19 +2459,7 @@ In addition to all arguments above, the following attributes are exported:
 
 ### JWT Validation Token Location
 
-`bearer_token` - (Optional) Empty. This can be used for messages where no values are needed. See [Bearer Token](#jwt-validation-token-location-bearer-token) below.
-
-<a id="jwt-validation-token-location-bearer-token"></a>
-
-### JWT Validation Token Location Bearer Token
-
-<a id="l7-ddos-action-block"></a>
-
-### L7 DDOS Action Block
-
-<a id="l7-ddos-action-default"></a>
-
-### L7 DDOS Action Default
+`bearer_token` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="l7-ddos-action-js-challenge"></a>
 
@@ -3787,15 +2479,15 @@ In addition to all arguments above, the following attributes are exported:
 
 `clientside_action_js_challenge` - (Optional) Javascript Challenge Parameters. Enables loadbalancer to perform client browser compatibility test by redirecting to a page with Javascript. With this feature enabled, only clients that are capable of executing Javascript(mostly browsers) will be allowed to complete the HTTP request. When loadbalancer is configured to do Javascript Challenge, it will redirect the browser to an HTML page on every new HTTP request. This HTML page will have Javascript embedded in it. Loadbalancer chooses a set o. See [Clientside Action Js Challenge](#l7-ddos-protection-clientside-action-js-challenge) below.
 
-`clientside_action_none` - (Optional) Empty. This can be used for messages where no values are needed. See [Clientside Action None](#l7-ddos-protection-clientside-action-none) below.
+`clientside_action_none` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `ddos_policy_custom` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [DDOS Policy Custom](#l7-ddos-protection-ddos-policy-custom) below.
 
-`ddos_policy_none` - (Optional) Empty. This can be used for messages where no values are needed. See [DDOS Policy None](#l7-ddos-protection-ddos-policy-none) below.
+`ddos_policy_none` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`default_rps_threshold` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Rps Threshold](#l7-ddos-protection-default-rps-threshold) below.
+`default_rps_threshold` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`mitigation_block` - (Optional) Empty. This can be used for messages where no values are needed. See [Mitigation Block](#l7-ddos-protection-mitigation-block) below.
+`mitigation_block` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `mitigation_captcha_challenge` - (Optional) Captcha Challenge Parameters. Enables loadbalancer to perform captcha challenge Captcha challenge will be based on Google Recaptcha. With this feature enabled, only clients that pass the captcha challenge will be allowed to complete the HTTP request. When loadbalancer is configured to do Captcha Challenge, it will redirect the browser to an HTML page on every new HTTP request. This HTML page will have captcha challenge embedded in it. Client will be allowed to make the request only if the cap. See [Mitigation Captcha Challenge](#l7-ddos-protection-mitigation-captcha-challenge) below.
 
@@ -3821,10 +2513,6 @@ In addition to all arguments above, the following attributes are exported:
 
 `js_script_delay` - (Optional) Javascript Delay. Delay introduced by Javascript, in milliseconds (`Number`).
 
-<a id="l7-ddos-protection-clientside-action-none"></a>
-
-### L7 DDOS Protection Clientside Action None
-
 <a id="l7-ddos-protection-ddos-policy-custom"></a>
 
 ### L7 DDOS Protection DDOS Policy Custom
@@ -3834,18 +2522,6 @@ In addition to all arguments above, the following attributes are exported:
 `namespace` - (Optional) Namespace. When a configuration object(e.g. virtual_host) refers to another(e.g route) then namespace will hold the referred object's(e.g. route's) namespace (`String`).
 
 `tenant` - (Optional) Tenant. When a configuration object(e.g. virtual_host) refers to another(e.g route) then tenant will hold the referred object's(e.g. route's) tenant (`String`).
-
-<a id="l7-ddos-protection-ddos-policy-none"></a>
-
-### L7 DDOS Protection DDOS Policy None
-
-<a id="l7-ddos-protection-default-rps-threshold"></a>
-
-### L7 DDOS Protection Default Rps Threshold
-
-<a id="l7-ddos-protection-mitigation-block"></a>
-
-### L7 DDOS Protection Mitigation Block
 
 <a id="l7-ddos-protection-mitigation-captcha-challenge"></a>
 
@@ -3864,10 +2540,6 @@ In addition to all arguments above, the following attributes are exported:
 `custom_page` - (Optional) Custom Message for Javascript Challenge. Custom message is of type uri_ref. Currently supported URL schemes is string:///. For string:/// scheme, message needs to be encoded in Base64 format. You can specify this message as base64 encoded plain text message e.g. 'Please Wait.' or it can be HTML paragraph or a body string encoded as base64 string E.g. '<p> Please Wait </p>'. Base64 encoded string for this HTML is 'PHA+IFBsZWFzZSBXYWl0IDwvcD4=' (`String`).
 
 `js_script_delay` - (Optional) Javascript Delay. Delay introduced by Javascript, in milliseconds (`Number`).
-
-<a id="least-active"></a>
-
-### Least Active
 
 <a id="malware-protection-settings"></a>
 
@@ -3893,33 +2565,17 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Malware Protection Settings Malware Protection Rules Action
 
-`block` - (Optional) Empty. This can be used for messages where no values are needed. See [Block](#malware-protection-settings-malware-protection-rules-action-block) below.
+`block` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`report` - (Optional) Empty. This can be used for messages where no values are needed. See [Report](#malware-protection-settings-malware-protection-rules-action-report) below.
-
-<a id="malware-protection-settings-malware-protection-rules-action-block"></a>
-
-### Malware Protection Settings Malware Protection Rules Action Block
-
-<a id="malware-protection-settings-malware-protection-rules-action-report"></a>
-
-### Malware Protection Settings Malware Protection Rules Action Report
+`report` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="malware-protection-settings-malware-protection-rules-domain"></a>
 
 ### Malware Protection Settings Malware Protection Rules Domain
 
-`any_domain` - (Optional) Empty. This can be used for messages where no values are needed. See [Any Domain](#malware-protection-settings-malware-protection-rules-domain-any-domain) below.
+`any_domain` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`domain` - (Optional) Configuration for domain. See [Domain](#malware-protection-settings-malware-protection-rules-domain-domain) below.
-
-<a id="malware-protection-settings-malware-protection-rules-domain-any-domain"></a>
-
-### Malware Protection Settings Malware Protection Rules Domain Any Domain
-
-<a id="malware-protection-settings-malware-protection-rules-domain-domain"></a>
-
-### Malware Protection Settings Malware Protection Rules Domain Domain
+`domain` - (Optional) Configuration for domain (`Block`).
 
 <a id="malware-protection-settings-malware-protection-rules-metadata"></a>
 
@@ -3947,13 +2603,13 @@ In addition to all arguments above, the following attributes are exported:
 
 `compression_params` - (Optional) Compression Parameters. Enables loadbalancer to compress dispatched data from an upstream service upon client request. The content is compressed and then sent to the client with the appropriate headers if either response and request allow. Only GZIP compression is supported. By default compression will be skipped when: A request does NOT contain accept-encoding header. A request includes accept-encoding header, but it does not contain “gzip” or “*”. A request includes accept-encoding. See [Compression Params](#more-option-compression-params) below.
 
-`custom_errors` - (Optional) Custom Error Responses. Map of integer error codes as keys and string values that can be used to provide custom HTTP pages for each error code. Key of the map can be either response code class or HTTP Error code. Response code classes for key is configured as follows 3 -- for 3xx response code class 4 -- for 4xx response code class 5 -- for 5xx response code class Value of the map is string which represents custom HTTP responses. Specific response code takes preference when both response code. See [Custom Errors](#more-option-custom-errors) below.
+`custom_errors` - (Optional) Custom Error Responses. Map of integer error codes as keys and string values that can be used to provide custom HTTP pages for each error code. Key of the map can be either response code class or HTTP Error code. Response code classes for key is configured as follows 3 -- for 3xx response code class 4 -- for 4xx response code class 5 -- for 5xx response code class Value of the map is string which represents custom HTTP responses. Specific response code takes preference when both response code (`Block`).
 
 `disable_default_error_pages` - (Optional) Disable Default Error Pages. Disable the use of default F5XC error pages (`Bool`).
 
-`disable_path_normalize` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Path Normalize](#more-option-disable-path-normalize) below.
+`disable_path_normalize` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`enable_path_normalize` - (Optional) Empty. This can be used for messages where no values are needed. See [Enable Path Normalize](#more-option-enable-path-normalize) below.
+`enable_path_normalize` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `idle_timeout` - (Optional) Idle Timeout. The amount of time that a stream can exist without upstream or downstream activity, in milliseconds. The stream is terminated with a HTTP 504 (Gateway Timeout) error code if no upstream response header has been received, otherwise the stream is reset (`Number`).
 
@@ -3995,18 +2651,6 @@ In addition to all arguments above, the following attributes are exported:
 
 `remove_accept_encoding_header` - (Optional) Remove Accept-Encoding Header. If true, removes accept-encoding from the request headers before dispatching it to the upstream so that responses do not get compressed before reaching the filter (`Bool`).
 
-<a id="more-option-custom-errors"></a>
-
-### More Option Custom Errors
-
-<a id="more-option-disable-path-normalize"></a>
-
-### More Option Disable Path Normalize
-
-<a id="more-option-enable-path-normalize"></a>
-
-### More Option Enable Path Normalize
-
 <a id="more-option-request-cookies-to-add"></a>
 
 ### More Option Request Cookies To Add
@@ -4023,17 +2667,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ### More Option Request Cookies To Add Secret Value
 
-`blindfold_secret_info` - (Optional) Blindfold Secret. BlindfoldSecretInfoType specifies information about the Secret managed by F5XC Secret Management. See [Blindfold Secret Info](#more-option-request-cookies-to-add-secret-value-blindfold-secret-info) below.
+`blindfold_secret_info` - (Optional) Blindfold Secret. BlindfoldSecretInfoType specifies information about the Secret managed by F5XC Secret Management (`Block`).
 
-`clear_secret_info` - (Optional) In-Clear Secret. ClearSecretInfoType specifies information about the Secret that is not encrypted. See [Clear Secret Info](#more-option-request-cookies-to-add-secret-value-clear-secret-info) below.
-
-<a id="more-option-request-cookies-to-add-secret-value-blindfold-secret-info"></a>
-
-### More Option Request Cookies To Add Secret Value Blindfold Secret Info
-
-<a id="more-option-request-cookies-to-add-secret-value-clear-secret-info"></a>
-
-### More Option Request Cookies To Add Secret Value Clear Secret Info
+`clear_secret_info` - (Optional) In-Clear Secret. ClearSecretInfoType specifies information about the Secret that is not encrypted (`Block`).
 
 <a id="more-option-request-headers-to-add"></a>
 
@@ -4051,17 +2687,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ### More Option Request Headers To Add Secret Value
 
-`blindfold_secret_info` - (Optional) Blindfold Secret. BlindfoldSecretInfoType specifies information about the Secret managed by F5XC Secret Management. See [Blindfold Secret Info](#more-option-request-headers-to-add-secret-value-blindfold-secret-info) below.
+`blindfold_secret_info` - (Optional) Blindfold Secret. BlindfoldSecretInfoType specifies information about the Secret managed by F5XC Secret Management (`Block`).
 
-`clear_secret_info` - (Optional) In-Clear Secret. ClearSecretInfoType specifies information about the Secret that is not encrypted. See [Clear Secret Info](#more-option-request-headers-to-add-secret-value-clear-secret-info) below.
-
-<a id="more-option-request-headers-to-add-secret-value-blindfold-secret-info"></a>
-
-### More Option Request Headers To Add Secret Value Blindfold Secret Info
-
-<a id="more-option-request-headers-to-add-secret-value-clear-secret-info"></a>
-
-### More Option Request Headers To Add Secret Value Clear Secret Info
+`clear_secret_info` - (Optional) In-Clear Secret. ClearSecretInfoType specifies information about the Secret that is not encrypted (`Block`).
 
 <a id="more-option-response-cookies-to-add"></a>
 
@@ -4071,31 +2699,31 @@ In addition to all arguments above, the following attributes are exported:
 
 `add_expiry` - (Optional) Configuration for add_expiry (`String`).
 
-`add_httponly` - (Optional) Empty. This can be used for messages where no values are needed. See [Add Httponly](#more-option-response-cookies-to-add-add-httponly) below.
+`add_httponly` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`add_partitioned` - (Optional) Empty. This can be used for messages where no values are needed. See [Add Partitioned](#more-option-response-cookies-to-add-add-partitioned) below.
+`add_partitioned` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `add_path` - (Optional) Configuration for add_path (`String`).
 
-`add_secure` - (Optional) Empty. This can be used for messages where no values are needed. See [Add Secure](#more-option-response-cookies-to-add-add-secure) below.
+`add_secure` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`ignore_domain` - (Optional) Empty. This can be used for messages where no values are needed. See [Ignore Domain](#more-option-response-cookies-to-add-ignore-domain) below.
+`ignore_domain` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`ignore_expiry` - (Optional) Empty. This can be used for messages where no values are needed. See [Ignore Expiry](#more-option-response-cookies-to-add-ignore-expiry) below.
+`ignore_expiry` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`ignore_httponly` - (Optional) Empty. This can be used for messages where no values are needed. See [Ignore Httponly](#more-option-response-cookies-to-add-ignore-httponly) below.
+`ignore_httponly` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`ignore_max_age` - (Optional) Empty. This can be used for messages where no values are needed. See [Ignore Max Age](#more-option-response-cookies-to-add-ignore-max-age) below.
+`ignore_max_age` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`ignore_partitioned` - (Optional) Empty. This can be used for messages where no values are needed. See [Ignore Partitioned](#more-option-response-cookies-to-add-ignore-partitioned) below.
+`ignore_partitioned` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`ignore_path` - (Optional) Empty. This can be used for messages where no values are needed. See [Ignore Path](#more-option-response-cookies-to-add-ignore-path) below.
+`ignore_path` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`ignore_samesite` - (Optional) Empty. This can be used for messages where no values are needed. See [Ignore Samesite](#more-option-response-cookies-to-add-ignore-samesite) below.
+`ignore_samesite` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`ignore_secure` - (Optional) Empty. This can be used for messages where no values are needed. See [Ignore Secure](#more-option-response-cookies-to-add-ignore-secure) below.
+`ignore_secure` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`ignore_value` - (Optional) Empty. This can be used for messages where no values are needed. See [Ignore Value](#more-option-response-cookies-to-add-ignore-value) below.
+`ignore_value` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `max_age_value` - (Optional) Add Max Age. Add max age attribute (`Number`).
 
@@ -4103,91 +2731,23 @@ In addition to all arguments above, the following attributes are exported:
 
 `overwrite` - (Optional) Overwrite. Should the value be overwritten? If true, the value is overwritten to existing values. Default value is do not overwrite (`Bool`).
 
-`samesite_lax` - (Optional) Empty. This can be used for messages where no values are needed. See [Samesite Lax](#more-option-response-cookies-to-add-samesite-lax) below.
+`samesite_lax` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`samesite_none` - (Optional) Empty. This can be used for messages where no values are needed. See [Samesite None](#more-option-response-cookies-to-add-samesite-none) below.
+`samesite_none` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`samesite_strict` - (Optional) Empty. This can be used for messages where no values are needed. See [Samesite Strict](#more-option-response-cookies-to-add-samesite-strict) below.
+`samesite_strict` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `secret_value` - (Optional) Secret. SecretType is used in an object to indicate a sensitive/confidential field. See [Secret Value](#more-option-response-cookies-to-add-secret-value) below.
 
 `value` - (Optional) Value. Value of the Cookie header (`String`).
 
-<a id="more-option-response-cookies-to-add-add-httponly"></a>
-
-### More Option Response Cookies To Add Add Httponly
-
-<a id="more-option-response-cookies-to-add-add-partitioned"></a>
-
-### More Option Response Cookies To Add Add Partitioned
-
-<a id="more-option-response-cookies-to-add-add-secure"></a>
-
-### More Option Response Cookies To Add Add Secure
-
-<a id="more-option-response-cookies-to-add-ignore-domain"></a>
-
-### More Option Response Cookies To Add Ignore Domain
-
-<a id="more-option-response-cookies-to-add-ignore-expiry"></a>
-
-### More Option Response Cookies To Add Ignore Expiry
-
-<a id="more-option-response-cookies-to-add-ignore-httponly"></a>
-
-### More Option Response Cookies To Add Ignore Httponly
-
-<a id="more-option-response-cookies-to-add-ignore-max-age"></a>
-
-### More Option Response Cookies To Add Ignore Max Age
-
-<a id="more-option-response-cookies-to-add-ignore-partitioned"></a>
-
-### More Option Response Cookies To Add Ignore Partitioned
-
-<a id="more-option-response-cookies-to-add-ignore-path"></a>
-
-### More Option Response Cookies To Add Ignore Path
-
-<a id="more-option-response-cookies-to-add-ignore-samesite"></a>
-
-### More Option Response Cookies To Add Ignore Samesite
-
-<a id="more-option-response-cookies-to-add-ignore-secure"></a>
-
-### More Option Response Cookies To Add Ignore Secure
-
-<a id="more-option-response-cookies-to-add-ignore-value"></a>
-
-### More Option Response Cookies To Add Ignore Value
-
-<a id="more-option-response-cookies-to-add-samesite-lax"></a>
-
-### More Option Response Cookies To Add Samesite Lax
-
-<a id="more-option-response-cookies-to-add-samesite-none"></a>
-
-### More Option Response Cookies To Add Samesite None
-
-<a id="more-option-response-cookies-to-add-samesite-strict"></a>
-
-### More Option Response Cookies To Add Samesite Strict
-
 <a id="more-option-response-cookies-to-add-secret-value"></a>
 
 ### More Option Response Cookies To Add Secret Value
 
-`blindfold_secret_info` - (Optional) Blindfold Secret. BlindfoldSecretInfoType specifies information about the Secret managed by F5XC Secret Management. See [Blindfold Secret Info](#more-option-response-cookies-to-add-secret-value-blindfold-secret-info) below.
+`blindfold_secret_info` - (Optional) Blindfold Secret. BlindfoldSecretInfoType specifies information about the Secret managed by F5XC Secret Management (`Block`).
 
-`clear_secret_info` - (Optional) In-Clear Secret. ClearSecretInfoType specifies information about the Secret that is not encrypted. See [Clear Secret Info](#more-option-response-cookies-to-add-secret-value-clear-secret-info) below.
-
-<a id="more-option-response-cookies-to-add-secret-value-blindfold-secret-info"></a>
-
-### More Option Response Cookies To Add Secret Value Blindfold Secret Info
-
-<a id="more-option-response-cookies-to-add-secret-value-clear-secret-info"></a>
-
-### More Option Response Cookies To Add Secret Value Clear Secret Info
+`clear_secret_info` - (Optional) In-Clear Secret. ClearSecretInfoType specifies information about the Secret that is not encrypted (`Block`).
 
 <a id="more-option-response-headers-to-add"></a>
 
@@ -4205,29 +2765,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ### More Option Response Headers To Add Secret Value
 
-`blindfold_secret_info` - (Optional) Blindfold Secret. BlindfoldSecretInfoType specifies information about the Secret managed by F5XC Secret Management. See [Blindfold Secret Info](#more-option-response-headers-to-add-secret-value-blindfold-secret-info) below.
+`blindfold_secret_info` - (Optional) Blindfold Secret. BlindfoldSecretInfoType specifies information about the Secret managed by F5XC Secret Management (`Block`).
 
-`clear_secret_info` - (Optional) In-Clear Secret. ClearSecretInfoType specifies information about the Secret that is not encrypted. See [Clear Secret Info](#more-option-response-headers-to-add-secret-value-clear-secret-info) below.
-
-<a id="more-option-response-headers-to-add-secret-value-blindfold-secret-info"></a>
-
-### More Option Response Headers To Add Secret Value Blindfold Secret Info
-
-<a id="more-option-response-headers-to-add-secret-value-clear-secret-info"></a>
-
-### More Option Response Headers To Add Secret Value Clear Secret Info
-
-<a id="multi-lb-app"></a>
-
-### Multi LB App
-
-<a id="no-challenge"></a>
-
-### No Challenge
-
-<a id="no-service-policies"></a>
-
-### No Service Policies
+`clear_secret_info` - (Optional) In-Clear Secret. ClearSecretInfoType specifies information about the Secret that is not encrypted (`Block`).
 
 <a id="origin-server-subset-rule-list"></a>
 
@@ -4239,9 +2779,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Origin Server Subset Rule List Origin Server Subset Rules
 
-`any_asn` - (Optional) Empty. This can be used for messages where no values are needed. See [Any Asn](#origin-server-subset-rule-list-origin-server-subset-rules-any-asn) below.
+`any_asn` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`any_ip` - (Optional) Empty. This can be used for messages where no values are needed. See [Any IP](#origin-server-subset-rule-list-origin-server-subset-rules-any-ip) below.
+`any_ip` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `asn_list` - (Optional) ASN Match List. An unordered set of RFC 6793 defined 4-byte AS numbers that can be used to create allow or deny lists for use in network policy or service policy. It can be used to create the allow list only for DNS Load Balancer. See [Asn List](#origin-server-subset-rule-list-origin-server-subset-rules-asn-list) below.
 
@@ -4257,19 +2797,11 @@ In addition to all arguments above, the following attributes are exported:
 
 `metadata` - (Optional) Message Metadata. MessageMetaType is metadata (common attributes) of a message that only certain messages have. This information is propagated to the metadata of a child object that gets created from the containing message during view processing. The information in this type can be specified by user during create and replace APIs. See [Metadata](#origin-server-subset-rule-list-origin-server-subset-rules-metadata) below.
 
-`none` - (Optional) Empty. This can be used for messages where no values are needed. See [None](#origin-server-subset-rule-list-origin-server-subset-rules-none) below.
+`none` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`origin_server_subsets_action` - (Optional) Action. Add labels to select one or more origin servers. Note: The pre-requisite settings to be configured in the origin pool are: 1. Add labels to origin servers 2. Enable subset load balancing in the Origin Server Subsets section and configure keys in origin server subsets classes. See [Origin Server Subsets Action](#origin-server-subset-rule-list-origin-server-subset-rules-origin-server-subsets-action) below.
+`origin_server_subsets_action` - (Optional) Action. Add labels to select one or more origin servers. Note: The pre-requisite settings to be configured in the origin pool are: 1. Add labels to origin servers 2. Enable subset load balancing in the Origin Server Subsets section and configure keys in origin server subsets classes (`Block`).
 
 `re_name_list` - (Optional) RE Names. List of RE names for match (`List`).
-
-<a id="origin-server-subset-rule-list-origin-server-subset-rules-any-asn"></a>
-
-### Origin Server Subset Rule List Origin Server Subset Rules Any Asn
-
-<a id="origin-server-subset-rule-list-origin-server-subset-rules-any-ip"></a>
-
-### Origin Server Subset Rule List Origin Server Subset Rules Any IP
 
 <a id="origin-server-subset-rule-list-origin-server-subset-rules-asn-list"></a>
 
@@ -4281,11 +2813,7 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Origin Server Subset Rule List Origin Server Subset Rules Asn Matcher
 
-`asn_sets` - (Optional) BGP ASN Sets. A list of references to bgp_asn_set objects. See [Asn Sets](#origin-server-subset-rule-list-origin-server-subset-rules-asn-matcher-asn-sets) below.
-
-<a id="origin-server-subset-rule-list-origin-server-subset-rules-asn-matcher-asn-sets"></a>
-
-### Origin Server Subset Rule List Origin Server Subset Rules Asn Matcher Asn Sets
+`asn_sets` - (Optional) BGP ASN Sets. A list of references to bgp_asn_set objects (`Block`).
 
 <a id="origin-server-subset-rule-list-origin-server-subset-rules-client-selector"></a>
 
@@ -4299,11 +2827,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `invert_matcher` - (Optional) Invert IP Matcher. Invert the match result (`Bool`).
 
-`prefix_sets` - (Optional) IP Prefix Sets. A list of references to ip_prefix_set objects. See [Prefix Sets](#origin-server-subset-rule-list-origin-server-subset-rules-ip-matcher-prefix-sets) below.
-
-<a id="origin-server-subset-rule-list-origin-server-subset-rules-ip-matcher-prefix-sets"></a>
-
-### Origin Server Subset Rule List Origin Server Subset Rules IP Matcher Prefix Sets
+`prefix_sets` - (Optional) IP Prefix Sets. A list of references to ip_prefix_set objects (`Block`).
 
 <a id="origin-server-subset-rule-list-origin-server-subset-rules-ip-prefix-list"></a>
 
@@ -4321,49 +2845,33 @@ In addition to all arguments above, the following attributes are exported:
 
 `name` - (Optional) Name. This is the name of the message. The value of name has to follow DNS-1035 format (`String`).
 
-<a id="origin-server-subset-rule-list-origin-server-subset-rules-none"></a>
-
-### Origin Server Subset Rule List Origin Server Subset Rules None
-
-<a id="origin-server-subset-rule-list-origin-server-subset-rules-origin-server-subsets-action"></a>
-
-### Origin Server Subset Rule List Origin Server Subset Rules Origin Server Subsets Action
-
 <a id="policy-based-challenge"></a>
 
 ### Policy Based Challenge
 
-`always_enable_captcha_challenge` - (Optional) Empty. This can be used for messages where no values are needed. See [Always Enable Captcha Challenge](#policy-based-challenge-always-enable-captcha-challenge) below.
+`always_enable_captcha_challenge` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`always_enable_js_challenge` - (Optional) Empty. This can be used for messages where no values are needed. See [Always Enable Js Challenge](#policy-based-challenge-always-enable-js-challenge) below.
+`always_enable_js_challenge` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `captcha_challenge_parameters` - (Optional) Captcha Challenge Parameters. Enables loadbalancer to perform captcha challenge Captcha challenge will be based on Google Recaptcha. With this feature enabled, only clients that pass the captcha challenge will be allowed to complete the HTTP request. When loadbalancer is configured to do Captcha Challenge, it will redirect the browser to an HTML page on every new HTTP request. This HTML page will have captcha challenge embedded in it. Client will be allowed to make the request only if the cap. See [Captcha Challenge Parameters](#policy-based-challenge-captcha-challenge-parameters) below.
 
-`default_captcha_challenge_parameters` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Captcha Challenge Parameters](#policy-based-challenge-default-captcha-challenge-parameters) below.
+`default_captcha_challenge_parameters` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`default_js_challenge_parameters` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Js Challenge Parameters](#policy-based-challenge-default-js-challenge-parameters) below.
+`default_js_challenge_parameters` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`default_mitigation_settings` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Mitigation Settings](#policy-based-challenge-default-mitigation-settings) below.
+`default_mitigation_settings` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`default_temporary_blocking_parameters` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Temporary Blocking Parameters](#policy-based-challenge-default-temporary-blocking-parameters) below.
+`default_temporary_blocking_parameters` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `js_challenge_parameters` - (Optional) Javascript Challenge Parameters. Enables loadbalancer to perform client browser compatibility test by redirecting to a page with Javascript. With this feature enabled, only clients that are capable of executing Javascript(mostly browsers) will be allowed to complete the HTTP request. When loadbalancer is configured to do Javascript Challenge, it will redirect the browser to an HTML page on every new HTTP request. This HTML page will have Javascript embedded in it. Loadbalancer chooses a set o. See [Js Challenge Parameters](#policy-based-challenge-js-challenge-parameters) below.
 
 `malicious_user_mitigation` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Malicious User Mitigation](#policy-based-challenge-malicious-user-mitigation) below.
 
-`no_challenge` - (Optional) Empty. This can be used for messages where no values are needed. See [No Challenge](#policy-based-challenge-no-challenge) below.
+`no_challenge` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `rule_list` - (Optional) Challenge Rule List. List of challenge rules to be used in policy based challenge. See [Rule List](#policy-based-challenge-rule-list) below.
 
 `temporary_user_blocking` - (Optional) Temporary User Blocking. Specifies configuration for temporary user blocking resulting from user behavior analysis. When Malicious User Mitigation is enabled from service policy rules, users' accessing the application will be analyzed for malicious activity and the configured mitigation actions will be taken on identified malicious users. These mitigation actions include setting up temporary blocking on that user. This configuration specifies settings on how that blocking should be done by th. See [Temporary User Blocking](#policy-based-challenge-temporary-user-blocking) below.
-
-<a id="policy-based-challenge-always-enable-captcha-challenge"></a>
-
-### Policy Based Challenge Always Enable Captcha Challenge
-
-<a id="policy-based-challenge-always-enable-js-challenge"></a>
-
-### Policy Based Challenge Always Enable Js Challenge
 
 <a id="policy-based-challenge-captcha-challenge-parameters"></a>
 
@@ -4372,22 +2880,6 @@ In addition to all arguments above, the following attributes are exported:
 `cookie_expiry` - (Optional) Cookie Expiration Period. Cookie expiration period, in seconds. An expired cookie causes the loadbalancer to issue a new challenge (`Number`).
 
 `custom_page` - (Optional) Custom message for Captcha Challenge. Custom message is of type uri_ref. Currently supported URL schemes is string:///. For string:/// scheme, message needs to be encoded in Base64 format. You can specify this message as base64 encoded plain text message e.g. 'Please Wait.' or it can be HTML paragraph or a body string encoded as base64 string E.g. '<p> Please Wait </p>'. Base64 encoded string for this HTML is 'PHA+IFBsZWFzZSBXYWl0IDwvcD4=' (`String`).
-
-<a id="policy-based-challenge-default-captcha-challenge-parameters"></a>
-
-### Policy Based Challenge Default Captcha Challenge Parameters
-
-<a id="policy-based-challenge-default-js-challenge-parameters"></a>
-
-### Policy Based Challenge Default Js Challenge Parameters
-
-<a id="policy-based-challenge-default-mitigation-settings"></a>
-
-### Policy Based Challenge Default Mitigation Settings
-
-<a id="policy-based-challenge-default-temporary-blocking-parameters"></a>
-
-### Policy Based Challenge Default Temporary Blocking Parameters
 
 <a id="policy-based-challenge-js-challenge-parameters"></a>
 
@@ -4409,10 +2901,6 @@ In addition to all arguments above, the following attributes are exported:
 
 `tenant` - (Optional) Tenant. When a configuration object(e.g. virtual_host) refers to another(e.g route) then tenant will hold the referred object's(e.g. route's) tenant (`String`).
 
-<a id="policy-based-challenge-no-challenge"></a>
-
-### Policy Based Challenge No Challenge
-
 <a id="policy-based-challenge-rule-list"></a>
 
 ### Policy Based Challenge Rule List
@@ -4423,17 +2911,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Policy Based Challenge Rule List Rules
 
-`metadata` - (Optional) Message Metadata. MessageMetaType is metadata (common attributes) of a message that only certain messages have. This information is propagated to the metadata of a child object that gets created from the containing message during view processing. The information in this type can be specified by user during create and replace APIs. See [Metadata](#policy-based-challenge-rule-list-rules-metadata) below.
+`metadata` - (Optional) Message Metadata. MessageMetaType is metadata (common attributes) of a message that only certain messages have. This information is propagated to the metadata of a child object that gets created from the containing message during view processing. The information in this type can be specified by user during create and replace APIs (`Block`).
 
-`spec` - (Optional) Challenge Rule Specification. A Challenge Rule consists of an unordered list of predicates and an action. The predicates are evaluated against a set of input fields that are extracted from or derived from an L7 request API. A request API is considered to match the rule if all predicates in the rule evaluate to true for that request. Any predicates that are not specified in a rule are implicitly considered to be true. If a request API matches a challenge rule, the configured challenge is enfor. See [Spec](#policy-based-challenge-rule-list-rules-spec) below.
-
-<a id="policy-based-challenge-rule-list-rules-metadata"></a>
-
-### Policy Based Challenge Rule List Rules Metadata
-
-<a id="policy-based-challenge-rule-list-rules-spec"></a>
-
-### Policy Based Challenge Rule List Rules Spec
+`spec` - (Optional) Challenge Rule Specification. A Challenge Rule consists of an unordered list of predicates and an action. The predicates are evaluated against a set of input fields that are extracted from or derived from an L7 request API. A request API is considered to match the rule if all predicates in the rule evaluate to true for that request. Any predicates that are not specified in a rule are implicitly considered to be true. If a request API matches a challenge rule, the configured challenge is enfor (`Block`).
 
 <a id="policy-based-challenge-temporary-user-blocking"></a>
 
@@ -4445,79 +2925,31 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Protected Cookies
 
-`add_httponly` - (Optional) Empty. This can be used for messages where no values are needed. See [Add Httponly](#protected-cookies-add-httponly) below.
+`add_httponly` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`add_secure` - (Optional) Empty. This can be used for messages where no values are needed. See [Add Secure](#protected-cookies-add-secure) below.
+`add_secure` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`disable_tampering_protection` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Tampering Protection](#protected-cookies-disable-tampering-protection) below.
+`disable_tampering_protection` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`enable_tampering_protection` - (Optional) Empty. This can be used for messages where no values are needed. See [Enable Tampering Protection](#protected-cookies-enable-tampering-protection) below.
+`enable_tampering_protection` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`ignore_httponly` - (Optional) Empty. This can be used for messages where no values are needed. See [Ignore Httponly](#protected-cookies-ignore-httponly) below.
+`ignore_httponly` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`ignore_max_age` - (Optional) Empty. This can be used for messages where no values are needed. See [Ignore Max Age](#protected-cookies-ignore-max-age) below.
+`ignore_max_age` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`ignore_samesite` - (Optional) Empty. This can be used for messages where no values are needed. See [Ignore Samesite](#protected-cookies-ignore-samesite) below.
+`ignore_samesite` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`ignore_secure` - (Optional) Empty. This can be used for messages where no values are needed. See [Ignore Secure](#protected-cookies-ignore-secure) below.
+`ignore_secure` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `max_age_value` - (Optional) Add Max Age. Add max age attribute (`Number`).
 
 `name` - (Optional) Cookie Name. Name of the Cookie (`String`).
 
-`samesite_lax` - (Optional) Empty. This can be used for messages where no values are needed. See [Samesite Lax](#protected-cookies-samesite-lax) below.
+`samesite_lax` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`samesite_none` - (Optional) Empty. This can be used for messages where no values are needed. See [Samesite None](#protected-cookies-samesite-none) below.
+`samesite_none` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`samesite_strict` - (Optional) Empty. This can be used for messages where no values are needed. See [Samesite Strict](#protected-cookies-samesite-strict) below.
-
-<a id="protected-cookies-add-httponly"></a>
-
-### Protected Cookies Add Httponly
-
-<a id="protected-cookies-add-secure"></a>
-
-### Protected Cookies Add Secure
-
-<a id="protected-cookies-disable-tampering-protection"></a>
-
-### Protected Cookies Disable Tampering Protection
-
-<a id="protected-cookies-enable-tampering-protection"></a>
-
-### Protected Cookies Enable Tampering Protection
-
-<a id="protected-cookies-ignore-httponly"></a>
-
-### Protected Cookies Ignore Httponly
-
-<a id="protected-cookies-ignore-max-age"></a>
-
-### Protected Cookies Ignore Max Age
-
-<a id="protected-cookies-ignore-samesite"></a>
-
-### Protected Cookies Ignore Samesite
-
-<a id="protected-cookies-ignore-secure"></a>
-
-### Protected Cookies Ignore Secure
-
-<a id="protected-cookies-samesite-lax"></a>
-
-### Protected Cookies Samesite Lax
-
-<a id="protected-cookies-samesite-none"></a>
-
-### Protected Cookies Samesite None
-
-<a id="protected-cookies-samesite-strict"></a>
-
-### Protected Cookies Samesite Strict
-
-<a id="random"></a>
-
-### Random
+`samesite_strict` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="rate-limit"></a>
 
@@ -4527,9 +2959,9 @@ In addition to all arguments above, the following attributes are exported:
 
 `ip_allowed_list` - (Optional) IPv4 Prefix List. x-example: '192.168.20.0/24' List of IPv4 prefixes that represent an endpoint. See [IP Allowed List](#rate-limit-ip-allowed-list) below.
 
-`no_ip_allowed_list` - (Optional) Empty. This can be used for messages where no values are needed. See [No IP Allowed List](#rate-limit-no-ip-allowed-list) below.
+`no_ip_allowed_list` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_policies` - (Optional) Empty. This can be used for messages where no values are needed. See [No Policies](#rate-limit-no-policies) below.
+`no_policies` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `policies` - (Optional) List of service policies. Service policies form a sequential evaluation engine where each policy (and rules within that policy) are evaluated in order from top to bottom. When a request's characteristics match a policy's criteria, that policy takes effect and no further policies are evaluated. The order of policies in this list is critical for achieving the intended behavior. Each policy is a reference to a service_policy resource. See [Policies](#rate-limit-policies) below.
 
@@ -4557,14 +2989,6 @@ In addition to all arguments above, the following attributes are exported:
 
 `prefixes` - (Optional) IPv4 Prefix List. List of IPv4 prefixes that represent an endpoint (`List`).
 
-<a id="rate-limit-no-ip-allowed-list"></a>
-
-### Rate Limit No IP Allowed List
-
-<a id="rate-limit-no-policies"></a>
-
-### Rate Limit No Policies
-
 <a id="rate-limit-policies"></a>
 
 ### Rate Limit Policies
@@ -4589,13 +3013,13 @@ In addition to all arguments above, the following attributes are exported:
 
 `burst_multiplier` - (Optional) Burst Multiplier. The maximum burst of requests to accommodate, expressed as a multiple of the rate (`Number`).
 
-`disabled` - (Optional) Empty. This can be used for messages where no values are needed. See [Disabled](#rate-limit-rate-limiter-disabled) below.
+`disabled` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`leaky_bucket` - (Optional) Leaky Bucket Rate Limiter. Leaky-Bucket is the default rate limiter algorithm for F5. See [Leaky Bucket](#rate-limit-rate-limiter-leaky-bucket) below.
+`leaky_bucket` - (Optional) Leaky Bucket Rate Limiter. Leaky-Bucket is the default rate limiter algorithm for F5 (`Block`).
 
 `period_multiplier` - (Optional) Periods. This setting, combined with Per Period units, provides a duration (`Number`).
 
-`token_bucket` - (Optional) Token Bucket Rate Limiter. Token-Bucket is a rate limiter algorithm that is stricter with enforcing limits. See [Token Bucket](#rate-limit-rate-limiter-token-bucket) below.
+`token_bucket` - (Optional) Token Bucket Rate Limiter. Token-Bucket is a rate limiter algorithm that is stricter with enforcing limits (`Block`).
 
 `total_number` - (Optional) Number Of Requests. The total number of allowed requests per rate-limiting period (`Number`).
 
@@ -4605,35 +3029,11 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Rate Limit Rate Limiter Action Block
 
-`hours` - (Optional) Hours. Input Duration Hours. See [Hours](#rate-limit-rate-limiter-action-block-hours) below.
+`hours` - (Optional) Hours. Input Duration Hours (`Block`).
 
-`minutes` - (Optional) Minutes. Input Duration Minutes. See [Minutes](#rate-limit-rate-limiter-action-block-minutes) below.
+`minutes` - (Optional) Minutes. Input Duration Minutes (`Block`).
 
-`seconds` - (Optional) Seconds. Input Duration Seconds. See [Seconds](#rate-limit-rate-limiter-action-block-seconds) below.
-
-<a id="rate-limit-rate-limiter-action-block-hours"></a>
-
-### Rate Limit Rate Limiter Action Block Hours
-
-<a id="rate-limit-rate-limiter-action-block-minutes"></a>
-
-### Rate Limit Rate Limiter Action Block Minutes
-
-<a id="rate-limit-rate-limiter-action-block-seconds"></a>
-
-### Rate Limit Rate Limiter Action Block Seconds
-
-<a id="rate-limit-rate-limiter-disabled"></a>
-
-### Rate Limit Rate Limiter Disabled
-
-<a id="rate-limit-rate-limiter-leaky-bucket"></a>
-
-### Rate Limit Rate Limiter Leaky Bucket
-
-<a id="rate-limit-rate-limiter-token-bucket"></a>
-
-### Rate Limit Rate Limiter Token Bucket
+`seconds` - (Optional) Seconds. Input Duration Seconds (`Block`).
 
 <a id="ring-hash"></a>
 
@@ -4657,63 +3057,27 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Ring Hash Hash Policy Cookie
 
-`add_httponly` - (Optional) Empty. This can be used for messages where no values are needed. See [Add Httponly](#ring-hash-hash-policy-cookie-add-httponly) below.
+`add_httponly` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`add_secure` - (Optional) Empty. This can be used for messages where no values are needed. See [Add Secure](#ring-hash-hash-policy-cookie-add-secure) below.
+`add_secure` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`ignore_httponly` - (Optional) Empty. This can be used for messages where no values are needed. See [Ignore Httponly](#ring-hash-hash-policy-cookie-ignore-httponly) below.
+`ignore_httponly` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`ignore_samesite` - (Optional) Empty. This can be used for messages where no values are needed. See [Ignore Samesite](#ring-hash-hash-policy-cookie-ignore-samesite) below.
+`ignore_samesite` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`ignore_secure` - (Optional) Empty. This can be used for messages where no values are needed. See [Ignore Secure](#ring-hash-hash-policy-cookie-ignore-secure) below.
+`ignore_secure` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `name` - (Optional) Name. The name of the cookie that will be used to obtain the hash key. If the cookie is not present and TTL below is not set, no hash will be produced (`String`).
 
 `path` - (Optional) Path. The name of the path for the cookie. If no path is specified here, no path will be set for the cookie (`String`).
 
-`samesite_lax` - (Optional) Empty. This can be used for messages where no values are needed. See [Samesite Lax](#ring-hash-hash-policy-cookie-samesite-lax) below.
+`samesite_lax` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`samesite_none` - (Optional) Empty. This can be used for messages where no values are needed. See [Samesite None](#ring-hash-hash-policy-cookie-samesite-none) below.
+`samesite_none` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`samesite_strict` - (Optional) Empty. This can be used for messages where no values are needed. See [Samesite Strict](#ring-hash-hash-policy-cookie-samesite-strict) below.
+`samesite_strict` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `ttl` - (Optional) TTL. If specified, a cookie with the TTL will be generated if the cookie is not present. If the TTL is present and zero, the generated cookie will be a session cookie. TTL value is in milliseconds (`Number`).
-
-<a id="ring-hash-hash-policy-cookie-add-httponly"></a>
-
-### Ring Hash Hash Policy Cookie Add Httponly
-
-<a id="ring-hash-hash-policy-cookie-add-secure"></a>
-
-### Ring Hash Hash Policy Cookie Add Secure
-
-<a id="ring-hash-hash-policy-cookie-ignore-httponly"></a>
-
-### Ring Hash Hash Policy Cookie Ignore Httponly
-
-<a id="ring-hash-hash-policy-cookie-ignore-samesite"></a>
-
-### Ring Hash Hash Policy Cookie Ignore Samesite
-
-<a id="ring-hash-hash-policy-cookie-ignore-secure"></a>
-
-### Ring Hash Hash Policy Cookie Ignore Secure
-
-<a id="ring-hash-hash-policy-cookie-samesite-lax"></a>
-
-### Ring Hash Hash Policy Cookie Samesite Lax
-
-<a id="ring-hash-hash-policy-cookie-samesite-none"></a>
-
-### Ring Hash Hash Policy Cookie Samesite None
-
-<a id="ring-hash-hash-policy-cookie-samesite-strict"></a>
-
-### Ring Hash Hash Policy Cookie Samesite Strict
-
-<a id="round-robin"></a>
-
-### Round Robin
 
 <a id="routes"></a>
 
@@ -4775,15 +3139,11 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Routes Direct Response Route Incoming Port
 
-`no_port_match` - (Optional) Empty. This can be used for messages where no values are needed. See [No Port Match](#routes-direct-response-route-incoming-port-no-port-match) below.
+`no_port_match` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `port` - (Optional) Port. Exact Port to match (`Number`).
 
 `port_ranges` - (Optional) Configuration for port_ranges (`String`).
-
-<a id="routes-direct-response-route-incoming-port-no-port-match"></a>
-
-### Routes Direct Response Route Incoming Port No Port Match
 
 <a id="routes-direct-response-route-path"></a>
 
@@ -4835,15 +3195,11 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Routes Redirect Route Incoming Port
 
-`no_port_match` - (Optional) Empty. This can be used for messages where no values are needed. See [No Port Match](#routes-redirect-route-incoming-port-no-port-match) below.
+`no_port_match` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `port` - (Optional) Port. Exact Port to match (`Number`).
 
 `port_ranges` - (Optional) Configuration for port_ranges (`String`).
-
-<a id="routes-redirect-route-incoming-port-no-port-match"></a>
-
-### Routes Redirect Route Incoming Port No Port Match
 
 <a id="routes-redirect-route-path"></a>
 
@@ -4867,21 +3223,13 @@ In addition to all arguments above, the following attributes are exported:
 
 `proto_redirect` - (Optional) Protocol. swap protocol part of incoming URL in redirect URL The protocol can be swapped with either HTTP or HTTPS When incoming-proto option is specified, swapping of protocol is not done (`String`).
 
-`remove_all_params` - (Optional) Empty. This can be used for messages where no values are needed. See [Remove All Params](#routes-redirect-route-route-redirect-remove-all-params) below.
+`remove_all_params` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `replace_params` - (Optional) Replace All Parameters (`String`).
 
 `response_code` - (Optional) Response Code. The HTTP status code to use in the redirect response (`Number`).
 
-`retain_all_params` - (Optional) Empty. This can be used for messages where no values are needed. See [Retain All Params](#routes-redirect-route-route-redirect-retain-all-params) below.
-
-<a id="routes-redirect-route-route-redirect-remove-all-params"></a>
-
-### Routes Redirect Route Route Redirect Remove All Params
-
-<a id="routes-redirect-route-route-redirect-retain-all-params"></a>
-
-### Routes Redirect Route Route Redirect Retain All Params
+`retain_all_params` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="routes-simple-route"></a>
 
@@ -4889,9 +3237,9 @@ In addition to all arguments above, the following attributes are exported:
 
 `advanced_options` - (Optional) Advanced Route Options. Configure advanced options for route like path rewrite, hash policy, etc. See [Advanced Options](#routes-simple-route-advanced-options) below.
 
-`auto_host_rewrite` - (Optional) Empty. This can be used for messages where no values are needed. See [Auto Host Rewrite](#routes-simple-route-auto-host-rewrite) below.
+`auto_host_rewrite` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`disable_host_rewrite` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Host Rewrite](#routes-simple-route-disable-host-rewrite) below.
+`disable_host_rewrite` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `headers` - (Optional) Headers. List of (key, value) headers. See [Headers](#routes-simple-route-headers) below.
 
@@ -4911,215 +3259,83 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Routes Simple Route Advanced Options
 
-`app_firewall` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [App Firewall](#routes-simple-route-advanced-options-app-firewall) below.
+`app_firewall` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name (`Block`).
 
-`bot_defense_javascript_injection` - (Optional) Bot Defense Javascript Injection Configuration for inline deployments. Bot Defense Javascript Injection Configuration for inline bot defense deployments. See [Bot Defense Javascript Injection](#routes-simple-route-advanced-options-bot-defense-javascript-injection) below.
+`bot_defense_javascript_injection` - (Optional) Bot Defense Javascript Injection Configuration for inline deployments. Bot Defense Javascript Injection Configuration for inline bot defense deployments (`Block`).
 
-`buffer_policy` - (Optional) Buffer Configuration. Some upstream applications are not capable of handling streamed data. This config enables buffering the entire request before sending to upstream application. We can specify the maximum buffer size and buffer interval with this config. Buffering can be enabled and disabled at VirtualHost and Route levels Route level buffer configuration takes precedence. See [Buffer Policy](#routes-simple-route-advanced-options-buffer-policy) below.
+`buffer_policy` - (Optional) Buffer Configuration. Some upstream applications are not capable of handling streamed data. This config enables buffering the entire request before sending to upstream application. We can specify the maximum buffer size and buffer interval with this config. Buffering can be enabled and disabled at VirtualHost and Route levels Route level buffer configuration takes precedence (`Block`).
 
-`common_buffering` - (Optional) Empty. This can be used for messages where no values are needed. See [Common Buffering](#routes-simple-route-advanced-options-common-buffering) below.
+`common_buffering` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`common_hash_policy` - (Optional) Empty. This can be used for messages where no values are needed. See [Common Hash Policy](#routes-simple-route-advanced-options-common-hash-policy) below.
+`common_hash_policy` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`cors_policy` - (Optional) CORS Policy. Cross-Origin Resource Sharing requests configuration specified at Virtual-host or Route level. Route level configuration takes precedence. An example of an Cross origin HTTP request GET /resources/public-data/ HTTP/1.1 Host: bar.other User-Agent: Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.5; en-US; rv:1.9.1b3pre) Gecko/20081130 Minefield/3.1b3pre Accept: text/HTML,application/xhtml+XML,application/XML;q=0.9,*/*;q=0.8 Accept-Language: en-us,en;q=0.5 Accept-Encoding: gzip,deflate. See [CORS Policy](#routes-simple-route-advanced-options-cors-policy) below.
+`cors_policy` - (Optional) CORS Policy. Cross-Origin Resource Sharing requests configuration specified at Virtual-host or Route level. Route level configuration takes precedence. An example of an Cross origin HTTP request GET /resources/public-data/ HTTP/1.1 Host: bar.other User-Agent: Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.5; en-US; rv:1.9.1b3pre) Gecko/20081130 Minefield/3.1b3pre Accept: text/HTML,application/xhtml+XML,application/XML;q=0.9,*/*;q=0.8 Accept-Language: en-us,en;q=0.5 Accept-Encoding: gzip,deflate (`Block`).
 
-`csrf_policy` - (Optional) CSRF Policy. To mitigate CSRF attack , the policy checks where a request is coming from to determine if the request's origin is the same as its detination.The policy relies on two pieces of information used in determining if a request originated from the same host. 1. The origin that caused the user agent to issue the request (source origin). 2. The origin that the request is going to (target origin). When the policy evaluating a request, it ensures both pieces of information are present and. See [CSRF Policy](#routes-simple-route-advanced-options-csrf-policy) below.
+`csrf_policy` - (Optional) CSRF Policy. To mitigate CSRF attack , the policy checks where a request is coming from to determine if the request's origin is the same as its detination.The policy relies on two pieces of information used in determining if a request originated from the same host. 1. The origin that caused the user agent to issue the request (source origin). 2. The origin that the request is going to (target origin). When the policy evaluating a request, it ensures both pieces of information are present and (`Block`).
 
-`default_retry_policy` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Retry Policy](#routes-simple-route-advanced-options-default-retry-policy) below.
+`default_retry_policy` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `disable_location_add` - (Optional) Disable Location Addition. disables append of x-volterra-location = <RE-site-name> at route level, if it is configured at virtual-host level. This configuration is ignored on CE sites (`Bool`).
 
-`disable_mirroring` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Mirroring](#routes-simple-route-advanced-options-disable-mirroring) below.
+`disable_mirroring` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`disable_prefix_rewrite` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Prefix Rewrite](#routes-simple-route-advanced-options-disable-prefix-rewrite) below.
+`disable_prefix_rewrite` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`disable_spdy` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Spdy](#routes-simple-route-advanced-options-disable-spdy) below.
+`disable_spdy` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`disable_waf` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable WAF](#routes-simple-route-advanced-options-disable-waf) below.
+`disable_waf` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`disable_web_socket_config` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Web Socket Config](#routes-simple-route-advanced-options-disable-web-socket-config) below.
+`disable_web_socket_config` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`do_not_retract_cluster` - (Optional) Empty. This can be used for messages where no values are needed. See [Do Not Retract Cluster](#routes-simple-route-advanced-options-do-not-retract-cluster) below.
+`do_not_retract_cluster` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`enable_spdy` - (Optional) Empty. This can be used for messages where no values are needed. See [Enable Spdy](#routes-simple-route-advanced-options-enable-spdy) below.
+`enable_spdy` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`endpoint_subsets` - (Optional) Origin Servers Subsets. Upstream origin pool may be configured to divide its origin servers into subsets based on metadata attached to the origin servers. Routes may then specify the metadata that a endpoint must match in order to be selected by the load balancer For origin servers which are discovered in K8S or Consul cluster, the label of the service is merged with endpoint's labels. In case of Consul, the label is derived from the 'Tag' field. For labels that are common between configured. See [Endpoint Subsets](#routes-simple-route-advanced-options-endpoint-subsets) below.
+`endpoint_subsets` - (Optional) Origin Servers Subsets. Upstream origin pool may be configured to divide its origin servers into subsets based on metadata attached to the origin servers. Routes may then specify the metadata that a endpoint must match in order to be selected by the load balancer For origin servers which are discovered in K8S or Consul cluster, the label of the service is merged with endpoint's labels. In case of Consul, the label is derived from the 'Tag' field. For labels that are common between configured (`Block`).
 
-`inherited_bot_defense_javascript_injection` - (Optional) Empty. This can be used for messages where no values are needed. See [Inherited Bot Defense Javascript Injection](#routes-simple-route-advanced-options-inherited-bot-defense-javascript-injection) below.
+`inherited_bot_defense_javascript_injection` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`inherited_waf` - (Optional) Empty. This can be used for messages where no values are needed. See [Inherited WAF](#routes-simple-route-advanced-options-inherited-waf) below.
+`inherited_waf` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`inherited_waf_exclusion` - (Optional) Empty. This can be used for messages where no values are needed. See [Inherited WAF Exclusion](#routes-simple-route-advanced-options-inherited-waf-exclusion) below.
+`inherited_waf_exclusion` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`mirror_policy` - (Optional) Mirror Policy. MirrorPolicy is used for shadowing traffic from one origin pool to another. The approach used is 'fire and forget', meaning it will not wait for the shadow origin pool to respond before returning the response from the primary origin pool. All normal statistics are collected for the shadow origin pool making this feature useful for testing and troubleshooting. See [Mirror Policy](#routes-simple-route-advanced-options-mirror-policy) below.
+`mirror_policy` - (Optional) Mirror Policy. MirrorPolicy is used for shadowing traffic from one origin pool to another. The approach used is 'fire and forget', meaning it will not wait for the shadow origin pool to respond before returning the response from the primary origin pool. All normal statistics are collected for the shadow origin pool making this feature useful for testing and troubleshooting (`Block`).
 
-`no_retry_policy` - (Optional) Empty. This can be used for messages where no values are needed. See [No Retry Policy](#routes-simple-route-advanced-options-no-retry-policy) below.
+`no_retry_policy` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `prefix_rewrite` - (Optional) Enable Prefix Rewrite. prefix_rewrite indicates that during forwarding, the matched prefix (or path) should be swapped with its value. When using regex path matching, the entire path (not including the query string) will be swapped with this value (`String`).
 
 `priority` - (Optional) Routing Priority. Priority routing for each request. Different connection pools are used based on the priority selected for the request. Also, circuit-breaker configuration at destination cluster is chosen based on selected priority. Default routing mechanism High-Priority routing mechanism. Possible values are `DEFAULT`, `HIGH`. Defaults to `DEFAULT` (`String`).
 
-`regex_rewrite` - (Optional) Regex Match Rewrite. RegexMatchRewrite describes how to match a string and then produce a new string using a regular expression and a substitution string. See [Regex Rewrite](#routes-simple-route-advanced-options-regex-rewrite) below.
+`regex_rewrite` - (Optional) Regex Match Rewrite. RegexMatchRewrite describes how to match a string and then produce a new string using a regular expression and a substitution string (`Block`).
 
-`request_cookies_to_add` - (Optional) Add Cookies in Cookie Header. Cookies are key-value pairs to be added to HTTP request being routed towards upstream. Cookies specified at this level are applied after cookies from matched Route are applied. See [Request Cookies To Add](#routes-simple-route-advanced-options-request-cookies-to-add) below.
+`request_cookies_to_add` - (Optional) Add Cookies in Cookie Header. Cookies are key-value pairs to be added to HTTP request being routed towards upstream. Cookies specified at this level are applied after cookies from matched Route are applied (`Block`).
 
 `request_cookies_to_remove` - (Optional) Remove Cookies from Cookie Header. List of keys of Cookies to be removed from the HTTP request being sent towards upstream (`List`).
 
-`request_headers_to_add` - (Optional) Add Request Headers. Headers are key-value pairs to be added to HTTP request being routed towards upstream. See [Request Headers To Add](#routes-simple-route-advanced-options-request-headers-to-add) below.
+`request_headers_to_add` - (Optional) Add Request Headers. Headers are key-value pairs to be added to HTTP request being routed towards upstream (`Block`).
 
 `request_headers_to_remove` - (Optional) Remove Request Headers. List of keys of Headers to be removed from the HTTP request being sent towards upstream (`List`).
 
-`response_cookies_to_add` - (Optional) Add Set-Cookie Headers. Cookies are name-value pairs along with optional attribute parameters to be added to HTTP response being sent towards downstream. Cookies specified at this level are applied after cookies from matched Route are applied. See [Response Cookies To Add](#routes-simple-route-advanced-options-response-cookies-to-add) below.
+`response_cookies_to_add` - (Optional) Add Set-Cookie Headers. Cookies are name-value pairs along with optional attribute parameters to be added to HTTP response being sent towards downstream. Cookies specified at this level are applied after cookies from matched Route are applied (`Block`).
 
 `response_cookies_to_remove` - (Optional) Remove Cookies from Set-Cookie Headers. List of name of Cookies to be removed from the HTTP response being sent towards downstream. Entire set-cookie header will be removed (`List`).
 
-`response_headers_to_add` - (Optional) Add Response Headers. Headers are key-value pairs to be added to HTTP response being sent towards downstream. See [Response Headers To Add](#routes-simple-route-advanced-options-response-headers-to-add) below.
+`response_headers_to_add` - (Optional) Add Response Headers. Headers are key-value pairs to be added to HTTP response being sent towards downstream (`Block`).
 
 `response_headers_to_remove` - (Optional) Remove Response Headers. List of keys of Headers to be removed from the HTTP response being sent towards downstream (`List`).
 
-`retract_cluster` - (Optional) Empty. This can be used for messages where no values are needed. See [Retract Cluster](#routes-simple-route-advanced-options-retract-cluster) below.
+`retract_cluster` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`retry_policy` - (Optional) Retry Policy. Retry policy configuration for route destination. See [Retry Policy](#routes-simple-route-advanced-options-retry-policy) below.
+`retry_policy` - (Optional) Retry Policy. Retry policy configuration for route destination (`Block`).
 
-`specific_hash_policy` - (Optional) Hash Policy List. List of hash policy rules. See [Specific Hash Policy](#routes-simple-route-advanced-options-specific-hash-policy) below.
+`specific_hash_policy` - (Optional) Hash Policy List. List of hash policy rules (`Block`).
 
 `timeout` - (Optional) Timeout. The timeout for the route including all retries, in milliseconds. Should be set to a high value or 0 (infinite timeout) for server-side streaming (`Number`).
 
-`waf_exclusion_policy` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [WAF Exclusion Policy](#routes-simple-route-advanced-options-waf-exclusion-policy) below.
+`waf_exclusion_policy` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name (`Block`).
 
-`web_socket_config` - (Optional) WebSocket Configuration. Configuration to allow WebSocket Request headers of such upgrade looks like below 'connection', 'Upgrade' 'upgrade', 'WebSocket' With configuration to allow WebSocket upgrade, ADC will produce following response 'HTTP/1.1 101 Switching Protocols 'Upgrade': 'WebSocket' 'Connection': 'Upgrade'. See [Web Socket Config](#routes-simple-route-advanced-options-web-socket-config) below.
-
-<a id="routes-simple-route-advanced-options-app-firewall"></a>
-
-### Routes Simple Route Advanced Options App Firewall
-
-<a id="routes-simple-route-advanced-options-bot-defense-javascript-injection"></a>
-
-### Routes Simple Route Advanced Options Bot Defense Javascript Injection
-
-<a id="routes-simple-route-advanced-options-buffer-policy"></a>
-
-### Routes Simple Route Advanced Options Buffer Policy
-
-<a id="routes-simple-route-advanced-options-common-buffering"></a>
-
-### Routes Simple Route Advanced Options Common Buffering
-
-<a id="routes-simple-route-advanced-options-common-hash-policy"></a>
-
-### Routes Simple Route Advanced Options Common Hash Policy
-
-<a id="routes-simple-route-advanced-options-cors-policy"></a>
-
-### Routes Simple Route Advanced Options CORS Policy
-
-<a id="routes-simple-route-advanced-options-csrf-policy"></a>
-
-### Routes Simple Route Advanced Options CSRF Policy
-
-<a id="routes-simple-route-advanced-options-default-retry-policy"></a>
-
-### Routes Simple Route Advanced Options Default Retry Policy
-
-<a id="routes-simple-route-advanced-options-disable-mirroring"></a>
-
-### Routes Simple Route Advanced Options Disable Mirroring
-
-<a id="routes-simple-route-advanced-options-disable-prefix-rewrite"></a>
-
-### Routes Simple Route Advanced Options Disable Prefix Rewrite
-
-<a id="routes-simple-route-advanced-options-disable-spdy"></a>
-
-### Routes Simple Route Advanced Options Disable Spdy
-
-<a id="routes-simple-route-advanced-options-disable-waf"></a>
-
-### Routes Simple Route Advanced Options Disable WAF
-
-<a id="routes-simple-route-advanced-options-disable-web-socket-config"></a>
-
-### Routes Simple Route Advanced Options Disable Web Socket Config
-
-<a id="routes-simple-route-advanced-options-do-not-retract-cluster"></a>
-
-### Routes Simple Route Advanced Options Do Not Retract Cluster
-
-<a id="routes-simple-route-advanced-options-enable-spdy"></a>
-
-### Routes Simple Route Advanced Options Enable Spdy
-
-<a id="routes-simple-route-advanced-options-endpoint-subsets"></a>
-
-### Routes Simple Route Advanced Options Endpoint Subsets
-
-<a id="routes-simple-route-advanced-options-inherited-bot-defense-javascript-injection"></a>
-
-### Routes Simple Route Advanced Options Inherited Bot Defense Javascript Injection
-
-<a id="routes-simple-route-advanced-options-inherited-waf"></a>
-
-### Routes Simple Route Advanced Options Inherited WAF
-
-<a id="routes-simple-route-advanced-options-inherited-waf-exclusion"></a>
-
-### Routes Simple Route Advanced Options Inherited WAF Exclusion
-
-<a id="routes-simple-route-advanced-options-mirror-policy"></a>
-
-### Routes Simple Route Advanced Options Mirror Policy
-
-<a id="routes-simple-route-advanced-options-no-retry-policy"></a>
-
-### Routes Simple Route Advanced Options No Retry Policy
-
-<a id="routes-simple-route-advanced-options-regex-rewrite"></a>
-
-### Routes Simple Route Advanced Options Regex Rewrite
-
-<a id="routes-simple-route-advanced-options-request-cookies-to-add"></a>
-
-### Routes Simple Route Advanced Options Request Cookies To Add
-
-<a id="routes-simple-route-advanced-options-request-headers-to-add"></a>
-
-### Routes Simple Route Advanced Options Request Headers To Add
-
-<a id="routes-simple-route-advanced-options-response-cookies-to-add"></a>
-
-### Routes Simple Route Advanced Options Response Cookies To Add
-
-<a id="routes-simple-route-advanced-options-response-headers-to-add"></a>
-
-### Routes Simple Route Advanced Options Response Headers To Add
-
-<a id="routes-simple-route-advanced-options-retract-cluster"></a>
-
-### Routes Simple Route Advanced Options Retract Cluster
-
-<a id="routes-simple-route-advanced-options-retry-policy"></a>
-
-### Routes Simple Route Advanced Options Retry Policy
-
-<a id="routes-simple-route-advanced-options-specific-hash-policy"></a>
-
-### Routes Simple Route Advanced Options Specific Hash Policy
-
-<a id="routes-simple-route-advanced-options-waf-exclusion-policy"></a>
-
-### Routes Simple Route Advanced Options WAF Exclusion Policy
-
-<a id="routes-simple-route-advanced-options-web-socket-config"></a>
-
-### Routes Simple Route Advanced Options Web Socket Config
-
-<a id="routes-simple-route-auto-host-rewrite"></a>
-
-### Routes Simple Route Auto Host Rewrite
-
-<a id="routes-simple-route-disable-host-rewrite"></a>
-
-### Routes Simple Route Disable Host Rewrite
+`web_socket_config` - (Optional) WebSocket Configuration. Configuration to allow WebSocket Request headers of such upgrade looks like below 'connection', 'Upgrade' 'upgrade', 'WebSocket' With configuration to allow WebSocket upgrade, ADC will produce following response 'HTTP/1.1 101 Switching Protocols 'Upgrade': 'WebSocket' 'Connection': 'Upgrade' (`Block`).
 
 <a id="routes-simple-route-headers"></a>
 
@@ -5139,41 +3355,25 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Routes Simple Route Incoming Port
 
-`no_port_match` - (Optional) Empty. This can be used for messages where no values are needed. See [No Port Match](#routes-simple-route-incoming-port-no-port-match) below.
+`no_port_match` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `port` - (Optional) Port. Exact Port to match (`Number`).
 
 `port_ranges` - (Optional) Configuration for port_ranges (`String`).
 
-<a id="routes-simple-route-incoming-port-no-port-match"></a>
-
-### Routes Simple Route Incoming Port No Port Match
-
 <a id="routes-simple-route-origin-pools"></a>
 
 ### Routes Simple Route Origin Pools
 
-`cluster` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Cluster](#routes-simple-route-origin-pools-cluster) below.
+`cluster` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name (`Block`).
 
-`endpoint_subsets` - (Optional) Origin Servers Subsets. Upstream origin pool may be configured to divide its origin servers into subsets based on metadata attached to the origin servers. Routes may then specify the metadata that a endpoint must match in order to be selected by the load balancer For origin servers which are discovered in K8S or Consul cluster, the label of the service is merged with endpoint's labels. In case of Consul, the label is derived from the 'Tag' field. For labels that are common between configured. See [Endpoint Subsets](#routes-simple-route-origin-pools-endpoint-subsets) below.
+`endpoint_subsets` - (Optional) Origin Servers Subsets. Upstream origin pool may be configured to divide its origin servers into subsets based on metadata attached to the origin servers. Routes may then specify the metadata that a endpoint must match in order to be selected by the load balancer For origin servers which are discovered in K8S or Consul cluster, the label of the service is merged with endpoint's labels. In case of Consul, the label is derived from the 'Tag' field. For labels that are common between configured (`Block`).
 
-`pool` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Pool](#routes-simple-route-origin-pools-pool) below.
+`pool` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name (`Block`).
 
 `priority` - (Optional) Priority. Priority of this origin pool, valid only with multiple origin pools. Value of 0 will make the pool as lowest priority origin pool Priority of 1 means highest priority and is considered active. When active origin pool is not available, lower priority origin pools are made active as per the increasing priority (`Number`).
 
 `weight` - (Optional) Weight. Weight of this origin pool, valid only with multiple origin pool. Value of 0 will disable the pool (`Number`).
-
-<a id="routes-simple-route-origin-pools-cluster"></a>
-
-### Routes Simple Route Origin Pools Cluster
-
-<a id="routes-simple-route-origin-pools-endpoint-subsets"></a>
-
-### Routes Simple Route Origin Pools Endpoint Subsets
-
-<a id="routes-simple-route-origin-pools-pool"></a>
-
-### Routes Simple Route Origin Pools Pool
 
 <a id="routes-simple-route-path"></a>
 
@@ -5189,19 +3389,11 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Routes Simple Route Query Params
 
-`remove_all_params` - (Optional) Empty. This can be used for messages where no values are needed. See [Remove All Params](#routes-simple-route-query-params-remove-all-params) below.
+`remove_all_params` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `replace_params` - (Optional) Replace All Parameters (`String`).
 
-`retain_all_params` - (Optional) Empty. This can be used for messages where no values are needed. See [Retain All Params](#routes-simple-route-query-params-retain-all-params) below.
-
-<a id="routes-simple-route-query-params-remove-all-params"></a>
-
-### Routes Simple Route Query Params Remove All Params
-
-<a id="routes-simple-route-query-params-retain-all-params"></a>
-
-### Routes Simple Route Query Params Retain All Params
+`retain_all_params` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="sensitive-data-disclosure-rules"></a>
 
@@ -5217,9 +3409,9 @@ In addition to all arguments above, the following attributes are exported:
 
 `body` - (Optional) Body Section Masking Options. Options for HTTP Body Masking. See [Body](#sensitive-data-disclosure-rules-sensitive-data-types-in-response-body) below.
 
-`mask` - (Optional) Empty. This can be used for messages where no values are needed. See [Mask](#sensitive-data-disclosure-rules-sensitive-data-types-in-response-mask) below.
+`mask` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`report` - (Optional) Empty. This can be used for messages where no values are needed. See [Report](#sensitive-data-disclosure-rules-sensitive-data-types-in-response-report) below.
+`report` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="sensitive-data-disclosure-rules-sensitive-data-types-in-response-api-endpoint"></a>
 
@@ -5234,14 +3426,6 @@ In addition to all arguments above, the following attributes are exported:
 ### Sensitive Data Disclosure Rules Sensitive Data Types In Response Body
 
 `fields` - (Optional) Values. List of JSON Path field values. Use square brackets with an underscore [_] to indicate array elements (e.g., person.emails[_]). To reference JSON keys that contain spaces, enclose the entire path in double quotes. For example: 'person.first name' (`List`).
-
-<a id="sensitive-data-disclosure-rules-sensitive-data-types-in-response-mask"></a>
-
-### Sensitive Data Disclosure Rules Sensitive Data Types In Response Mask
-
-<a id="sensitive-data-disclosure-rules-sensitive-data-types-in-response-report"></a>
-
-### Sensitive Data Disclosure Rules Sensitive Data Types In Response Report
 
 <a id="sensitive-data-policy"></a>
 
@@ -5259,29 +3443,17 @@ In addition to all arguments above, the following attributes are exported:
 
 `tenant` - (Optional) Tenant. When a configuration object(e.g. virtual_host) refers to another(e.g route) then tenant will hold the referred object's(e.g. route's) tenant (`String`).
 
-<a id="service-policies-from-namespace"></a>
-
-### Service Policies From Namespace
-
 <a id="single-lb-app"></a>
 
 ### Single LB App
 
-`disable_discovery` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Discovery](#single-lb-app-disable-discovery) below.
+`disable_discovery` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`disable_malicious_user_detection` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Malicious User Detection](#single-lb-app-disable-malicious-user-detection) below.
+`disable_malicious_user_detection` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `enable_discovery` - (Optional) API Discovery Setting. Specifies the settings used for API discovery. See [Enable Discovery](#single-lb-app-enable-discovery) below.
 
-`enable_malicious_user_detection` - (Optional) Empty. This can be used for messages where no values are needed. See [Enable Malicious User Detection](#single-lb-app-enable-malicious-user-detection) below.
-
-<a id="single-lb-app-disable-discovery"></a>
-
-### Single LB App Disable Discovery
-
-<a id="single-lb-app-disable-malicious-user-detection"></a>
-
-### Single LB App Disable Malicious User Detection
+`enable_malicious_user_detection` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="single-lb-app-enable-discovery"></a>
 
@@ -5293,57 +3465,33 @@ In addition to all arguments above, the following attributes are exported:
 
 `custom_api_auth_discovery` - (Optional) API Discovery Advanced Settings. API Discovery Advanced settings. See [Custom API Auth Discovery](#single-lb-app-enable-discovery-custom-api-auth-discovery) below.
 
-`default_api_auth_discovery` - (Optional) Empty. This can be used for messages where no values are needed. See [Default API Auth Discovery](#single-lb-app-enable-discovery-default-api-auth-discovery) below.
+`default_api_auth_discovery` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`disable_learn_from_redirect_traffic` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Learn From Redirect Traffic](#single-lb-app-enable-discovery-disable-learn-from-redirect-traffic) below.
+`disable_learn_from_redirect_traffic` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `discovered_api_settings` - (Optional) Discovered API Settings. x-example: '2' Configure Discovered API Settings. See [Discovered API Settings](#single-lb-app-enable-discovery-discovered-api-settings) below.
 
-`enable_learn_from_redirect_traffic` - (Optional) Empty. This can be used for messages where no values are needed. See [Enable Learn From Redirect Traffic](#single-lb-app-enable-discovery-enable-learn-from-redirect-traffic) below.
+`enable_learn_from_redirect_traffic` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="single-lb-app-enable-discovery-api-crawler"></a>
 
 ### Single LB App Enable Discovery API Crawler
 
-`api_crawler_config` - (Optional) Crawler Configure. See [API Crawler Config](#single-lb-app-enable-discovery-api-crawler-api-crawler-config) below.
+`api_crawler_config` - (Optional) Crawler Configure (`Block`).
 
-`disable_api_crawler` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable API Crawler](#single-lb-app-enable-discovery-api-crawler-disable-api-crawler) below.
-
-<a id="single-lb-app-enable-discovery-api-crawler-api-crawler-config"></a>
-
-### Single LB App Enable Discovery API Crawler API Crawler Config
-
-<a id="single-lb-app-enable-discovery-api-crawler-disable-api-crawler"></a>
-
-### Single LB App Enable Discovery API Crawler Disable API Crawler
+`disable_api_crawler` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="single-lb-app-enable-discovery-api-discovery-from-code-scan"></a>
 
 ### Single LB App Enable Discovery API Discovery From Code Scan
 
-`code_base_integrations` - (Optional) Select Code Base Integrations. See [Code Base Integrations](#single-lb-app-enable-discovery-api-discovery-from-code-scan-code-base-integrations) below.
-
-<a id="single-lb-app-enable-discovery-api-discovery-from-code-scan-code-base-integrations"></a>
-
-### Single LB App Enable Discovery API Discovery From Code Scan Code Base Integrations
+`code_base_integrations` - (Optional) Select Code Base Integrations (`Block`).
 
 <a id="single-lb-app-enable-discovery-custom-api-auth-discovery"></a>
 
 ### Single LB App Enable Discovery Custom API Auth Discovery
 
-`api_discovery_ref` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [API Discovery Ref](#single-lb-app-enable-discovery-custom-api-auth-discovery-api-discovery-ref) below.
-
-<a id="single-lb-app-enable-discovery-custom-api-auth-discovery-api-discovery-ref"></a>
-
-### Single LB App Enable Discovery Custom API Auth Discovery API Discovery Ref
-
-<a id="single-lb-app-enable-discovery-default-api-auth-discovery"></a>
-
-### Single LB App Enable Discovery Default API Auth Discovery
-
-<a id="single-lb-app-enable-discovery-disable-learn-from-redirect-traffic"></a>
-
-### Single LB App Enable Discovery Disable Learn From Redirect Traffic
+`api_discovery_ref` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name (`Block`).
 
 <a id="single-lb-app-enable-discovery-discovered-api-settings"></a>
 
@@ -5351,35 +3499,15 @@ In addition to all arguments above, the following attributes are exported:
 
 `purge_duration_for_inactive_discovered_apis` - (Optional) Purge Duration for Inactive Discovered APIs from Traffic. Inactive discovered API will be deleted after configured duration (`Number`).
 
-<a id="single-lb-app-enable-discovery-enable-learn-from-redirect-traffic"></a>
-
-### Single LB App Enable Discovery Enable Learn From Redirect Traffic
-
-<a id="single-lb-app-enable-malicious-user-detection"></a>
-
-### Single LB App Enable Malicious User Detection
-
 <a id="slow-ddos-mitigation"></a>
 
 ### Slow DDOS Mitigation
 
-`disable_request_timeout` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Request Timeout](#slow-ddos-mitigation-disable-request-timeout) below.
+`disable_request_timeout` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `request_headers_timeout` - (Optional) Request Headers Timeout. The amount of time the client has to send only the headers on the request stream before the stream is cancelled. The default value is 10000 milliseconds. This setting provides protection against Slowloris attacks (`Number`).
 
 `request_timeout` - (Optional) Custom Timeout (`Number`).
-
-<a id="slow-ddos-mitigation-disable-request-timeout"></a>
-
-### Slow DDOS Mitigation Disable Request Timeout
-
-<a id="source-ip-stickiness"></a>
-
-### Source IP Stickiness
-
-<a id="system-default-timeouts"></a>
-
-### System Default Timeouts
 
 <a id="timeouts"></a>
 
@@ -5401,7 +3529,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `as_number` - (Optional) AS Number. RFC 6793 defined 4-byte AS number (`Number`).
 
-`bot_skip_processing` - (Optional) Empty. This can be used for messages where no values are needed. See [Bot Skip Processing](#trusted-clients-bot-skip-processing) below.
+`bot_skip_processing` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `expiration_timestamp` - (Optional) Expiration Timestamp. The expiration_timestamp is the RFC 3339 format timestamp at which the containing rule is considered to be logically expired. The rule continues to exist in the configuration but is not applied anymore (`String`).
 
@@ -5413,15 +3541,11 @@ In addition to all arguments above, the following attributes are exported:
 
 `metadata` - (Optional) Message Metadata. MessageMetaType is metadata (common attributes) of a message that only certain messages have. This information is propagated to the metadata of a child object that gets created from the containing message during view processing. The information in this type can be specified by user during create and replace APIs. See [Metadata](#trusted-clients-metadata) below.
 
-`skip_processing` - (Optional) Empty. This can be used for messages where no values are needed. See [Skip Processing](#trusted-clients-skip-processing) below.
+`skip_processing` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `user_identifier` - (Optional) User Identifier. Identify user based on user identifier. User identifier value needs to be copied from security event (`String`).
 
-`waf_skip_processing` - (Optional) Empty. This can be used for messages where no values are needed. See [WAF Skip Processing](#trusted-clients-waf-skip-processing) below.
-
-<a id="trusted-clients-bot-skip-processing"></a>
-
-### Trusted Clients Bot Skip Processing
+`waf_skip_processing` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="trusted-clients-http-header"></a>
 
@@ -5451,18 +3575,6 @@ In addition to all arguments above, the following attributes are exported:
 
 `name` - (Optional) Name. This is the name of the message. The value of name has to follow DNS-1035 format (`String`).
 
-<a id="trusted-clients-skip-processing"></a>
-
-### Trusted Clients Skip Processing
-
-<a id="trusted-clients-waf-skip-processing"></a>
-
-### Trusted Clients WAF Skip Processing
-
-<a id="user-id-client-ip"></a>
-
-### User Id Client IP
-
 <a id="user-identification"></a>
 
 ### User Identification
@@ -5491,17 +3603,17 @@ In addition to all arguments above, the following attributes are exported:
 
 ### WAF Exclusion WAF Exclusion Inline Rules Rules
 
-`any_domain` - (Optional) Empty. This can be used for messages where no values are needed. See [Any Domain](#waf-exclusion-waf-exclusion-inline-rules-rules-any-domain) below.
+`any_domain` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`any_path` - (Optional) Empty. This can be used for messages where no values are needed. See [Any Path](#waf-exclusion-waf-exclusion-inline-rules-rules-any-path) below.
+`any_path` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`app_firewall_detection_control` - (Optional) App Firewall Detection Control. Define the list of Signature IDs, Violations, Attack Types and Bot Names that should be excluded from triggering on the defined match criteria. See [App Firewall Detection Control](#waf-exclusion-waf-exclusion-inline-rules-rules-app-firewall-detection-control) below.
+`app_firewall_detection_control` - (Optional) App Firewall Detection Control. Define the list of Signature IDs, Violations, Attack Types and Bot Names that should be excluded from triggering on the defined match criteria (`Block`).
 
 `exact_value` - (Optional) Exact Value. Exact domain name (`String`).
 
 `expiration_timestamp` - (Optional) Expiration Timestamp. The expiration_timestamp is the RFC 3339 format timestamp at which the containing rule is considered to be logically expired. The rule continues to exist in the configuration but is not applied anymore (`String`).
 
-`metadata` - (Optional) Message Metadata. MessageMetaType is metadata (common attributes) of a message that only certain messages have. This information is propagated to the metadata of a child object that gets created from the containing message during view processing. The information in this type can be specified by user during create and replace APIs. See [Metadata](#waf-exclusion-waf-exclusion-inline-rules-rules-metadata) below.
+`metadata` - (Optional) Message Metadata. MessageMetaType is metadata (common attributes) of a message that only certain messages have. This information is propagated to the metadata of a child object that gets created from the containing message during view processing. The information in this type can be specified by user during create and replace APIs (`Block`).
 
 `methods` - (Optional) Methods. methods to be matched (`List`).
 
@@ -5511,27 +3623,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `suffix_value` - (Optional) Suffix Value. Suffix of domain name e.g 'xyz.com' will match '*.xyz.com' and 'xyz.com' (`String`).
 
-`waf_skip_processing` - (Optional) Empty. This can be used for messages where no values are needed. See [WAF Skip Processing](#waf-exclusion-waf-exclusion-inline-rules-rules-waf-skip-processing) below.
-
-<a id="waf-exclusion-waf-exclusion-inline-rules-rules-any-domain"></a>
-
-### WAF Exclusion WAF Exclusion Inline Rules Rules Any Domain
-
-<a id="waf-exclusion-waf-exclusion-inline-rules-rules-any-path"></a>
-
-### WAF Exclusion WAF Exclusion Inline Rules Rules Any Path
-
-<a id="waf-exclusion-waf-exclusion-inline-rules-rules-app-firewall-detection-control"></a>
-
-### WAF Exclusion WAF Exclusion Inline Rules Rules App Firewall Detection Control
-
-<a id="waf-exclusion-waf-exclusion-inline-rules-rules-metadata"></a>
-
-### WAF Exclusion WAF Exclusion Inline Rules Rules Metadata
-
-<a id="waf-exclusion-waf-exclusion-inline-rules-rules-waf-skip-processing"></a>
-
-### WAF Exclusion WAF Exclusion Inline Rules Rules WAF Skip Processing
+`waf_skip_processing` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="waf-exclusion-waf-exclusion-policy"></a>
 

--- a/docs/resources/ike1.md
+++ b/docs/resources/ike1.md
@@ -68,11 +68,11 @@ resource "f5xc_ike1" "example" {
 
 `ike_keylifetime_minutes` - (Optional) Minutes. Set IKE Key Lifetime in minutes. See [Ike Keylifetime Minutes](#ike-keylifetime-minutes) below for details.
 
-`use_default_keylifetime` - (Optional) Empty. This can be used for messages where no values are needed. See [Use Default Keylifetime](#use-default-keylifetime) below for details.
+`use_default_keylifetime` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 > **Note:** One of the arguments from this list "reauth_disabled, reauth_timeout_days, reauth_timeout_hours" must be set.
 
-`reauth_disabled` - (Optional) Empty. This can be used for messages where no values are needed. See [Reauth Disabled](#reauth-disabled) below for details.
+`reauth_disabled` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `reauth_timeout_days` - (Optional) Days. Set Duration in days. See [Reauth Timeout Days](#reauth-timeout-days) below for details.
 
@@ -100,10 +100,6 @@ In addition to all arguments above, the following attributes are exported:
 
 `duration` - (Optional) Duration (`Number`).
 
-<a id="reauth-disabled"></a>
-
-### Reauth Disabled
-
 <a id="reauth-timeout-days"></a>
 
 ### Reauth Timeout Days
@@ -127,10 +123,6 @@ In addition to all arguments above, the following attributes are exported:
 `read` - (Optional) A string that can be [parsed as a duration](`HTTPS://pkg.go.dev/time#ParseDuration`) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Read operations occur during any refresh or planning operation when refresh is enabled (`String`).
 
 `update` - (Optional) A string that can be [parsed as a duration](`HTTPS://pkg.go.dev/time#ParseDuration`) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours) (`String`).
-
-<a id="use-default-keylifetime"></a>
-
-### Use Default Keylifetime
 
 ## Import
 

--- a/docs/resources/ike2.md
+++ b/docs/resources/ike2.md
@@ -66,7 +66,7 @@ resource "f5xc_ike2" "example" {
 
 `dh_group_set` - (Optional) Diffie Hellman Groups. Choose the acceptable Diffie Hellman(DH) Group or Groups that you are willing to accept as part of this profile. See [Dh Group Set](#dh-group-set) below for details.
 
-`disable_pfs` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Pfs](#disable-pfs) below for details.
+`disable_pfs` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 > **Note:** One of the arguments from this list "ike_keylifetime_hours, ike_keylifetime_minutes, use_default_keylifetime" must be set.
 
@@ -74,7 +74,7 @@ resource "f5xc_ike2" "example" {
 
 `ike_keylifetime_minutes` - (Optional) Minutes. Set IKE Key Lifetime in minutes. See [Ike Keylifetime Minutes](#ike-keylifetime-minutes) below for details.
 
-`use_default_keylifetime` - (Optional) Empty. This can be used for messages where no values are needed. See [Use Default Keylifetime](#use-default-keylifetime) below for details.
+`use_default_keylifetime` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `timeouts` - (Optional) See [Timeouts](#timeouts) below for details.
 
@@ -91,10 +91,6 @@ In addition to all arguments above, the following attributes are exported:
 ### Dh Group Set
 
 `dh_groups` - (Optional) Diffie Hellman Groups (`List`).
-
-<a id="disable-pfs"></a>
-
-### Disable Pfs
 
 <a id="ike-keylifetime-hours"></a>
 
@@ -119,10 +115,6 @@ In addition to all arguments above, the following attributes are exported:
 `read` - (Optional) A string that can be [parsed as a duration](`HTTPS://pkg.go.dev/time#ParseDuration`) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Read operations occur during any refresh or planning operation when refresh is enabled (`String`).
 
 `update` - (Optional) A string that can be [parsed as a duration](`HTTPS://pkg.go.dev/time#ParseDuration`) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours) (`String`).
-
-<a id="use-default-keylifetime"></a>
-
-### Use Default Keylifetime
 
 ## Import
 

--- a/docs/resources/ike_phase1_profile.md
+++ b/docs/resources/ike_phase1_profile.md
@@ -74,13 +74,13 @@ resource "f5xc_ike_phase1_profile" "example" {
 
 `ike_keylifetime_minutes` - (Optional) Minutes. Set IKE Key Lifetime in minutes. See [Ike Keylifetime Minutes](#ike-keylifetime-minutes) below for details.
 
-`use_default_keylifetime` - (Optional) Empty. This can be used for messages where no values are needed. See [Use Default Keylifetime](#use-default-keylifetime) below for details.
+`use_default_keylifetime` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `prf` - (Optional) PseudoRandomFunction. Select PseudoRandomFunction for IKE SA (`List`).
 
 > **Note:** One of the arguments from this list "reauth_disabled, reauth_timeout_days, reauth_timeout_hours" must be set.
 
-`reauth_disabled` - (Optional) Empty. This can be used for messages where no values are needed. See [Reauth Disabled](#reauth-disabled) below for details.
+`reauth_disabled` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `reauth_timeout_days` - (Optional) Days. Set Duration in days. See [Reauth Timeout Days](#reauth-timeout-days) below for details.
 
@@ -108,10 +108,6 @@ In addition to all arguments above, the following attributes are exported:
 
 `duration` - (Optional) Duration (`Number`).
 
-<a id="reauth-disabled"></a>
-
-### Reauth Disabled
-
 <a id="reauth-timeout-days"></a>
 
 ### Reauth Timeout Days
@@ -135,10 +131,6 @@ In addition to all arguments above, the following attributes are exported:
 `read` - (Optional) A string that can be [parsed as a duration](`HTTPS://pkg.go.dev/time#ParseDuration`) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Read operations occur during any refresh or planning operation when refresh is enabled (`String`).
 
 `update` - (Optional) A string that can be [parsed as a duration](`HTTPS://pkg.go.dev/time#ParseDuration`) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours) (`String`).
-
-<a id="use-default-keylifetime"></a>
-
-### Use Default Keylifetime
 
 ## Import
 

--- a/docs/resources/ike_phase2_profile.md
+++ b/docs/resources/ike_phase2_profile.md
@@ -68,7 +68,7 @@ resource "f5xc_ike_phase2_profile" "example" {
 
 `dh_group_set` - (Optional) Diffie Hellman Groups. Choose the acceptable Diffie Hellman(DH) Group or Groups that you are willing to accept as part of this profile. See [Dh Group Set](#dh-group-set) below for details.
 
-`disable_pfs` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Pfs](#disable-pfs) below for details.
+`disable_pfs` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `encryption_algos` - (Optional) Encryption Algorithms. Choose one or more encryption algorithms (`List`).
 
@@ -78,7 +78,7 @@ resource "f5xc_ike_phase2_profile" "example" {
 
 `ike_keylifetime_minutes` - (Optional) Minutes. Set IKE Key Lifetime in minutes. See [Ike Keylifetime Minutes](#ike-keylifetime-minutes) below for details.
 
-`use_default_keylifetime` - (Optional) Empty. This can be used for messages where no values are needed. See [Use Default Keylifetime](#use-default-keylifetime) below for details.
+`use_default_keylifetime` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `timeouts` - (Optional) See [Timeouts](#timeouts) below for details.
 
@@ -95,10 +95,6 @@ In addition to all arguments above, the following attributes are exported:
 ### Dh Group Set
 
 `dh_groups` - (Optional) Diffie Hellman Groups. Choose the acceptable Diffie Hellman(DH) Group or Groups that you are willing to accept as part of this profile (`List`).
-
-<a id="disable-pfs"></a>
-
-### Disable Pfs
 
 <a id="ike-keylifetime-hours"></a>
 
@@ -123,10 +119,6 @@ In addition to all arguments above, the following attributes are exported:
 `read` - (Optional) A string that can be [parsed as a duration](`HTTPS://pkg.go.dev/time#ParseDuration`) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Read operations occur during any refresh or planning operation when refresh is enabled (`String`).
 
 `update` - (Optional) A string that can be [parsed as a duration](`HTTPS://pkg.go.dev/time#ParseDuration`) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours) (`String`).
-
-<a id="use-default-keylifetime"></a>
-
-### Use Default Keylifetime
 
 ## Import
 

--- a/docs/resources/infraprotect_asn.md
+++ b/docs/resources/infraprotect_asn.md
@@ -62,9 +62,9 @@ resource "f5xc_infraprotect_asn" "example" {
 
 > **Note:** One of the arguments from this list "bgp_session_disabled, bgp_session_enabled" must be set.
 
-`bgp_session_disabled` - (Optional) Empty. This can be used for messages where no values are needed. See [BGP Session Disabled](#bgp-session-disabled) below for details.
+`bgp_session_disabled` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`bgp_session_enabled` - (Optional) Empty. This can be used for messages where no values are needed. See [BGP Session Enabled](#bgp-session-enabled) below for details.
+`bgp_session_enabled` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `timeouts` - (Optional) See [Timeouts](#timeouts) below for details.
 
@@ -75,14 +75,6 @@ In addition to all arguments above, the following attributes are exported:
 `id` - (Optional) Unique identifier for the resource (`String`).
 
 ---
-
-<a id="bgp-session-disabled"></a>
-
-### BGP Session Disabled
-
-<a id="bgp-session-enabled"></a>
-
-### BGP Session Enabled
 
 <a id="timeouts"></a>
 

--- a/docs/resources/infraprotect_deny_list_rule.md
+++ b/docs/resources/infraprotect_deny_list_rule.md
@@ -64,17 +64,17 @@ resource "f5xc_infraprotect_deny_list_rule" "example" {
 
 > **Note:** One of the arguments from this list "expiration_never, expiration_timestamp, one_day, one_hour, one_month, one_year" must be set.
 
-`expiration_never` - (Optional) Empty. This can be used for messages where no values are needed. See [Expiration Never](#expiration-never) below for details.
+`expiration_never` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `expiration_timestamp` - (Optional) Expiration Time (UTC). This deny list rule will expire at the given timestamp and will be removed from the system afterwards (`String`).
 
-`one_day` - (Optional) Empty. This can be used for messages where no values are needed. See [One Day](#one-day) below for details.
+`one_day` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`one_hour` - (Optional) Empty. This can be used for messages where no values are needed. See [One Hour](#one-hour) below for details.
+`one_hour` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`one_month` - (Optional) Empty. This can be used for messages where no values are needed. See [One Month](#one-month) below for details.
+`one_month` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`one_year` - (Optional) Empty. This can be used for messages where no values are needed. See [One Year](#one-year) below for details.
+`one_year` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `prefix` - (Optional) Configuration for prefix (`String`).
 
@@ -87,26 +87,6 @@ In addition to all arguments above, the following attributes are exported:
 `id` - (Optional) Unique identifier for the resource (`String`).
 
 ---
-
-<a id="expiration-never"></a>
-
-### Expiration Never
-
-<a id="one-day"></a>
-
-### One Day
-
-<a id="one-hour"></a>
-
-### One Hour
-
-<a id="one-month"></a>
-
-### One Month
-
-<a id="one-year"></a>
-
-### One Year
 
 <a id="timeouts"></a>
 

--- a/docs/resources/infraprotect_firewall_rule.md
+++ b/docs/resources/infraprotect_firewall_rule.md
@@ -64,37 +64,37 @@ resource "f5xc_infraprotect_firewall_rule" "example" {
 
 > **Note:** One of the arguments from this list "action_allow, action_deny" must be set.
 
-`action_allow` - (Optional) Empty. This can be used for messages where no values are needed. See [Action Allow](#action-allow) below for details.
+`action_allow` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`action_deny` - (Optional) Empty. This can be used for messages where no values are needed. See [Action Deny](#action-deny) below for details.
+`action_deny` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 > **Note:** One of the arguments from this list "destination_prefix_all, destination_prefix_single" must be set.
 
-`destination_prefix_all` - (Optional) Empty. This can be used for messages where no values are needed. See [Destination Prefix All](#destination-prefix-all) below for details.
+`destination_prefix_all` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `destination_prefix_single` - (Optional) Configuration for destination_prefix_single (`String`).
 
 > **Note:** One of the arguments from this list "fragments_allow, fragments_deny" must be set.
 
-`fragments_allow` - (Optional) Empty. This can be used for messages where no values are needed. See [Fragments Allow](#fragments-allow) below for details.
+`fragments_allow` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`fragments_deny` - (Optional) Empty. This can be used for messages where no values are needed. See [Fragments Deny](#fragments-deny) below for details.
+`fragments_deny` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 > **Note:** One of the arguments from this list "protocol_ah, protocol_all, protocol_esp, protocol_gre, protocol_icmp, protocol_icmp6, protocol_ipv6, protocol_tcp, protocol_udp" must be set.
 
-`protocol_ah` - (Optional) Empty. This can be used for messages where no values are needed. See [Protocol Ah](#protocol-ah) below for details.
+`protocol_ah` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`protocol_all` - (Optional) Empty. This can be used for messages where no values are needed. See [Protocol All](#protocol-all) below for details.
+`protocol_all` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`protocol_esp` - (Optional) Empty. This can be used for messages where no values are needed. See [Protocol Esp](#protocol-esp) below for details.
+`protocol_esp` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`protocol_gre` - (Optional) Empty. This can be used for messages where no values are needed. See [Protocol Gre](#protocol-gre) below for details.
+`protocol_gre` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `protocol_icmp` - (Optional) ICMP Protocol. x-required ICMP Protocol. See [Protocol ICMP](#protocol-icmp) below for details.
 
 `protocol_icmp6` - (Optional) ICMP6 Protocol. x-required ICMP6 Protocol. See [Protocol Icmp6](#protocol-icmp6) below for details.
 
-`protocol_ipv6` - (Optional) Empty. This can be used for messages where no values are needed. See [Protocol IPv6](#protocol-ipv6) below for details.
+`protocol_ipv6` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `protocol_tcp` - (Optional) TCP Protocol. x-required TCP Protocol. See [Protocol TCP](#protocol-tcp) below for details.
 
@@ -102,23 +102,23 @@ resource "f5xc_infraprotect_firewall_rule" "example" {
 
 > **Note:** One of the arguments from this list "source_prefix_all, source_prefix_single" must be set.
 
-`source_prefix_all` - (Optional) Empty. This can be used for messages where no values are needed. See [Source Prefix All](#source-prefix-all) below for details.
+`source_prefix_all` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `source_prefix_single` - (Optional) Configuration for source_prefix_single (`String`).
 
 > **Note:** One of the arguments from this list "state_off, state_on" must be set.
 
-`state_off` - (Optional) Empty. This can be used for messages where no values are needed. See [State Off](#state-off) below for details.
+`state_off` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`state_on` - (Optional) Empty. This can be used for messages where no values are needed. See [State On](#state-on) below for details.
+`state_on` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `timeouts` - (Optional) See [Timeouts](#timeouts) below for details.
 
 > **Note:** One of the arguments from this list "version_ipv4, version_ipv6" must be set.
 
-`version_ipv4` - (Optional) Empty. This can be used for messages where no values are needed. See [Version IPv4](#version-ipv4) below for details.
+`version_ipv4` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`version_ipv6` - (Optional) Empty. This can be used for messages where no values are needed. See [Version IPv6](#version-ipv6) below for details.
+`version_ipv6` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 ### Attributes Reference
 
@@ -127,42 +127,6 @@ In addition to all arguments above, the following attributes are exported:
 `id` - (Optional) Unique identifier for the resource (`String`).
 
 ---
-
-<a id="action-allow"></a>
-
-### Action Allow
-
-<a id="action-deny"></a>
-
-### Action Deny
-
-<a id="destination-prefix-all"></a>
-
-### Destination Prefix All
-
-<a id="fragments-allow"></a>
-
-### Fragments Allow
-
-<a id="fragments-deny"></a>
-
-### Fragments Deny
-
-<a id="protocol-ah"></a>
-
-### Protocol Ah
-
-<a id="protocol-all"></a>
-
-### Protocol All
-
-<a id="protocol-esp"></a>
-
-### Protocol Esp
-
-<a id="protocol-gre"></a>
-
-### Protocol Gre
 
 <a id="protocol-icmp"></a>
 
@@ -208,31 +172,19 @@ In addition to all arguments above, the following attributes are exported:
 
 `time_exceeded` - (Optional) Time-Exceeded. Time-Exceeded (`Bool`).
 
-<a id="protocol-ipv6"></a>
-
-### Protocol IPv6
-
 <a id="protocol-tcp"></a>
 
 ### Protocol TCP
 
 `description` - (Optional) Configuration for description (`String`).
 
-`destination_port_all` - (Optional) Empty. This can be used for messages where no values are needed. See [Destination Port All](#protocol-tcp-destination-port-all) below.
+`destination_port_all` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `destination_port_range` - (Optional) Port Range. Port Range (`String`).
 
-`source_port_all` - (Optional) Empty. This can be used for messages where no values are needed. See [Source Port All](#protocol-tcp-source-port-all) below.
+`source_port_all` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `source_port_range` - (Optional) Port Range. Port Range (`String`).
-
-<a id="protocol-tcp-destination-port-all"></a>
-
-### Protocol TCP Destination Port All
-
-<a id="protocol-tcp-source-port-all"></a>
-
-### Protocol TCP Source Port All
 
 <a id="protocol-udp"></a>
 
@@ -240,33 +192,13 @@ In addition to all arguments above, the following attributes are exported:
 
 `description` - (Optional) Configuration for description (`String`).
 
-`destination_port_all` - (Optional) Empty. This can be used for messages where no values are needed. See [Destination Port All](#protocol-udp-destination-port-all) below.
+`destination_port_all` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `destination_port_range` - (Optional) Port Range. Port Range (`String`).
 
-`source_port_all` - (Optional) Empty. This can be used for messages where no values are needed. See [Source Port All](#protocol-udp-source-port-all) below.
+`source_port_all` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `source_port_range` - (Optional) Port Range. Port Range (`String`).
-
-<a id="protocol-udp-destination-port-all"></a>
-
-### Protocol UDP Destination Port All
-
-<a id="protocol-udp-source-port-all"></a>
-
-### Protocol UDP Source Port All
-
-<a id="source-prefix-all"></a>
-
-### Source Prefix All
-
-<a id="state-off"></a>
-
-### State Off
-
-<a id="state-on"></a>
-
-### State On
 
 <a id="timeouts"></a>
 
@@ -279,14 +211,6 @@ In addition to all arguments above, the following attributes are exported:
 `read` - (Optional) A string that can be [parsed as a duration](`HTTPS://pkg.go.dev/time#ParseDuration`) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Read operations occur during any refresh or planning operation when refresh is enabled (`String`).
 
 `update` - (Optional) A string that can be [parsed as a duration](`HTTPS://pkg.go.dev/time#ParseDuration`) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours) (`String`).
-
-<a id="version-ipv4"></a>
-
-### Version IPv4
-
-<a id="version-ipv6"></a>
-
-### Version IPv6
 
 ## Import
 

--- a/docs/resources/infraprotect_internet_prefix_advertisement.md
+++ b/docs/resources/infraprotect_internet_prefix_advertisement.md
@@ -64,13 +64,13 @@ resource "f5xc_infraprotect_internet_prefix_advertisement" "example" {
 
 > **Note:** One of the arguments from this list "activation_announce, activation_withdraw" must be set.
 
-`activation_announce` - (Optional) Empty. This can be used for messages where no values are needed. See [Activation Announce](#activation-announce) below for details.
+`activation_announce` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`activation_withdraw` - (Optional) Empty. This can be used for messages where no values are needed. See [Activation Withdraw](#activation-withdraw) below for details.
+`activation_withdraw` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 > **Note:** One of the arguments from this list "expiration_never, expiration_timestamp" must be set.
 
-`expiration_never` - (Optional) Empty. This can be used for messages where no values are needed. See [Expiration Never](#expiration-never) below for details.
+`expiration_never` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `expiration_timestamp` - (Optional) Expiration Time (UTC). This advertisement will expire at the given timestamp and will be removed from the system afterwards (`String`).
 
@@ -85,18 +85,6 @@ In addition to all arguments above, the following attributes are exported:
 `id` - (Optional) Unique identifier for the resource (`String`).
 
 ---
-
-<a id="activation-announce"></a>
-
-### Activation Announce
-
-<a id="activation-withdraw"></a>
-
-### Activation Withdraw
-
-<a id="expiration-never"></a>
-
-### Expiration Never
 
 <a id="timeouts"></a>
 

--- a/docs/resources/infraprotect_tunnel.md
+++ b/docs/resources/infraprotect_tunnel.md
@@ -104,11 +104,11 @@ In addition to all arguments above, the following attributes are exported:
 
 `holddown_timer_seconds` - (Optional) Hold down Timer. BGP hold down timer, in seconds (`Number`).
 
-`no_secret` - (Optional) Empty. This can be used for messages where no values are needed. See [No Secret](#bgp-information-no-secret) below.
+`no_secret` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `peer_secret_override` - (Optional) Secret. SecretType is used in an object to indicate a sensitive/confidential field. See [Peer Secret Override](#bgp-information-peer-secret-override) below.
 
-`use_default_secret` - (Optional) Empty. This can be used for messages where no values are needed. See [Use Default Secret](#bgp-information-use-default-secret) below.
+`use_default_secret` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="bgp-information-asn"></a>
 
@@ -119,10 +119,6 @@ In addition to all arguments above, the following attributes are exported:
 `namespace` - (Optional) Namespace. When a configuration object(e.g. virtual_host) refers to another(e.g route) then namespace will hold the referred object's(e.g. route's) namespace (`String`).
 
 `tenant` - (Optional) Tenant. When a configuration object(e.g. virtual_host) refers to another(e.g route) then tenant will hold the referred object's(e.g. route's) tenant (`String`).
-
-<a id="bgp-information-no-secret"></a>
-
-### BGP Information No Secret
 
 <a id="bgp-information-peer-secret-override"></a>
 
@@ -150,10 +146,6 @@ In addition to all arguments above, the following attributes are exported:
 
 `url` - (Optional) URL. URL of the secret. Currently supported URL schemes is string:///. For string:/// scheme, Secret needs to be encoded Base64 format. When asked for this secret, caller will get Secret bytes after Base64 decoding (`String`).
 
-<a id="bgp-information-use-default-secret"></a>
-
-### BGP Information Use Default Secret
-
 <a id="firewall-rule-group"></a>
 
 ### Firewall Rule Group
@@ -170,41 +162,17 @@ In addition to all arguments above, the following attributes are exported:
 
 `customer_endpoint_ipv4` - (Optional) Customer Endpoint IP. IPv4 address for the customer endpoint of the tunnel (`String`).
 
-`fragmentation_disabled` - (Optional) Empty. This can be used for messages where no values are needed. See [Fragmentation Disabled](#gre-ipv4-fragmentation-disabled) below.
+`fragmentation_disabled` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`fragmentation_enabled` - (Optional) Empty. This can be used for messages where no values are needed. See [Fragmentation Enabled](#gre-ipv4-fragmentation-enabled) below.
+`fragmentation_enabled` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`ipv6_interconnect_disabled` - (Optional) Empty. This can be used for messages where no values are needed. See [IPv6 Interconnect Disabled](#gre-ipv4-ipv6-interconnect-disabled) below.
+`ipv6_interconnect_disabled` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`ipv6_interconnect_enabled` - (Optional) Empty. This can be used for messages where no values are needed. See [IPv6 Interconnect Enabled](#gre-ipv4-ipv6-interconnect-enabled) below.
+`ipv6_interconnect_enabled` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`keepalive_disabled` - (Optional) Empty. This can be used for messages where no values are needed. See [Keepalive Disabled](#gre-ipv4-keepalive-disabled) below.
+`keepalive_disabled` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`keepalive_enabled` - (Optional) Empty. This can be used for messages where no values are needed. See [Keepalive Enabled](#gre-ipv4-keepalive-enabled) below.
-
-<a id="gre-ipv4-fragmentation-disabled"></a>
-
-### Gre IPv4 Fragmentation Disabled
-
-<a id="gre-ipv4-fragmentation-enabled"></a>
-
-### Gre IPv4 Fragmentation Enabled
-
-<a id="gre-ipv4-ipv6-interconnect-disabled"></a>
-
-### Gre IPv4 IPv6 Interconnect Disabled
-
-<a id="gre-ipv4-ipv6-interconnect-enabled"></a>
-
-### Gre IPv4 IPv6 Interconnect Enabled
-
-<a id="gre-ipv4-keepalive-disabled"></a>
-
-### Gre IPv4 Keepalive Disabled
-
-<a id="gre-ipv4-keepalive-enabled"></a>
-
-### Gre IPv4 Keepalive Enabled
+`keepalive_enabled` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="gre-ipv6"></a>
 
@@ -212,17 +180,9 @@ In addition to all arguments above, the following attributes are exported:
 
 `customer_endpoint_ipv6` - (Optional) Customer Endpoint IP. IPv6 address for the customer endpoint of the tunnel (`String`).
 
-`ipv4_interconnect_disabled` - (Optional) Empty. This can be used for messages where no values are needed. See [IPv4 Interconnect Disabled](#gre-ipv6-ipv4-interconnect-disabled) below.
+`ipv4_interconnect_disabled` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`ipv4_interconnect_enabled` - (Optional) Empty. This can be used for messages where no values are needed. See [IPv4 Interconnect Enabled](#gre-ipv6-ipv4-interconnect-enabled) below.
-
-<a id="gre-ipv6-ipv4-interconnect-disabled"></a>
-
-### Gre IPv6 IPv4 Interconnect Disabled
-
-<a id="gre-ipv6-ipv4-interconnect-enabled"></a>
-
-### Gre IPv6 IPv4 Interconnect Enabled
+`ipv4_interconnect_enabled` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="ip-in-ip"></a>
 
@@ -254,17 +214,9 @@ In addition to all arguments above, the following attributes are exported:
 
 `name` - (Optional) Location Name. Destination tunnel Location (`String`).
 
-`zone1` - (Optional) Empty. This can be used for messages where no values are needed. See [Zone1](#tunnel-location-zone1) below.
+`zone1` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`zone2` - (Optional) Empty. This can be used for messages where no values are needed. See [Zone2](#tunnel-location-zone2) below.
-
-<a id="tunnel-location-zone1"></a>
-
-### Tunnel Location Zone1
-
-<a id="tunnel-location-zone2"></a>
-
-### Tunnel Location Zone2
+`zone2` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 ## Import
 

--- a/docs/resources/k8s_cluster.md
+++ b/docs/resources/k8s_cluster.md
@@ -73,33 +73,33 @@ resource "f5xc_k8s_cluster" "example" {
 
 > **Note:** One of the arguments from this list "cluster_scoped_access_deny, cluster_scoped_access_permit" must be set.
 
-`cluster_scoped_access_deny` - (Optional) Empty. This can be used for messages where no values are needed. See [Cluster Scoped Access Deny](#cluster-scoped-access-deny) below for details.
+`cluster_scoped_access_deny` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`cluster_scoped_access_permit` - (Optional) Empty. This can be used for messages where no values are needed. See [Cluster Scoped Access Permit](#cluster-scoped-access-permit) below for details.
+`cluster_scoped_access_permit` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 > **Note:** One of the arguments from this list "cluster_wide_app_list, no_cluster_wide_apps" must be set.
 
 `cluster_wide_app_list` - (Optional) Cluster Wide Application List. List of cluster wide applications. See [Cluster Wide App List](#cluster-wide-app-list) below for details.
 
-`no_cluster_wide_apps` - (Optional) Empty. This can be used for messages where no values are needed. See [No Cluster Wide Apps](#no-cluster-wide-apps) below for details.
+`no_cluster_wide_apps` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 > **Note:** One of the arguments from this list "global_access_enable, no_global_access" must be set.
 
-`global_access_enable` - (Optional) Empty. This can be used for messages where no values are needed. See [Global Access Enable](#global-access-enable) below for details.
+`global_access_enable` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_global_access` - (Optional) Empty. This can be used for messages where no values are needed. See [No Global Access](#no-global-access) below for details.
+`no_global_access` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 > **Note:** One of the arguments from this list "insecure_registry_list, no_insecure_registries" must be set.
 
 `insecure_registry_list` - (Optional) Docker Insecure Registry List. List of docker insecure registries. See [Insecure Registry List](#insecure-registry-list) below for details.
 
-`no_insecure_registries` - (Optional) Empty. This can be used for messages where no values are needed. See [No Insecure Registries](#no-insecure-registries) below for details.
+`no_insecure_registries` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 > **Note:** One of the arguments from this list "local_access_config, no_local_access" must be set.
 
 `local_access_config` - (Optional) Local Access Configuration. Parameters required to enable local access. See [Local Access Config](#local-access-config) below for details.
 
-`no_local_access` - (Optional) Empty. This can be used for messages where no values are needed. See [No Local Access](#no-local-access) below for details.
+`no_local_access` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `timeouts` - (Optional) See [Timeouts](#timeouts) below for details.
 
@@ -107,31 +107,31 @@ resource "f5xc_k8s_cluster" "example" {
 
 `use_custom_cluster_role_bindings` - (Optional) Cluster Role Binding List. List of active cluster role binding list for a K8s cluster. See [Use Custom Cluster Role Bindings](#use-custom-cluster-role-bindings) below for details.
 
-`use_default_cluster_role_bindings` - (Optional) Empty. This can be used for messages where no values are needed. See [Use Default Cluster Role Bindings](#use-default-cluster-role-bindings) below for details.
+`use_default_cluster_role_bindings` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 > **Note:** One of the arguments from this list "use_custom_cluster_role_list, use_default_cluster_roles" must be set.
 
 `use_custom_cluster_role_list` - (Optional) Cluster Role List. List of active cluster role list for a K8s cluster. See [Use Custom Cluster Role List](#use-custom-cluster-role-list) below for details.
 
-`use_default_cluster_roles` - (Optional) Empty. This can be used for messages where no values are needed. See [Use Default Cluster Roles](#use-default-cluster-roles) below for details.
+`use_default_cluster_roles` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 > **Note:** One of the arguments from this list "use_custom_pod_security_admission, use_default_pod_security_admission" must be set.
 
 `use_custom_pod_security_admission` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Use Custom Pod Security Admission](#use-custom-pod-security-admission) below for details.
 
-`use_default_pod_security_admission` - (Optional) Empty. This can be used for messages where no values are needed. See [Use Default Pod Security Admission](#use-default-pod-security-admission) below for details.
+`use_default_pod_security_admission` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 > **Note:** One of the arguments from this list "use_custom_psp_list, use_default_psp" must be set.
 
 `use_custom_psp_list` - (Optional) Pod Security Policy List. List of active Pod security policies for a K8s cluster. See [Use Custom Psp List](#use-custom-psp-list) below for details.
 
-`use_default_psp` - (Optional) Empty. This can be used for messages where no values are needed. See [Use Default Psp](#use-default-psp) below for details.
+`use_default_psp` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 > **Note:** One of the arguments from this list "vk8s_namespace_access_deny, vk8s_namespace_access_permit" must be set.
 
-`vk8s_namespace_access_deny` - (Optional) Empty. This can be used for messages where no values are needed. See [Vk8s Namespace Access Deny](#vk8s-namespace-access-deny) below for details.
+`vk8s_namespace_access_deny` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`vk8s_namespace_access_permit` - (Optional) Empty. This can be used for messages where no values are needed. See [Vk8s Namespace Access Permit](#vk8s-namespace-access-permit) below for details.
+`vk8s_namespace_access_permit` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 ### Attributes Reference
 
@@ -140,14 +140,6 @@ In addition to all arguments above, the following attributes are exported:
 `id` - (Optional) Unique identifier for the resource (`String`).
 
 ---
-
-<a id="cluster-scoped-access-deny"></a>
-
-### Cluster Scoped Access Deny
-
-<a id="cluster-scoped-access-permit"></a>
-
-### Cluster Scoped Access Permit
 
 <a id="cluster-wide-app-list"></a>
 
@@ -161,37 +153,17 @@ In addition to all arguments above, the following attributes are exported:
 
 `argo_cd` - (Optional) Argo CD configuration. description Parameters for Argo Continuous Deployment(CD) application. See [Argo Cd](#cluster-wide-app-list-cluster-wide-apps-argo-cd) below.
 
-`dashboard` - (Optional) K8s Dashboard configuration. description Parameters for K8s dashboard. See [Dashboard](#cluster-wide-app-list-cluster-wide-apps-dashboard) below.
+`dashboard` - (Optional) K8s Dashboard configuration. description Parameters for K8s dashboard (`Block`).
 
-`metrics_server` - (Optional) K8s Metrics Server configuration. description Parameters for Kubernetes Metrics Server application. See [Metrics Server](#cluster-wide-app-list-cluster-wide-apps-metrics-server) below.
+`metrics_server` - (Optional) K8s Metrics Server configuration. description Parameters for Kubernetes Metrics Server application (`Block`).
 
-`prometheus` - (Optional) Prometheus access configuration. description Parameters for Prometheus server access. See [Prometheus](#cluster-wide-app-list-cluster-wide-apps-prometheus) below.
+`prometheus` - (Optional) Prometheus access configuration. description Parameters for Prometheus server access (`Block`).
 
 <a id="cluster-wide-app-list-cluster-wide-apps-argo-cd"></a>
 
 ### Cluster Wide App List Cluster Wide Apps Argo Cd
 
-`local_domain` - (Optional) Local Access Configuration. Parameters required to enable local access. See [Local Domain](#cluster-wide-app-list-cluster-wide-apps-argo-cd-local-domain) below.
-
-<a id="cluster-wide-app-list-cluster-wide-apps-argo-cd-local-domain"></a>
-
-### Cluster Wide App List Cluster Wide Apps Argo Cd Local Domain
-
-<a id="cluster-wide-app-list-cluster-wide-apps-dashboard"></a>
-
-### Cluster Wide App List Cluster Wide Apps Dashboard
-
-<a id="cluster-wide-app-list-cluster-wide-apps-metrics-server"></a>
-
-### Cluster Wide App List Cluster Wide Apps Metrics Server
-
-<a id="cluster-wide-app-list-cluster-wide-apps-prometheus"></a>
-
-### Cluster Wide App List Cluster Wide Apps Prometheus
-
-<a id="global-access-enable"></a>
-
-### Global Access Enable
+`local_domain` - (Optional) Local Access Configuration. Parameters required to enable local access (`Block`).
 
 <a id="insecure-registry-list"></a>
 
@@ -203,31 +175,11 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Local Access Config
 
-`default_port` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Port](#local-access-config-default-port) below.
+`default_port` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `local_domain` - (Optional) Local Domain. Local K8s API server will be accessible at <site name>.<local domain> (`String`).
 
 `port` - (Optional) Custom k8s Port. Use custom K8s port for API server. Available port range is less than 65000 except reserved ports (`Number`).
-
-<a id="local-access-config-default-port"></a>
-
-### Local Access Config Default Port
-
-<a id="no-cluster-wide-apps"></a>
-
-### No Cluster Wide Apps
-
-<a id="no-global-access"></a>
-
-### No Global Access
-
-<a id="no-insecure-registries"></a>
-
-### No Insecure Registries
-
-<a id="no-local-access"></a>
-
-### No Local Access
 
 <a id="timeouts"></a>
 
@@ -298,30 +250,6 @@ In addition to all arguments above, the following attributes are exported:
 `namespace` - (Optional) Namespace. When a configuration object(e.g. virtual_host) refers to another(e.g route) then namespace will hold the referred object's(e.g. route's) namespace (`String`).
 
 `tenant` - (Optional) Tenant. When a configuration object(e.g. virtual_host) refers to another(e.g route) then tenant will hold the referred object's(e.g. route's) tenant (`String`).
-
-<a id="use-default-cluster-role-bindings"></a>
-
-### Use Default Cluster Role Bindings
-
-<a id="use-default-cluster-roles"></a>
-
-### Use Default Cluster Roles
-
-<a id="use-default-pod-security-admission"></a>
-
-### Use Default Pod Security Admission
-
-<a id="use-default-psp"></a>
-
-### Use Default Psp
-
-<a id="vk8s-namespace-access-deny"></a>
-
-### Vk8s Namespace Access Deny
-
-<a id="vk8s-namespace-access-permit"></a>
-
-### Vk8s Namespace Access Permit
 
 ## Import
 

--- a/docs/resources/k8s_pod_security_admission.md
+++ b/docs/resources/k8s_pod_security_admission.md
@@ -78,41 +78,17 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Pod Security Admission Specs
 
-`audit` - (Optional) Empty. This can be used for messages where no values are needed. See [Audit](#pod-security-admission-specs-audit) below.
+`audit` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`baseline` - (Optional) Empty. This can be used for messages where no values are needed. See [Baseline](#pod-security-admission-specs-baseline) below.
+`baseline` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`enforce` - (Optional) Empty. This can be used for messages where no values are needed. See [Enforce](#pod-security-admission-specs-enforce) below.
+`enforce` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`privileged` - (Optional) Empty. This can be used for messages where no values are needed. See [Privileged](#pod-security-admission-specs-privileged) below.
+`privileged` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`restricted` - (Optional) Empty. This can be used for messages where no values are needed. See [Restricted](#pod-security-admission-specs-restricted) below.
+`restricted` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`warn` - (Optional) Empty. This can be used for messages where no values are needed. See [Warn](#pod-security-admission-specs-warn) below.
-
-<a id="pod-security-admission-specs-audit"></a>
-
-### Pod Security Admission Specs Audit
-
-<a id="pod-security-admission-specs-baseline"></a>
-
-### Pod Security Admission Specs Baseline
-
-<a id="pod-security-admission-specs-enforce"></a>
-
-### Pod Security Admission Specs Enforce
-
-<a id="pod-security-admission-specs-privileged"></a>
-
-### Pod Security Admission Specs Privileged
-
-<a id="pod-security-admission-specs-restricted"></a>
-
-### Pod Security Admission Specs Restricted
-
-<a id="pod-security-admission-specs-warn"></a>
-
-### Pod Security Admission Specs Warn
+`warn` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="timeouts"></a>
 

--- a/docs/resources/k8s_pod_security_policy.md
+++ b/docs/resources/k8s_pod_security_policy.md
@@ -114,23 +114,23 @@ In addition to all arguments above, the following attributes are exported:
 
 `host_port_ranges` - (Optional) Host Ports Ranges. Host port ranges determines which ports ranges are allowed to be exposed (`String`).
 
-`no_allowed_capabilities` - (Optional) Empty. This can be used for messages where no values are needed. See [No Allowed Capabilities](#psp-spec-no-allowed-capabilities) below.
+`no_allowed_capabilities` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_default_capabilities` - (Optional) Empty. This can be used for messages where no values are needed. See [No Default Capabilities](#psp-spec-no-default-capabilities) below.
+`no_default_capabilities` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_drop_capabilities` - (Optional) Empty. This can be used for messages where no values are needed. See [No Drop Capabilities](#psp-spec-no-drop-capabilities) below.
+`no_drop_capabilities` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_fs_groups` - (Optional) Empty. This can be used for messages where no values are needed. See [No Fs Groups](#psp-spec-no-fs-groups) below.
+`no_fs_groups` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_run_as_group` - (Optional) Empty. This can be used for messages where no values are needed. See [No Run As Group](#psp-spec-no-run-as-group) below.
+`no_run_as_group` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_run_as_user` - (Optional) Empty. This can be used for messages where no values are needed. See [No Run As User](#psp-spec-no-run-as-user) below.
+`no_run_as_user` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_runtime_class` - (Optional) Empty. This can be used for messages where no values are needed. See [No Runtime Class](#psp-spec-no-runtime-class) below.
+`no_runtime_class` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_se_linux_options` - (Optional) Empty. This can be used for messages where no values are needed. See [No Se Linux Options](#psp-spec-no-se-linux-options) below.
+`no_se_linux_options` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_supplemental_groups` - (Optional) Empty. This can be used for messages where no values are needed. See [No Supplemental Groups](#psp-spec-no-supplemental-groups) below.
+`no_supplemental_groups` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `privileged` - (Optional) Privileged. Privileged determines if a pod can request to be run as privileged (`Bool`).
 
@@ -185,42 +185,6 @@ In addition to all arguments above, the following attributes are exported:
 `max_id` - (Optional) Ending ID. Ending(maximum) ID for for ID range (`Number`).
 
 `min_id` - (Optional) Starting ID. Starting(minimum) ID for for ID range (`Number`).
-
-<a id="psp-spec-no-allowed-capabilities"></a>
-
-### Psp Spec No Allowed Capabilities
-
-<a id="psp-spec-no-default-capabilities"></a>
-
-### Psp Spec No Default Capabilities
-
-<a id="psp-spec-no-drop-capabilities"></a>
-
-### Psp Spec No Drop Capabilities
-
-<a id="psp-spec-no-fs-groups"></a>
-
-### Psp Spec No Fs Groups
-
-<a id="psp-spec-no-run-as-group"></a>
-
-### Psp Spec No Run As Group
-
-<a id="psp-spec-no-run-as-user"></a>
-
-### Psp Spec No Run As User
-
-<a id="psp-spec-no-runtime-class"></a>
-
-### Psp Spec No Runtime Class
-
-<a id="psp-spec-no-se-linux-options"></a>
-
-### Psp Spec No Se Linux Options
-
-<a id="psp-spec-no-supplemental-groups"></a>
-
-### Psp Spec No Supplemental Groups
 
 <a id="psp-spec-run-as-group"></a>
 

--- a/docs/resources/log_receiver.md
+++ b/docs/resources/log_receiver.md
@@ -61,7 +61,7 @@ resource "f5xc_log_receiver" "example" {
 
 ### Spec Argument Reference
 
-`site_local` - (Optional) Empty. This can be used for messages where no values are needed. See [Site Local](#site-local) below for details.
+`site_local` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `syslog` - (Optional) Syslog Server Configuration. Configuration for syslog server. See [Syslog](#syslog) below for details.
 
@@ -74,10 +74,6 @@ In addition to all arguments above, the following attributes are exported:
 `id` - (Optional) Unique identifier for the resource (`String`).
 
 ---
-
-<a id="site-local"></a>
-
-### Site Local
 
 <a id="syslog"></a>
 
@@ -103,11 +99,11 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Syslog TLS Server
 
-`default_https_port` - (Optional) Empty. This can be used for messages where no values are needed. See [Default HTTPS Port](#syslog-tls-server-default-https-port) below.
+`default_https_port` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`default_syslog_tls_port` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Syslog TLS Port](#syslog-tls-server-default-syslog-tls-port) below.
+`default_syslog_tls_port` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`mtls_disabled` - (Optional) Empty. This can be used for messages where no values are needed. See [mTLS Disabled](#syslog-tls-server-mtls-disabled) below.
+`mtls_disabled` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `mtls_enable` - (Optional) mTLS Client Config. TLS config for client. See [mTLS Enable](#syslog-tls-server-mtls-enable) below.
 
@@ -117,19 +113,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `trusted_ca_url` - (Optional) Server CA Certificates. The URL or value for trusted Server CA certificate or certificate chain Certificates in PEM format including the PEM headers (`String`).
 
-`volterra_ca` - (Optional) Empty. This can be used for messages where no values are needed. See [Volterra CA](#syslog-tls-server-volterra-ca) below.
-
-<a id="syslog-tls-server-default-https-port"></a>
-
-### Syslog TLS Server Default HTTPS Port
-
-<a id="syslog-tls-server-default-syslog-tls-port"></a>
-
-### Syslog TLS Server Default Syslog TLS Port
-
-<a id="syslog-tls-server-mtls-disabled"></a>
-
-### Syslog TLS Server mTLS Disabled
+`volterra_ca` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="syslog-tls-server-mtls-enable"></a>
 
@@ -137,15 +121,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `certificate` - (Optional) Client Certificate. Client certificate is PEM-encoded certificate or certificate-chain (`String`).
 
-`key_url` - (Optional) Secret. SecretType is used in an object to indicate a sensitive/confidential field. See [Key URL](#syslog-tls-server-mtls-enable-key-url) below.
-
-<a id="syslog-tls-server-mtls-enable-key-url"></a>
-
-### Syslog TLS Server mTLS Enable Key URL
-
-<a id="syslog-tls-server-volterra-ca"></a>
-
-### Syslog TLS Server Volterra CA
+`key_url` - (Optional) Secret. SecretType is used in an object to indicate a sensitive/confidential field (`Block`).
 
 <a id="syslog-udp-server"></a>
 

--- a/docs/resources/malicious_user_mitigation.md
+++ b/docs/resources/malicious_user_mitigation.md
@@ -90,45 +90,21 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Mitigation Type Rules Mitigation Action
 
-`block_temporarily` - (Optional) Empty. This can be used for messages where no values are needed. See [Block Temporarily](#mitigation-type-rules-mitigation-action-block-temporarily) below.
+`block_temporarily` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`captcha_challenge` - (Optional) Empty. This can be used for messages where no values are needed. See [Captcha Challenge](#mitigation-type-rules-mitigation-action-captcha-challenge) below.
+`captcha_challenge` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`javascript_challenge` - (Optional) Empty. This can be used for messages where no values are needed. See [Javascript Challenge](#mitigation-type-rules-mitigation-action-javascript-challenge) below.
-
-<a id="mitigation-type-rules-mitigation-action-block-temporarily"></a>
-
-### Mitigation Type Rules Mitigation Action Block Temporarily
-
-<a id="mitigation-type-rules-mitigation-action-captcha-challenge"></a>
-
-### Mitigation Type Rules Mitigation Action Captcha Challenge
-
-<a id="mitigation-type-rules-mitigation-action-javascript-challenge"></a>
-
-### Mitigation Type Rules Mitigation Action Javascript Challenge
+`javascript_challenge` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="mitigation-type-rules-threat-level"></a>
 
 ### Mitigation Type Rules Threat Level
 
-`high` - (Optional) Empty. This can be used for messages where no values are needed. See [High](#mitigation-type-rules-threat-level-high) below.
+`high` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`low` - (Optional) Empty. This can be used for messages where no values are needed. See [Low](#mitigation-type-rules-threat-level-low) below.
+`low` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`medium` - (Optional) Empty. This can be used for messages where no values are needed. See [Medium](#mitigation-type-rules-threat-level-medium) below.
-
-<a id="mitigation-type-rules-threat-level-high"></a>
-
-### Mitigation Type Rules Threat Level High
-
-<a id="mitigation-type-rules-threat-level-low"></a>
-
-### Mitigation Type Rules Threat Level Low
-
-<a id="mitigation-type-rules-threat-level-medium"></a>
-
-### Mitigation Type Rules Threat Level Medium
+`medium` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="timeouts"></a>
 

--- a/docs/resources/nat_policy.md
+++ b/docs/resources/nat_policy.md
@@ -86,9 +86,9 @@ In addition to all arguments above, the following attributes are exported:
 
 `criteria` - (Optional) Match Criteria. Match criteria of the packet to apply the NAT Rule. See [Criteria](#rules-criteria) below.
 
-`disable` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable](#rules-disable) below.
+`disable` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`enable` - (Optional) Empty. This can be used for messages where no values are needed. See [Enable](#rules-enable) below.
+`enable` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `name` - (Optional) Name. Name of the Rule (`String`).
 
@@ -110,17 +110,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Rules Action Dynamic
 
-`elastic_ips` - (Optional) Cloud Elastic IP Ref List. List of references to Cloud Elastic IP Object. See [Elastic Ips](#rules-action-dynamic-elastic-ips) below.
+`elastic_ips` - (Optional) Cloud Elastic IP Ref List. List of references to Cloud Elastic IP Object (`Block`).
 
-`pools` - (Optional) IPv4 Prefix List. x-example: '192.168.20.0/24' List of IPv4 prefixes that represent an endpoint. See [Pools](#rules-action-dynamic-pools) below.
-
-<a id="rules-action-dynamic-elastic-ips"></a>
-
-### Rules Action Dynamic Elastic Ips
-
-<a id="rules-action-dynamic-pools"></a>
-
-### Rules Action Dynamic Pools
+`pools` - (Optional) IPv4 Prefix List. x-example: '192.168.20.0/24' List of IPv4 prefixes that represent an endpoint (`Block`).
 
 <a id="rules-cloud-connect"></a>
 
@@ -146,13 +138,13 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Rules Criteria
 
-`any` - (Optional) Empty. This can be used for messages where no values are needed. See [Any](#rules-criteria-any) below.
+`any` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `destination_cidr` - (Optional) Destination IP. Destination IP of the packet to match (`List`).
 
 `destination_port` - (Optional) Port to Match. Port match of the request can be a range or a specific port. See [Destination Port](#rules-criteria-destination-port) below.
 
-`icmp` - (Optional) Empty. This can be used for messages where no values are needed. See [ICMP](#rules-criteria-icmp) below.
+`icmp` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `protocol` - (Optional) Protocols. Protocols like TCP, UDP. Possible values are `ALL`, `ICMP`, `TCP`, `UDP`. Defaults to `ALL` (`String`).
 
@@ -168,101 +160,53 @@ In addition to all arguments above, the following attributes are exported:
 
 `virtual_network` - (Optional) Virtual Network Reference Type. Carries the reference to virtual network. See [Virtual Network](#rules-criteria-virtual-network) below.
 
-<a id="rules-criteria-any"></a>
-
-### Rules Criteria Any
-
 <a id="rules-criteria-destination-port"></a>
 
 ### Rules Criteria Destination Port
 
-`no_port_match` - (Optional) Empty. This can be used for messages where no values are needed. See [No Port Match](#rules-criteria-destination-port-no-port-match) below.
+`no_port_match` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `port` - (Optional) Port. Exact Port to match (`Number`).
 
 `port_ranges` - (Optional) Configuration for port_ranges (`String`).
-
-<a id="rules-criteria-destination-port-no-port-match"></a>
-
-### Rules Criteria Destination Port No Port Match
-
-<a id="rules-criteria-icmp"></a>
-
-### Rules Criteria ICMP
 
 <a id="rules-criteria-segment"></a>
 
 ### Rules Criteria Segment
 
-`refs` - (Optional) Segment. Reference to Segment Object. See [Refs](#rules-criteria-segment-refs) below.
-
-<a id="rules-criteria-segment-refs"></a>
-
-### Rules Criteria Segment Refs
+`refs` - (Optional) Segment. Reference to Segment Object (`Block`).
 
 <a id="rules-criteria-source-port"></a>
 
 ### Rules Criteria Source Port
 
-`no_port_match` - (Optional) Empty. This can be used for messages where no values are needed. See [No Port Match](#rules-criteria-source-port-no-port-match) below.
+`no_port_match` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `port` - (Optional) Port. Exact Port to match (`Number`).
 
 `port_ranges` - (Optional) Configuration for port_ranges (`String`).
 
-<a id="rules-criteria-source-port-no-port-match"></a>
-
-### Rules Criteria Source Port No Port Match
-
 <a id="rules-criteria-tcp"></a>
 
 ### Rules Criteria TCP
 
-`destination_port` - (Optional) Port to Match. Port match of the request can be a range or a specific port. See [Destination Port](#rules-criteria-tcp-destination-port) below.
+`destination_port` - (Optional) Port to Match. Port match of the request can be a range or a specific port (`Block`).
 
-`source_port` - (Optional) Port to Match. Port match of the request can be a range or a specific port. See [Source Port](#rules-criteria-tcp-source-port) below.
-
-<a id="rules-criteria-tcp-destination-port"></a>
-
-### Rules Criteria TCP Destination Port
-
-<a id="rules-criteria-tcp-source-port"></a>
-
-### Rules Criteria TCP Source Port
+`source_port` - (Optional) Port to Match. Port match of the request can be a range or a specific port (`Block`).
 
 <a id="rules-criteria-udp"></a>
 
 ### Rules Criteria UDP
 
-`destination_port` - (Optional) Port to Match. Port match of the request can be a range or a specific port. See [Destination Port](#rules-criteria-udp-destination-port) below.
+`destination_port` - (Optional) Port to Match. Port match of the request can be a range or a specific port (`Block`).
 
-`source_port` - (Optional) Port to Match. Port match of the request can be a range or a specific port. See [Source Port](#rules-criteria-udp-source-port) below.
-
-<a id="rules-criteria-udp-destination-port"></a>
-
-### Rules Criteria UDP Destination Port
-
-<a id="rules-criteria-udp-source-port"></a>
-
-### Rules Criteria UDP Source Port
+`source_port` - (Optional) Port to Match. Port match of the request can be a range or a specific port (`Block`).
 
 <a id="rules-criteria-virtual-network"></a>
 
 ### Rules Criteria Virtual Network
 
-`refs` - (Optional) Virtual Network Reference. Reference to virtual network. See [Refs](#rules-criteria-virtual-network-refs) below.
-
-<a id="rules-criteria-virtual-network-refs"></a>
-
-### Rules Criteria Virtual Network Refs
-
-<a id="rules-disable"></a>
-
-### Rules Disable
-
-<a id="rules-enable"></a>
-
-### Rules Enable
+`refs` - (Optional) Virtual Network Reference. Reference to virtual network (`Block`).
 
 <a id="rules-network-interface"></a>
 

--- a/docs/resources/network_connector.md
+++ b/docs/resources/network_connector.md
@@ -62,7 +62,7 @@ resource "f5xc_network_connector" "example" {
 
 > **Note:** One of the arguments from this list "disable_forward_proxy, enable_forward_proxy" must be set.
 
-`disable_forward_proxy` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Forward Proxy](#disable-forward-proxy) below for details.
+`disable_forward_proxy` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `enable_forward_proxy` - (Optional) Forward Proxy Configuration. Fine tune forward proxy behavior Few configurations allowed are White listed ports and IP prefixes: Forward proxy does application protocol detection and server name(SNI) detection by peeking into the traffic on the incoming downstream connection. Few protocols doesn't have client sending the first data. In such cases, protocol and SNI detection fails. This configuration allows, skipping protocol and SNI detection for whitelisted IP-prefix-list and ports connectio. See [Enable Forward Proxy](#enable-forward-proxy) below for details.
 
@@ -84,10 +84,6 @@ In addition to all arguments above, the following attributes are exported:
 
 ---
 
-<a id="disable-forward-proxy"></a>
-
-### Disable Forward Proxy
-
 <a id="enable-forward-proxy"></a>
 
 ### Enable Forward Proxy
@@ -96,7 +92,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `max_connect_attempts` - (Optional) Number of connect attempts. Specifies the allowed number of retries on connect failure to upstream server. Defaults to 1 (`Number`).
 
-`no_interception` - (Optional) Empty. This can be used for messages where no values are needed. See [No Interception](#enable-forward-proxy-no-interception) below.
+`no_interception` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `tls_intercept` - (Optional) Configuration for TLS interception. Configuration to enable TLS interception. See [TLS Intercept](#enable-forward-proxy-tls-intercept) below.
 
@@ -104,25 +100,21 @@ In addition to all arguments above, the following attributes are exported:
 
 `white_listed_prefixes` - (Optional) IP Prefixes to Skip Protocol Parsing. Traffic to these destination IP prefixes is not subjected to protocol parsing Example 'tmate' server IP (`List`).
 
-<a id="enable-forward-proxy-no-interception"></a>
-
-### Enable Forward Proxy No Interception
-
 <a id="enable-forward-proxy-tls-intercept"></a>
 
 ### Enable Forward Proxy TLS Intercept
 
 `custom_certificate` - (Optional) TLS Certificate. Handle to fetch certificate and key. See [Custom Certificate](#enable-forward-proxy-tls-intercept-custom-certificate) below.
 
-`enable_for_all_domains` - (Optional) Empty. This can be used for messages where no values are needed. See [Enable For All Domains](#enable-forward-proxy-tls-intercept-enable-for-all-domains) below.
+`enable_for_all_domains` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `policy` - (Optional) TLS Interception Policy. Policy to enable or disable TLS interception. See [Policy](#enable-forward-proxy-tls-intercept-policy) below.
 
 `trusted_ca_url` - (Optional) Custom Root CA Certificate. Custom Root CA Certificate for validating upstream server certificate (`String`).
 
-`volterra_certificate` - (Optional) Empty. This can be used for messages where no values are needed. See [Volterra Certificate](#enable-forward-proxy-tls-intercept-volterra-certificate) below.
+`volterra_certificate` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`volterra_trusted_ca` - (Optional) Empty. This can be used for messages where no values are needed. See [Volterra Trusted CA](#enable-forward-proxy-tls-intercept-volterra-trusted-ca) below.
+`volterra_trusted_ca` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="enable-forward-proxy-tls-intercept-custom-certificate"></a>
 
@@ -130,53 +122,21 @@ In addition to all arguments above, the following attributes are exported:
 
 `certificate_url` - (Optional) Certificate. TLS certificate. Certificate or certificate chain in PEM format including the PEM headers (`String`).
 
-`custom_hash_algorithms` - (Optional) Hash Algorithms. Specifies the hash algorithms to be used. See [Custom Hash Algorithms](#enable-forward-proxy-tls-intercept-custom-certificate-custom-hash-algorithms) below.
+`custom_hash_algorithms` - (Optional) Hash Algorithms. Specifies the hash algorithms to be used (`Block`).
 
 `description` - (Optional) Configuration for description (`String`).
 
-`disable_ocsp_stapling` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable OCSP Stapling](#enable-forward-proxy-tls-intercept-custom-certificate-disable-ocsp-stapling) below.
+`disable_ocsp_stapling` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`private_key` - (Optional) Secret. SecretType is used in an object to indicate a sensitive/confidential field. See [Private Key](#enable-forward-proxy-tls-intercept-custom-certificate-private-key) below.
+`private_key` - (Optional) Secret. SecretType is used in an object to indicate a sensitive/confidential field (`Block`).
 
-`use_system_defaults` - (Optional) Empty. This can be used for messages where no values are needed. See [Use System Defaults](#enable-forward-proxy-tls-intercept-custom-certificate-use-system-defaults) below.
-
-<a id="enable-forward-proxy-tls-intercept-custom-certificate-custom-hash-algorithms"></a>
-
-### Enable Forward Proxy TLS Intercept Custom Certificate Custom Hash Algorithms
-
-<a id="enable-forward-proxy-tls-intercept-custom-certificate-disable-ocsp-stapling"></a>
-
-### Enable Forward Proxy TLS Intercept Custom Certificate Disable OCSP Stapling
-
-<a id="enable-forward-proxy-tls-intercept-custom-certificate-private-key"></a>
-
-### Enable Forward Proxy TLS Intercept Custom Certificate Private Key
-
-<a id="enable-forward-proxy-tls-intercept-custom-certificate-use-system-defaults"></a>
-
-### Enable Forward Proxy TLS Intercept Custom Certificate Use System Defaults
-
-<a id="enable-forward-proxy-tls-intercept-enable-for-all-domains"></a>
-
-### Enable Forward Proxy TLS Intercept Enable For All Domains
+`use_system_defaults` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="enable-forward-proxy-tls-intercept-policy"></a>
 
 ### Enable Forward Proxy TLS Intercept Policy
 
-`interception_rules` - (Optional) TLS Interception Rules. List of ordered rules to enable or disable for TLS interception. See [Interception Rules](#enable-forward-proxy-tls-intercept-policy-interception-rules) below.
-
-<a id="enable-forward-proxy-tls-intercept-policy-interception-rules"></a>
-
-### Enable Forward Proxy TLS Intercept Policy Interception Rules
-
-<a id="enable-forward-proxy-tls-intercept-volterra-certificate"></a>
-
-### Enable Forward Proxy TLS Intercept Volterra Certificate
-
-<a id="enable-forward-proxy-tls-intercept-volterra-trusted-ca"></a>
-
-### Enable Forward Proxy TLS Intercept Volterra Trusted CA
+`interception_rules` - (Optional) TLS Interception Rules. List of ordered rules to enable or disable for TLS interception (`Block`).
 
 <a id="sli-to-global-dr"></a>
 
@@ -198,17 +158,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Sli To Slo Snat
 
-`default_gw_snat` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Gw Snat](#sli-to-slo-snat-default-gw-snat) below.
+`default_gw_snat` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`interface_ip` - (Optional) Empty. This can be used for messages where no values are needed. See [Interface IP](#sli-to-slo-snat-interface-ip) below.
-
-<a id="sli-to-slo-snat-default-gw-snat"></a>
-
-### Sli To Slo Snat Default Gw Snat
-
-<a id="sli-to-slo-snat-interface-ip"></a>
-
-### Sli To Slo Snat Interface IP
+`interface_ip` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="slo-to-global-dr"></a>
 

--- a/docs/resources/network_firewall.md
+++ b/docs/resources/network_firewall.md
@@ -68,19 +68,19 @@ resource "f5xc_network_firewall" "example" {
 
 `active_network_policies` - (Optional) Active Firewall Policies Type. List of firewall policy views. See [Active Network Policies](#active-network-policies) below for details.
 
-`disable_network_policy` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Network Policy](#disable-network-policy) below for details.
+`disable_network_policy` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 > **Note:** One of the arguments from this list "active_fast_acls, disable_fast_acl" must be set.
 
 `active_fast_acls` - (Optional) Active Fast ACL(s). List of Fast ACL(s). See [Active Fast Acls](#active-fast-acls) below for details.
 
-`disable_fast_acl` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Fast ACL](#disable-fast-acl) below for details.
+`disable_fast_acl` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 > **Note:** One of the arguments from this list "active_forward_proxy_policies, disable_forward_proxy_policy" must be set.
 
 `active_forward_proxy_policies` - (Optional) Active Forward Proxy Policies Type. Ordered List of Forward Proxy Policies active. See [Active Forward Proxy Policies](#active-forward-proxy-policies) below for details.
 
-`disable_forward_proxy_policy` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Forward Proxy Policy](#disable-forward-proxy-policy) below for details.
+`disable_forward_proxy_policy` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `timeouts` - (Optional) See [Timeouts](#timeouts) below for details.
 
@@ -155,18 +155,6 @@ In addition to all arguments above, the following attributes are exported:
 `namespace` - (Optional) Namespace. When a configuration object(e.g. virtual_host) refers to another(e.g route) then namespace will hold the referred object's(e.g. route's) namespace (`String`).
 
 `tenant` - (Optional) Tenant. When a configuration object(e.g. virtual_host) refers to another(e.g route) then tenant will hold the referred object's(e.g. route's) tenant (`String`).
-
-<a id="disable-fast-acl"></a>
-
-### Disable Fast ACL
-
-<a id="disable-forward-proxy-policy"></a>
-
-### Disable Forward Proxy Policy
-
-<a id="disable-network-policy"></a>
-
-### Disable Network Policy
 
 <a id="timeouts"></a>
 

--- a/docs/resources/network_interface.md
+++ b/docs/resources/network_interface.md
@@ -88,49 +88,29 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Dedicated Interface
 
-`cluster` - (Optional) Empty. This can be used for messages where no values are needed. See [Cluster](#dedicated-interface-cluster) below.
+`cluster` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `device` - (Optional) Interface Device. Name of the device for which interface is configured. Use wwan0 for 4G/LTE (`String`).
 
-`is_primary` - (Optional) Empty. This can be used for messages where no values are needed. See [Is Primary](#dedicated-interface-is-primary) below.
+`is_primary` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`monitor` - (Optional) Link Quality Monitoring Configuration. Link Quality Monitoring configuration for a network interface. See [Monitor](#dedicated-interface-monitor) below.
+`monitor` - (Optional) Link Quality Monitoring Configuration. Link Quality Monitoring configuration for a network interface (`Block`).
 
-`monitor_disabled` - (Optional) Empty. This can be used for messages where no values are needed. See [Monitor Disabled](#dedicated-interface-monitor-disabled) below.
+`monitor_disabled` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `mtu` - (Optional) Maximum Packet Size (MTU). Maximum packet size (Maximum Transfer Unit) of the interface When configured, MTU must be between 512 and 16384 (`Number`).
 
 `node` - (Optional) Specific Node. Configuration will apply to a device on the given node of the site (`String`).
 
-`not_primary` - (Optional) Empty. This can be used for messages where no values are needed. See [Not Primary](#dedicated-interface-not-primary) below.
+`not_primary` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `priority` - (Optional) Priority. Priority of the network interface when multiple network interfaces are present in outside network Greater the value, higher the priority (`Number`).
-
-<a id="dedicated-interface-cluster"></a>
-
-### Dedicated Interface Cluster
-
-<a id="dedicated-interface-is-primary"></a>
-
-### Dedicated Interface Is Primary
-
-<a id="dedicated-interface-monitor"></a>
-
-### Dedicated Interface Monitor
-
-<a id="dedicated-interface-monitor-disabled"></a>
-
-### Dedicated Interface Monitor Disabled
-
-<a id="dedicated-interface-not-primary"></a>
-
-### Dedicated Interface Not Primary
 
 <a id="dedicated-management-interface"></a>
 
 ### Dedicated Management Interface
 
-`cluster` - (Optional) Empty. This can be used for messages where no values are needed. See [Cluster](#dedicated-management-interface-cluster) below.
+`cluster` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `device` - (Optional) Interface Device. Name of the device for which interface is configured (`String`).
 
@@ -138,83 +118,63 @@ In addition to all arguments above, the following attributes are exported:
 
 `node` - (Optional) Specific Node. Configuration will apply to a device on the given node of the site (`String`).
 
-<a id="dedicated-management-interface-cluster"></a>
-
-### Dedicated Management Interface Cluster
-
 <a id="ethernet-interface"></a>
 
 ### Ethernet Interface
 
-`cluster` - (Optional) Empty. This can be used for messages where no values are needed. See [Cluster](#ethernet-interface-cluster) below.
+`cluster` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `device` - (Optional) Ethernet Device. Interface configuration for the ethernet device (`String`).
 
-`dhcp_client` - (Optional) Empty. This can be used for messages where no values are needed. See [DHCP Client](#ethernet-interface-dhcp-client) below.
+`dhcp_client` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `dhcp_server` - (Optional) DHCPServerParametersType. See [DHCP Server](#ethernet-interface-dhcp-server) below.
 
 `ipv6_auto_config` - (Optional) IPV6AutoConfigType. See [IPv6 Auto Config](#ethernet-interface-ipv6-auto-config) below.
 
-`is_primary` - (Optional) Empty. This can be used for messages where no values are needed. See [Is Primary](#ethernet-interface-is-primary) below.
+`is_primary` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`monitor` - (Optional) Link Quality Monitoring Configuration. Link Quality Monitoring configuration for a network interface. See [Monitor](#ethernet-interface-monitor) below.
+`monitor` - (Optional) Link Quality Monitoring Configuration. Link Quality Monitoring configuration for a network interface (`Block`).
 
-`monitor_disabled` - (Optional) Empty. This can be used for messages where no values are needed. See [Monitor Disabled](#ethernet-interface-monitor-disabled) below.
+`monitor_disabled` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `mtu` - (Optional) Maximum Packet Size (MTU). Maximum packet size (Maximum Transfer Unit) of the interface When configured, MTU must be between 512 and 16384 (`Number`).
 
-`no_ipv6_address` - (Optional) Empty. This can be used for messages where no values are needed. See [No IPv6 Address](#ethernet-interface-no-ipv6-address) below.
+`no_ipv6_address` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `node` - (Optional) Specific Node. Configuration will apply to a device on the given node (`String`).
 
-`not_primary` - (Optional) Empty. This can be used for messages where no values are needed. See [Not Primary](#ethernet-interface-not-primary) below.
+`not_primary` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `priority` - (Optional) Priority. Priority of the network interface when multiple network interfaces are present in outside network Greater the value, higher the priority (`Number`).
 
-`site_local_inside_network` - (Optional) Empty. This can be used for messages where no values are needed. See [Site Local Inside Network](#ethernet-interface-site-local-inside-network) below.
+`site_local_inside_network` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`site_local_network` - (Optional) Empty. This can be used for messages where no values are needed. See [Site Local Network](#ethernet-interface-site-local-network) below.
+`site_local_network` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `static_ip` - (Optional) Static IP Parameters. Configure Static IP parameters. See [Static IP](#ethernet-interface-static-ip) below.
 
 `static_ipv6_address` - (Optional) Static IP Parameters. Configure Static IP parameters. See [Static IPv6 Address](#ethernet-interface-static-ipv6-address) below.
 
-`storage_network` - (Optional) Empty. This can be used for messages where no values are needed. See [Storage Network](#ethernet-interface-storage-network) below.
+`storage_network` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`untagged` - (Optional) Empty. This can be used for messages where no values are needed. See [Untagged](#ethernet-interface-untagged) below.
+`untagged` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `vlan_id` - (Optional) VLAN Id. Configure a VLAN tagged ethernet interface (`Number`).
-
-<a id="ethernet-interface-cluster"></a>
-
-### Ethernet Interface Cluster
-
-<a id="ethernet-interface-dhcp-client"></a>
-
-### Ethernet Interface DHCP Client
 
 <a id="ethernet-interface-dhcp-server"></a>
 
 ### Ethernet Interface DHCP Server
 
-`automatic_from_end` - (Optional) Empty. This can be used for messages where no values are needed. See [Automatic From End](#ethernet-interface-dhcp-server-automatic-from-end) below.
+`automatic_from_end` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`automatic_from_start` - (Optional) Empty. This can be used for messages where no values are needed. See [Automatic From Start](#ethernet-interface-dhcp-server-automatic-from-start) below.
+`automatic_from_start` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `dhcp_networks` - (Optional) DHCP Networks. List of networks from which DHCP Server can allocate IPv4 Addresses. See [DHCP Networks](#ethernet-interface-dhcp-server-dhcp-networks) below.
 
-`fixed_ip_map` - (Optional) Fixed MAC Address to IPv4 Assignments. Assign fixed IPv4 addresses based on the MAC Address of the DHCP Client. See [Fixed IP Map](#ethernet-interface-dhcp-server-fixed-ip-map) below.
+`fixed_ip_map` - (Optional) Fixed MAC Address to IPv4 Assignments. Assign fixed IPv4 addresses based on the MAC Address of the DHCP Client (`Block`).
 
 `interface_ip_map` - (Optional) Interface IPv4 Assignments. Specify static IPv4 addresses per node. See [Interface IP Map](#ethernet-interface-dhcp-server-interface-ip-map) below.
-
-<a id="ethernet-interface-dhcp-server-automatic-from-end"></a>
-
-### Ethernet Interface DHCP Server Automatic From End
-
-<a id="ethernet-interface-dhcp-server-automatic-from-start"></a>
-
-### Ethernet Interface DHCP Server Automatic From Start
 
 <a id="ethernet-interface-dhcp-server-dhcp-networks"></a>
 
@@ -224,105 +184,41 @@ In addition to all arguments above, the following attributes are exported:
 
 `dns_address` - (Optional) Static IPv4 Configuration. Enter a IPv4 address from the network prefix to be used as the DNS server (`String`).
 
-`first_address` - (Optional) Empty. This can be used for messages where no values are needed. See [First Address](#ethernet-interface-dhcp-server-dhcp-networks-first-address) below.
+`first_address` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`last_address` - (Optional) Empty. This can be used for messages where no values are needed. See [Last Address](#ethernet-interface-dhcp-server-dhcp-networks-last-address) below.
+`last_address` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `network_prefix` - (Optional) Network Prefix. Set the network prefix for the site. ex: 10.1.1.0/24 (`String`).
 
 `pool_settings` - (Optional) Interface Network Type. Identifies the how to pick the network for Interface. Address ranges in DHCP pool list are used for IP Address allocation Address ranges in DHCP pool list are excluded from IP Address allocation. Possible values are `INCLUDE_IP_ADDRESSES_FROM_DHCP_POOLS`, `EXCLUDE_IP_ADDRESSES_FROM_DHCP_POOLS`. Defaults to `INCLUDE_IP_ADDRESSES_FROM_DHCP_POOLS` (`String`).
 
-`pools` - (Optional) DHCP Pools. List of non overlapping IP address ranges. See [Pools](#ethernet-interface-dhcp-server-dhcp-networks-pools) below.
+`pools` - (Optional) DHCP Pools. List of non overlapping IP address ranges (`Block`).
 
-`same_as_dgw` - (Optional) Empty. This can be used for messages where no values are needed. See [Same As Dgw](#ethernet-interface-dhcp-server-dhcp-networks-same-as-dgw) below.
-
-<a id="ethernet-interface-dhcp-server-dhcp-networks-first-address"></a>
-
-### Ethernet Interface DHCP Server DHCP Networks First Address
-
-<a id="ethernet-interface-dhcp-server-dhcp-networks-last-address"></a>
-
-### Ethernet Interface DHCP Server DHCP Networks Last Address
-
-<a id="ethernet-interface-dhcp-server-dhcp-networks-pools"></a>
-
-### Ethernet Interface DHCP Server DHCP Networks Pools
-
-<a id="ethernet-interface-dhcp-server-dhcp-networks-same-as-dgw"></a>
-
-### Ethernet Interface DHCP Server DHCP Networks Same As Dgw
-
-<a id="ethernet-interface-dhcp-server-fixed-ip-map"></a>
-
-### Ethernet Interface DHCP Server Fixed IP Map
+`same_as_dgw` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="ethernet-interface-dhcp-server-interface-ip-map"></a>
 
 ### Ethernet Interface DHCP Server Interface IP Map
 
-`interface_ip_map` - (Optional) Site:Node to IPv4 Address Mapping. Specify static IPv4 addresses per site:node. See [Interface IP Map](#ethernet-interface-dhcp-server-interface-ip-map-interface-ip-map) below.
-
-<a id="ethernet-interface-dhcp-server-interface-ip-map-interface-ip-map"></a>
-
-### Ethernet Interface DHCP Server Interface IP Map Interface IP Map
+`interface_ip_map` - (Optional) Site:Node to IPv4 Address Mapping. Specify static IPv4 addresses per site:node (`Block`).
 
 <a id="ethernet-interface-ipv6-auto-config"></a>
 
 ### Ethernet Interface IPv6 Auto Config
 
-`host` - (Optional) Empty. This can be used for messages where no values are needed. See [Host](#ethernet-interface-ipv6-auto-config-host) below.
+`host` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `router` - (Optional) IPV6AutoConfigRouterType. See [Router](#ethernet-interface-ipv6-auto-config-router) below.
-
-<a id="ethernet-interface-ipv6-auto-config-host"></a>
-
-### Ethernet Interface IPv6 Auto Config Host
 
 <a id="ethernet-interface-ipv6-auto-config-router"></a>
 
 ### Ethernet Interface IPv6 Auto Config Router
 
-`dns_config` - (Optional) IPV6DnsConfig. See [DNS Config](#ethernet-interface-ipv6-auto-config-router-dns-config) below.
+`dns_config` - (Optional) IPV6DnsConfig (`Block`).
 
 `network_prefix` - (Optional) Network Prefix. Nework prefix that is used as Prefix information Allowed only /64 prefix length as per RFC 4862 (`String`).
 
-`stateful` - (Optional) DHCPIPV6 Stateful Server. See [Stateful](#ethernet-interface-ipv6-auto-config-router-stateful) below.
-
-<a id="ethernet-interface-ipv6-auto-config-router-dns-config"></a>
-
-### Ethernet Interface IPv6 Auto Config Router DNS Config
-
-<a id="ethernet-interface-ipv6-auto-config-router-stateful"></a>
-
-### Ethernet Interface IPv6 Auto Config Router Stateful
-
-<a id="ethernet-interface-is-primary"></a>
-
-### Ethernet Interface Is Primary
-
-<a id="ethernet-interface-monitor"></a>
-
-### Ethernet Interface Monitor
-
-<a id="ethernet-interface-monitor-disabled"></a>
-
-### Ethernet Interface Monitor Disabled
-
-<a id="ethernet-interface-no-ipv6-address"></a>
-
-### Ethernet Interface No IPv6 Address
-
-<a id="ethernet-interface-not-primary"></a>
-
-### Ethernet Interface Not Primary
-
-<a id="ethernet-interface-site-local-inside-network"></a>
-
-### Ethernet Interface Site Local Inside Network
-
-<a id="ethernet-interface-site-local-network"></a>
-
-### Ethernet Interface Site Local Network
+`stateful` - (Optional) DHCPIPV6 Stateful Server (`Block`).
 
 <a id="ethernet-interface-static-ip"></a>
 
@@ -336,11 +232,7 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Ethernet Interface Static IP Cluster Static IP
 
-`interface_ip_map` - (Optional) Node to IP Mapping. Map of Node to Static IP configuration value, Key:Node, Value:IP Address. See [Interface IP Map](#ethernet-interface-static-ip-cluster-static-ip-interface-ip-map) below.
-
-<a id="ethernet-interface-static-ip-cluster-static-ip-interface-ip-map"></a>
-
-### Ethernet Interface Static IP Cluster Static IP Interface IP Map
+`interface_ip_map` - (Optional) Node to IP Mapping. Map of Node to Static IP configuration value, Key:Node, Value:IP Address (`Block`).
 
 <a id="ethernet-interface-static-ip-node-static-ip"></a>
 
@@ -362,11 +254,7 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Ethernet Interface Static IPv6 Address Cluster Static IP
 
-`interface_ip_map` - (Optional) Node to IP Mapping. Map of Node to Static IP configuration value, Key:Node, Value:IP Address. See [Interface IP Map](#ethernet-interface-static-ipv6-address-cluster-static-ip-interface-ip-map) below.
-
-<a id="ethernet-interface-static-ipv6-address-cluster-static-ip-interface-ip-map"></a>
-
-### Ethernet Interface Static IPv6 Address Cluster Static IP Interface IP Map
+`interface_ip_map` - (Optional) Node to IP Mapping. Map of Node to Static IP configuration value, Key:Node, Value:IP Address (`Block`).
 
 <a id="ethernet-interface-static-ipv6-address-node-static-ip"></a>
 
@@ -375,14 +263,6 @@ In addition to all arguments above, the following attributes are exported:
 `default_gw` - (Optional) Default Gateway. IP address of the default gateway (`String`).
 
 `ip_address` - (Optional) IP address/Prefix Length. IP address of the interface and prefix length (`String`).
-
-<a id="ethernet-interface-storage-network"></a>
-
-### Ethernet Interface Storage Network
-
-<a id="ethernet-interface-untagged"></a>
-
-### Ethernet Interface Untagged
 
 <a id="layer2-interface"></a>
 
@@ -400,13 +280,9 @@ In addition to all arguments above, the following attributes are exported:
 
 `device` - (Optional) Ethernet Device. Physical ethernet interface (`String`).
 
-`untagged` - (Optional) Empty. This can be used for messages where no values are needed. See [Untagged](#layer2-interface-l2sriov-interface-untagged) below.
+`untagged` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `vlan_id` - (Optional) VLAN Id. Configure a VLAN tagged interface (`Number`).
-
-<a id="layer2-interface-l2sriov-interface-untagged"></a>
-
-### Layer2 Interface L2sriov Interface Untagged
 
 <a id="layer2-interface-l2vlan-interface"></a>
 
@@ -444,21 +320,13 @@ In addition to all arguments above, the following attributes are exported:
 
 `priority` - (Optional) Priority. Priority of the network interface when multiple network interfaces are present in outside network Greater the value, higher the priority (`Number`).
 
-`site_local_inside_network` - (Optional) Empty. This can be used for messages where no values are needed. See [Site Local Inside Network](#tunnel-interface-site-local-inside-network) below.
+`site_local_inside_network` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`site_local_network` - (Optional) Empty. This can be used for messages where no values are needed. See [Site Local Network](#tunnel-interface-site-local-network) below.
+`site_local_network` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `static_ip` - (Optional) Static IP Parameters. Configure Static IP parameters. See [Static IP](#tunnel-interface-static-ip) below.
 
 `tunnel` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Tunnel](#tunnel-interface-tunnel) below.
-
-<a id="tunnel-interface-site-local-inside-network"></a>
-
-### Tunnel Interface Site Local Inside Network
-
-<a id="tunnel-interface-site-local-network"></a>
-
-### Tunnel Interface Site Local Network
 
 <a id="tunnel-interface-static-ip"></a>
 
@@ -472,11 +340,7 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Tunnel Interface Static IP Cluster Static IP
 
-`interface_ip_map` - (Optional) Node to IP Mapping. Map of Node to Static IP configuration value, Key:Node, Value:IP Address. See [Interface IP Map](#tunnel-interface-static-ip-cluster-static-ip-interface-ip-map) below.
-
-<a id="tunnel-interface-static-ip-cluster-static-ip-interface-ip-map"></a>
-
-### Tunnel Interface Static IP Cluster Static IP Interface IP Map
+`interface_ip_map` - (Optional) Node to IP Mapping. Map of Node to Static IP configuration value, Key:Node, Value:IP Address (`Block`).
 
 <a id="tunnel-interface-static-ip-node-static-ip"></a>
 

--- a/docs/resources/network_policy.md
+++ b/docs/resources/network_policy.md
@@ -91,33 +91,21 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Endpoint
 
-`any` - (Optional) Empty. This can be used for messages where no values are needed. See [Any](#endpoint-any) below.
+`any` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`inside_endpoints` - (Optional) Empty. This can be used for messages where no values are needed. See [Inside Endpoints](#endpoint-inside-endpoints) below.
+`inside_endpoints` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `label_selector` - (Optional) Label Selector. This type can be used to establish a 'selector reference' from one object(called selector) to a set of other objects(called selectees) based on the value of expresssions. A label selector is a label query over a set of resources. An empty label selector matches all objects. A null label selector matches no objects. Label selector is immutable. expressions is a list of strings of label selection expression. Each string has ',' separated values which are 'AND' and all strings ar. See [Label Selector](#endpoint-label-selector) below.
 
-`outside_endpoints` - (Optional) Empty. This can be used for messages where no values are needed. See [Outside Endpoints](#endpoint-outside-endpoints) below.
+`outside_endpoints` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `prefix_list` - (Optional) IPv4 Prefix List. x-example: '192.168.20.0/24' List of IPv4 prefixes that represent an endpoint. See [Prefix List](#endpoint-prefix-list) below.
-
-<a id="endpoint-any"></a>
-
-### Endpoint Any
-
-<a id="endpoint-inside-endpoints"></a>
-
-### Endpoint Inside Endpoints
 
 <a id="endpoint-label-selector"></a>
 
 ### Endpoint Label Selector
 
 `expressions` - (Optional) Selector Expression. expressions contains the kubernetes style label expression for selections (`List`).
-
-<a id="endpoint-outside-endpoints"></a>
-
-### Endpoint Outside Endpoints
 
 <a id="endpoint-prefix-list"></a>
 
@@ -141,17 +129,17 @@ In addition to all arguments above, the following attributes are exported:
 
 `adv_action` - (Optional) Network Policy Rule Advanced Action. Network Policy Rule Advanced Action provides additional options along with RuleAction and PBRRuleAction. See [Adv Action](#rules-egress-rules-adv-action) below.
 
-`all_tcp_traffic` - (Optional) Empty. This can be used for messages where no values are needed. See [All TCP Traffic](#rules-egress-rules-all-tcp-traffic) below.
+`all_tcp_traffic` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`all_traffic` - (Optional) Empty. This can be used for messages where no values are needed. See [All Traffic](#rules-egress-rules-all-traffic) below.
+`all_traffic` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`all_udp_traffic` - (Optional) Empty. This can be used for messages where no values are needed. See [All UDP Traffic](#rules-egress-rules-all-udp-traffic) below.
+`all_udp_traffic` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`any` - (Optional) Empty. This can be used for messages where no values are needed. See [Any](#rules-egress-rules-any) below.
+`any` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `applications` - (Optional) Applications. Application protocols like HTTP, SNMP. See [Applications](#rules-egress-rules-applications) below.
 
-`inside_endpoints` - (Optional) Empty. This can be used for messages where no values are needed. See [Inside Endpoints](#rules-egress-rules-inside-endpoints) below.
+`inside_endpoints` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `ip_prefix_set` - (Optional) IP Prefix Set Reference. A list of references to ip_prefix_set objects. See [IP Prefix Set](#rules-egress-rules-ip-prefix-set) below.
 
@@ -161,7 +149,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `metadata` - (Optional) Message Metadata. MessageMetaType is metadata (common attributes) of a message that only certain messages have. This information is propagated to the metadata of a child object that gets created from the containing message during view processing. The information in this type can be specified by user during create and replace APIs. See [Metadata](#rules-egress-rules-metadata) below.
 
-`outside_endpoints` - (Optional) Empty. This can be used for messages where no values are needed. See [Outside Endpoints](#rules-egress-rules-outside-endpoints) below.
+`outside_endpoints` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `prefix_list` - (Optional) IPv4 Prefix List. x-example: '192.168.20.0/24' List of IPv4 prefixes that represent an endpoint. See [Prefix List](#rules-egress-rules-prefix-list) below.
 
@@ -173,41 +161,17 @@ In addition to all arguments above, the following attributes are exported:
 
 `action` - (Optional) Log Action. Choice to choose logging or no logging This works together with option selected via NetworkPolicyRuleAction or any other action specified x-example: (No Selection in NetworkPolicyRuleAction + AdvancedAction as LOG) = LOG Only, (ALLOW/DENY in NetworkPolicyRuleAction + AdvancedAction as LOG) = Log and Allow/Deny, (ALLOW/DENY in NetworkPolicyRuleAction + NOLOG in AdvancedAction) = Allow/Deny with no log Don't sample the traffic hitting the rule Sample the traffic hitting the rule. Possible values are `NOLOG`, `LOG`. Defaults to `NOLOG` (`String`).
 
-<a id="rules-egress-rules-all-tcp-traffic"></a>
-
-### Rules Egress Rules All TCP Traffic
-
-<a id="rules-egress-rules-all-traffic"></a>
-
-### Rules Egress Rules All Traffic
-
-<a id="rules-egress-rules-all-udp-traffic"></a>
-
-### Rules Egress Rules All UDP Traffic
-
-<a id="rules-egress-rules-any"></a>
-
-### Rules Egress Rules Any
-
 <a id="rules-egress-rules-applications"></a>
 
 ### Rules Egress Rules Applications
 
 `applications` - (Optional) Application Protocols. Application protocols like HTTP, SNMP (`List`).
 
-<a id="rules-egress-rules-inside-endpoints"></a>
-
-### Rules Egress Rules Inside Endpoints
-
 <a id="rules-egress-rules-ip-prefix-set"></a>
 
 ### Rules Egress Rules IP Prefix Set
 
-`ref` - (Optional) Reference. A list of references to ip_prefix_set objects. See [Ref](#rules-egress-rules-ip-prefix-set-ref) below.
-
-<a id="rules-egress-rules-ip-prefix-set-ref"></a>
-
-### Rules Egress Rules IP Prefix Set Ref
+`ref` - (Optional) Reference. A list of references to ip_prefix_set objects (`Block`).
 
 <a id="rules-egress-rules-label-matcher"></a>
 
@@ -228,10 +192,6 @@ In addition to all arguments above, the following attributes are exported:
 `description` - (Optional) Description. Human readable description (`String`).
 
 `name` - (Optional) Name. This is the name of the message. The value of name has to follow DNS-1035 format (`String`).
-
-<a id="rules-egress-rules-outside-endpoints"></a>
-
-### Rules Egress Rules Outside Endpoints
 
 <a id="rules-egress-rules-prefix-list"></a>
 
@@ -255,17 +215,17 @@ In addition to all arguments above, the following attributes are exported:
 
 `adv_action` - (Optional) Network Policy Rule Advanced Action. Network Policy Rule Advanced Action provides additional options along with RuleAction and PBRRuleAction. See [Adv Action](#rules-ingress-rules-adv-action) below.
 
-`all_tcp_traffic` - (Optional) Empty. This can be used for messages where no values are needed. See [All TCP Traffic](#rules-ingress-rules-all-tcp-traffic) below.
+`all_tcp_traffic` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`all_traffic` - (Optional) Empty. This can be used for messages where no values are needed. See [All Traffic](#rules-ingress-rules-all-traffic) below.
+`all_traffic` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`all_udp_traffic` - (Optional) Empty. This can be used for messages where no values are needed. See [All UDP Traffic](#rules-ingress-rules-all-udp-traffic) below.
+`all_udp_traffic` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`any` - (Optional) Empty. This can be used for messages where no values are needed. See [Any](#rules-ingress-rules-any) below.
+`any` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `applications` - (Optional) Applications. Application protocols like HTTP, SNMP. See [Applications](#rules-ingress-rules-applications) below.
 
-`inside_endpoints` - (Optional) Empty. This can be used for messages where no values are needed. See [Inside Endpoints](#rules-ingress-rules-inside-endpoints) below.
+`inside_endpoints` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `ip_prefix_set` - (Optional) IP Prefix Set Reference. A list of references to ip_prefix_set objects. See [IP Prefix Set](#rules-ingress-rules-ip-prefix-set) below.
 
@@ -275,7 +235,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `metadata` - (Optional) Message Metadata. MessageMetaType is metadata (common attributes) of a message that only certain messages have. This information is propagated to the metadata of a child object that gets created from the containing message during view processing. The information in this type can be specified by user during create and replace APIs. See [Metadata](#rules-ingress-rules-metadata) below.
 
-`outside_endpoints` - (Optional) Empty. This can be used for messages where no values are needed. See [Outside Endpoints](#rules-ingress-rules-outside-endpoints) below.
+`outside_endpoints` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `prefix_list` - (Optional) IPv4 Prefix List. x-example: '192.168.20.0/24' List of IPv4 prefixes that represent an endpoint. See [Prefix List](#rules-ingress-rules-prefix-list) below.
 
@@ -287,41 +247,17 @@ In addition to all arguments above, the following attributes are exported:
 
 `action` - (Optional) Log Action. Choice to choose logging or no logging This works together with option selected via NetworkPolicyRuleAction or any other action specified x-example: (No Selection in NetworkPolicyRuleAction + AdvancedAction as LOG) = LOG Only, (ALLOW/DENY in NetworkPolicyRuleAction + AdvancedAction as LOG) = Log and Allow/Deny, (ALLOW/DENY in NetworkPolicyRuleAction + NOLOG in AdvancedAction) = Allow/Deny with no log Don't sample the traffic hitting the rule Sample the traffic hitting the rule. Possible values are `NOLOG`, `LOG`. Defaults to `NOLOG` (`String`).
 
-<a id="rules-ingress-rules-all-tcp-traffic"></a>
-
-### Rules Ingress Rules All TCP Traffic
-
-<a id="rules-ingress-rules-all-traffic"></a>
-
-### Rules Ingress Rules All Traffic
-
-<a id="rules-ingress-rules-all-udp-traffic"></a>
-
-### Rules Ingress Rules All UDP Traffic
-
-<a id="rules-ingress-rules-any"></a>
-
-### Rules Ingress Rules Any
-
 <a id="rules-ingress-rules-applications"></a>
 
 ### Rules Ingress Rules Applications
 
 `applications` - (Optional) Application Protocols. Application protocols like HTTP, SNMP (`List`).
 
-<a id="rules-ingress-rules-inside-endpoints"></a>
-
-### Rules Ingress Rules Inside Endpoints
-
 <a id="rules-ingress-rules-ip-prefix-set"></a>
 
 ### Rules Ingress Rules IP Prefix Set
 
-`ref` - (Optional) Reference. A list of references to ip_prefix_set objects. See [Ref](#rules-ingress-rules-ip-prefix-set-ref) below.
-
-<a id="rules-ingress-rules-ip-prefix-set-ref"></a>
-
-### Rules Ingress Rules IP Prefix Set Ref
+`ref` - (Optional) Reference. A list of references to ip_prefix_set objects (`Block`).
 
 <a id="rules-ingress-rules-label-matcher"></a>
 
@@ -342,10 +278,6 @@ In addition to all arguments above, the following attributes are exported:
 `description` - (Optional) Description. Human readable description (`String`).
 
 `name` - (Optional) Name. This is the name of the message. The value of name has to follow DNS-1035 format (`String`).
-
-<a id="rules-ingress-rules-outside-endpoints"></a>
-
-### Rules Ingress Rules Outside Endpoints
 
 <a id="rules-ingress-rules-prefix-list"></a>
 

--- a/docs/resources/network_policy_view.md
+++ b/docs/resources/network_policy_view.md
@@ -86,17 +86,17 @@ In addition to all arguments above, the following attributes are exported:
 
 `adv_action` - (Optional) Network Policy Rule Advanced Action. Network Policy Rule Advanced Action provides additional options along with RuleAction and PBRRuleAction. See [Adv Action](#egress-rules-adv-action) below.
 
-`all_tcp_traffic` - (Optional) Empty. This can be used for messages where no values are needed. See [All TCP Traffic](#egress-rules-all-tcp-traffic) below.
+`all_tcp_traffic` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`all_traffic` - (Optional) Empty. This can be used for messages where no values are needed. See [All Traffic](#egress-rules-all-traffic) below.
+`all_traffic` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`all_udp_traffic` - (Optional) Empty. This can be used for messages where no values are needed. See [All UDP Traffic](#egress-rules-all-udp-traffic) below.
+`all_udp_traffic` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`any` - (Optional) Empty. This can be used for messages where no values are needed. See [Any](#egress-rules-any) below.
+`any` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `applications` - (Optional) Applications. Application protocols like HTTP, SNMP. See [Applications](#egress-rules-applications) below.
 
-`inside_endpoints` - (Optional) Empty. This can be used for messages where no values are needed. See [Inside Endpoints](#egress-rules-inside-endpoints) below.
+`inside_endpoints` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `ip_prefix_set` - (Optional) IP Prefix Set Reference. A list of references to ip_prefix_set objects. See [IP Prefix Set](#egress-rules-ip-prefix-set) below.
 
@@ -106,7 +106,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `metadata` - (Optional) Message Metadata. MessageMetaType is metadata (common attributes) of a message that only certain messages have. This information is propagated to the metadata of a child object that gets created from the containing message during view processing. The information in this type can be specified by user during create and replace APIs. See [Metadata](#egress-rules-metadata) below.
 
-`outside_endpoints` - (Optional) Empty. This can be used for messages where no values are needed. See [Outside Endpoints](#egress-rules-outside-endpoints) below.
+`outside_endpoints` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `prefix_list` - (Optional) IPv4 Prefix List. x-example: '192.168.20.0/24' List of IPv4 prefixes that represent an endpoint. See [Prefix List](#egress-rules-prefix-list) below.
 
@@ -118,31 +118,11 @@ In addition to all arguments above, the following attributes are exported:
 
 `action` - (Optional) Log Action. Choice to choose logging or no logging This works together with option selected via NetworkPolicyRuleAction or any other action specified x-example: (No Selection in NetworkPolicyRuleAction + AdvancedAction as LOG) = LOG Only, (ALLOW/DENY in NetworkPolicyRuleAction + AdvancedAction as LOG) = Log and Allow/Deny, (ALLOW/DENY in NetworkPolicyRuleAction + NOLOG in AdvancedAction) = Allow/Deny with no log Don't sample the traffic hitting the rule Sample the traffic hitting the rule. Possible values are `NOLOG`, `LOG`. Defaults to `NOLOG` (`String`).
 
-<a id="egress-rules-all-tcp-traffic"></a>
-
-### Egress Rules All TCP Traffic
-
-<a id="egress-rules-all-traffic"></a>
-
-### Egress Rules All Traffic
-
-<a id="egress-rules-all-udp-traffic"></a>
-
-### Egress Rules All UDP Traffic
-
-<a id="egress-rules-any"></a>
-
-### Egress Rules Any
-
 <a id="egress-rules-applications"></a>
 
 ### Egress Rules Applications
 
 `applications` - (Optional) Application Protocols. Application protocols like HTTP, SNMP (`List`).
-
-<a id="egress-rules-inside-endpoints"></a>
-
-### Egress Rules Inside Endpoints
 
 <a id="egress-rules-ip-prefix-set"></a>
 
@@ -184,10 +164,6 @@ In addition to all arguments above, the following attributes are exported:
 
 `name` - (Optional) Name. This is the name of the message. The value of name has to follow DNS-1035 format (`String`).
 
-<a id="egress-rules-outside-endpoints"></a>
-
-### Egress Rules Outside Endpoints
-
 <a id="egress-rules-prefix-list"></a>
 
 ### Egress Rules Prefix List
@@ -206,33 +182,21 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Endpoint
 
-`any` - (Optional) Empty. This can be used for messages where no values are needed. See [Any](#endpoint-any) below.
+`any` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`inside_endpoints` - (Optional) Empty. This can be used for messages where no values are needed. See [Inside Endpoints](#endpoint-inside-endpoints) below.
+`inside_endpoints` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `label_selector` - (Optional) Label Selector. This type can be used to establish a 'selector reference' from one object(called selector) to a set of other objects(called selectees) based on the value of expresssions. A label selector is a label query over a set of resources. An empty label selector matches all objects. A null label selector matches no objects. Label selector is immutable. expressions is a list of strings of label selection expression. Each string has ',' separated values which are 'AND' and all strings ar. See [Label Selector](#endpoint-label-selector) below.
 
-`outside_endpoints` - (Optional) Empty. This can be used for messages where no values are needed. See [Outside Endpoints](#endpoint-outside-endpoints) below.
+`outside_endpoints` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `prefix_list` - (Optional) IPv4 Prefix List. x-example: '192.168.20.0/24' List of IPv4 prefixes that represent an endpoint. See [Prefix List](#endpoint-prefix-list) below.
-
-<a id="endpoint-any"></a>
-
-### Endpoint Any
-
-<a id="endpoint-inside-endpoints"></a>
-
-### Endpoint Inside Endpoints
 
 <a id="endpoint-label-selector"></a>
 
 ### Endpoint Label Selector
 
 `expressions` - (Optional) Selector Expression. expressions contains the kubernetes style label expression for selections (`List`).
-
-<a id="endpoint-outside-endpoints"></a>
-
-### Endpoint Outside Endpoints
 
 <a id="endpoint-prefix-list"></a>
 
@@ -248,17 +212,17 @@ In addition to all arguments above, the following attributes are exported:
 
 `adv_action` - (Optional) Network Policy Rule Advanced Action. Network Policy Rule Advanced Action provides additional options along with RuleAction and PBRRuleAction. See [Adv Action](#ingress-rules-adv-action) below.
 
-`all_tcp_traffic` - (Optional) Empty. This can be used for messages where no values are needed. See [All TCP Traffic](#ingress-rules-all-tcp-traffic) below.
+`all_tcp_traffic` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`all_traffic` - (Optional) Empty. This can be used for messages where no values are needed. See [All Traffic](#ingress-rules-all-traffic) below.
+`all_traffic` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`all_udp_traffic` - (Optional) Empty. This can be used for messages where no values are needed. See [All UDP Traffic](#ingress-rules-all-udp-traffic) below.
+`all_udp_traffic` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`any` - (Optional) Empty. This can be used for messages where no values are needed. See [Any](#ingress-rules-any) below.
+`any` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `applications` - (Optional) Applications. Application protocols like HTTP, SNMP. See [Applications](#ingress-rules-applications) below.
 
-`inside_endpoints` - (Optional) Empty. This can be used for messages where no values are needed. See [Inside Endpoints](#ingress-rules-inside-endpoints) below.
+`inside_endpoints` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `ip_prefix_set` - (Optional) IP Prefix Set Reference. A list of references to ip_prefix_set objects. See [IP Prefix Set](#ingress-rules-ip-prefix-set) below.
 
@@ -268,7 +232,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `metadata` - (Optional) Message Metadata. MessageMetaType is metadata (common attributes) of a message that only certain messages have. This information is propagated to the metadata of a child object that gets created from the containing message during view processing. The information in this type can be specified by user during create and replace APIs. See [Metadata](#ingress-rules-metadata) below.
 
-`outside_endpoints` - (Optional) Empty. This can be used for messages where no values are needed. See [Outside Endpoints](#ingress-rules-outside-endpoints) below.
+`outside_endpoints` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `prefix_list` - (Optional) IPv4 Prefix List. x-example: '192.168.20.0/24' List of IPv4 prefixes that represent an endpoint. See [Prefix List](#ingress-rules-prefix-list) below.
 
@@ -280,31 +244,11 @@ In addition to all arguments above, the following attributes are exported:
 
 `action` - (Optional) Log Action. Choice to choose logging or no logging This works together with option selected via NetworkPolicyRuleAction or any other action specified x-example: (No Selection in NetworkPolicyRuleAction + AdvancedAction as LOG) = LOG Only, (ALLOW/DENY in NetworkPolicyRuleAction + AdvancedAction as LOG) = Log and Allow/Deny, (ALLOW/DENY in NetworkPolicyRuleAction + NOLOG in AdvancedAction) = Allow/Deny with no log Don't sample the traffic hitting the rule Sample the traffic hitting the rule. Possible values are `NOLOG`, `LOG`. Defaults to `NOLOG` (`String`).
 
-<a id="ingress-rules-all-tcp-traffic"></a>
-
-### Ingress Rules All TCP Traffic
-
-<a id="ingress-rules-all-traffic"></a>
-
-### Ingress Rules All Traffic
-
-<a id="ingress-rules-all-udp-traffic"></a>
-
-### Ingress Rules All UDP Traffic
-
-<a id="ingress-rules-any"></a>
-
-### Ingress Rules Any
-
 <a id="ingress-rules-applications"></a>
 
 ### Ingress Rules Applications
 
 `applications` - (Optional) Application Protocols. Application protocols like HTTP, SNMP (`List`).
-
-<a id="ingress-rules-inside-endpoints"></a>
-
-### Ingress Rules Inside Endpoints
 
 <a id="ingress-rules-ip-prefix-set"></a>
 
@@ -345,10 +289,6 @@ In addition to all arguments above, the following attributes are exported:
 `description` - (Optional) Description. Human readable description (`String`).
 
 `name` - (Optional) Name. This is the name of the message. The value of name has to follow DNS-1035 format (`String`).
-
-<a id="ingress-rules-outside-endpoints"></a>
-
-### Ingress Rules Outside Endpoints
 
 <a id="ingress-rules-prefix-list"></a>
 

--- a/docs/resources/nfv_service.md
+++ b/docs/resources/nfv_service.md
@@ -64,13 +64,13 @@ resource "f5xc_nfv_service" "example" {
 
 > **Note:** One of the arguments from this list "disable_https_management, https_management" must be set.
 
-`disable_https_management` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable HTTPS Management](#disable-https-management) below for details.
+`disable_https_management` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `https_management` - (Optional) HTTPS based management. HTTPS based configuration. See [HTTPS Management](#https-management) below for details.
 
 > **Note:** One of the arguments from this list "disable_ssh_access, enabled_ssh_access" must be set.
 
-`disable_ssh_access` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable SSH Access](#disable-ssh-access) below for details.
+`disable_ssh_access` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `enabled_ssh_access` - (Optional) SSH based management. SSH based configuration. See [Enabled SSH Access](#enabled-ssh-access) below for details.
 
@@ -90,39 +90,19 @@ In addition to all arguments above, the following attributes are exported:
 
 ---
 
-<a id="disable-https-management"></a>
-
-### Disable HTTPS Management
-
-<a id="disable-ssh-access"></a>
-
-### Disable SSH Access
-
 <a id="enabled-ssh-access"></a>
 
 ### Enabled SSH Access
 
-`advertise_on_sli` - (Optional) Empty. This can be used for messages where no values are needed. See [Advertise On Sli](#enabled-ssh-access-advertise-on-sli) below.
+`advertise_on_sli` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`advertise_on_slo` - (Optional) Empty. This can be used for messages where no values are needed. See [Advertise On Slo](#enabled-ssh-access-advertise-on-slo) below.
+`advertise_on_slo` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`advertise_on_slo_sli` - (Optional) Empty. This can be used for messages where no values are needed. See [Advertise On Slo Sli](#enabled-ssh-access-advertise-on-slo-sli) below.
+`advertise_on_slo_sli` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `domain_suffix` - (Optional) Domain Suffix. Domain suffix will be used along with node name to form the hostname for SSH node management (`String`).
 
 `node_ssh_ports` - (Optional) Management Node SSH Port. Enter TCP port and node name per node. See [Node SSH Ports](#enabled-ssh-access-node-ssh-ports) below.
-
-<a id="enabled-ssh-access-advertise-on-sli"></a>
-
-### Enabled SSH Access Advertise On Sli
-
-<a id="enabled-ssh-access-advertise-on-slo"></a>
-
-### Enabled SSH Access Advertise On Slo
-
-<a id="enabled-ssh-access-advertise-on-slo-sli"></a>
-
-### Enabled SSH Access Advertise On Slo Sli
 
 <a id="enabled-ssh-access-node-ssh-ports"></a>
 
@@ -150,7 +130,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `ssh_key` - (Optional) Public SSH key. Public SSH key for accessing the Big IP nodes (`String`).
 
-`tags` - (Optional) AWS Tags. AWS Tags is a label consisting of a user-defined key and value. It helps to manage, identify, organize, search for, and filter resources in AWS console. See [Tags](#f5-big-ip-aws-service-tags) below.
+`tags` - (Optional) AWS Tags. AWS Tags is a label consisting of a user-defined key and value. It helps to manage, identify, organize, search for, and filter resources in AWS console (`Block`).
 
 <a id="f5-big-ip-aws-service-admin-password"></a>
 
@@ -198,11 +178,11 @@ In addition to all arguments above, the following attributes are exported:
 
 ### F5 Big IP AWS Service Endpoint Service
 
-`advertise_on_slo_ip` - (Optional) Empty. This can be used for messages where no values are needed. See [Advertise On Slo IP](#f5-big-ip-aws-service-endpoint-service-advertise-on-slo-ip) below.
+`advertise_on_slo_ip` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`advertise_on_slo_ip_external` - (Optional) Empty. This can be used for messages where no values are needed. See [Advertise On Slo IP External](#f5-big-ip-aws-service-endpoint-service-advertise-on-slo-ip-external) below.
+`advertise_on_slo_ip_external` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`automatic_vip` - (Optional) Empty. This can be used for messages where no values are needed. See [Automatic VIP](#f5-big-ip-aws-service-endpoint-service-automatic-vip) below.
+`automatic_vip` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `configured_vip` - (Optional) Configured VIP. Enter IP address for the default VIP (`String`).
 
@@ -210,29 +190,17 @@ In addition to all arguments above, the following attributes are exported:
 
 `custom_udp_ports` - (Optional) Port Range List. List of port ranges. See [Custom UDP Ports](#f5-big-ip-aws-service-endpoint-service-custom-udp-ports) below.
 
-`default_tcp_ports` - (Optional) Empty. This can be used for messages where no values are needed. See [Default TCP Ports](#f5-big-ip-aws-service-endpoint-service-default-tcp-ports) below.
+`default_tcp_ports` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`disable_advertise_on_slo_ip` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Advertise On Slo IP](#f5-big-ip-aws-service-endpoint-service-disable-advertise-on-slo-ip) below.
+`disable_advertise_on_slo_ip` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`http_port` - (Optional) Empty. This can be used for messages where no values are needed. See [HTTP Port](#f5-big-ip-aws-service-endpoint-service-http-port) below.
+`http_port` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`https_port` - (Optional) Empty. This can be used for messages where no values are needed. See [HTTPS Port](#f5-big-ip-aws-service-endpoint-service-https-port) below.
+`https_port` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_tcp_ports` - (Optional) Empty. This can be used for messages where no values are needed. See [No TCP Ports](#f5-big-ip-aws-service-endpoint-service-no-tcp-ports) below.
+`no_tcp_ports` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_udp_ports` - (Optional) Empty. This can be used for messages where no values are needed. See [No UDP Ports](#f5-big-ip-aws-service-endpoint-service-no-udp-ports) below.
-
-<a id="f5-big-ip-aws-service-endpoint-service-advertise-on-slo-ip"></a>
-
-### F5 Big IP AWS Service Endpoint Service Advertise On Slo IP
-
-<a id="f5-big-ip-aws-service-endpoint-service-advertise-on-slo-ip-external"></a>
-
-### F5 Big IP AWS Service Endpoint Service Advertise On Slo IP External
-
-<a id="f5-big-ip-aws-service-endpoint-service-automatic-vip"></a>
-
-### F5 Big IP AWS Service Endpoint Service Automatic VIP
+`no_udp_ports` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="f5-big-ip-aws-service-endpoint-service-custom-tcp-ports"></a>
 
@@ -246,51 +214,19 @@ In addition to all arguments above, the following attributes are exported:
 
 `ports` - (Optional) Port Ranges. List of port ranges. Each range is a single port or a pair of start and end ports e.g. 8080-8192 (`List`).
 
-<a id="f5-big-ip-aws-service-endpoint-service-default-tcp-ports"></a>
-
-### F5 Big IP AWS Service Endpoint Service Default TCP Ports
-
-<a id="f5-big-ip-aws-service-endpoint-service-disable-advertise-on-slo-ip"></a>
-
-### F5 Big IP AWS Service Endpoint Service Disable Advertise On Slo IP
-
-<a id="f5-big-ip-aws-service-endpoint-service-http-port"></a>
-
-### F5 Big IP AWS Service Endpoint Service HTTP Port
-
-<a id="f5-big-ip-aws-service-endpoint-service-https-port"></a>
-
-### F5 Big IP AWS Service Endpoint Service HTTPS Port
-
-<a id="f5-big-ip-aws-service-endpoint-service-no-tcp-ports"></a>
-
-### F5 Big IP AWS Service Endpoint Service No TCP Ports
-
-<a id="f5-big-ip-aws-service-endpoint-service-no-udp-ports"></a>
-
-### F5 Big IP AWS Service Endpoint Service No UDP Ports
-
 <a id="f5-big-ip-aws-service-market-place-image"></a>
 
 ### F5 Big IP AWS Service Market Place Image
 
-`awafpay_g200_mbps` - (Optional) Empty. This can be used for messages where no values are needed. See [Awafpay G200 Mbps](#f5-big-ip-aws-service-market-place-image-awafpay-g200-mbps) below.
+`awafpay_g200_mbps` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`awafpay_g3_gbps` - (Optional) Empty. This can be used for messages where no values are needed. See [Awafpay G3 Gbps](#f5-big-ip-aws-service-market-place-image-awafpay-g3-gbps) below.
-
-<a id="f5-big-ip-aws-service-market-place-image-awafpay-g200-mbps"></a>
-
-### F5 Big IP AWS Service Market Place Image Awafpay G200 Mbps
-
-<a id="f5-big-ip-aws-service-market-place-image-awafpay-g3-gbps"></a>
-
-### F5 Big IP AWS Service Market Place Image Awafpay G3 Gbps
+`awafpay_g3_gbps` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="f5-big-ip-aws-service-nodes"></a>
 
 ### F5 Big IP AWS Service Nodes
 
-`automatic_prefix` - (Optional) Empty. This can be used for messages where no values are needed. See [Automatic Prefix](#f5-big-ip-aws-service-nodes-automatic-prefix) below.
+`automatic_prefix` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `aws_az_name` - (Optional) AWS AZ Name. The AWS Availability Zone must be consistent with the AWS Region chosen. Please select an AZ in the same Region as your TGW Site (`String`).
 
@@ -298,13 +234,9 @@ In addition to all arguments above, the following attributes are exported:
 
 `node_name` - (Optional) Node Name. Node Name will be used to assign as hostname to the service (`String`).
 
-`reserved_mgmt_subnet` - (Optional) Empty. This can be used for messages where no values are needed. See [Reserved Mgmt Subnet](#f5-big-ip-aws-service-nodes-reserved-mgmt-subnet) below.
+`reserved_mgmt_subnet` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `tunnel_prefix` - (Optional) Tunnel IP Prefix. Enter IP prefix for the tunnel, it has to be /30 (`String`).
-
-<a id="f5-big-ip-aws-service-nodes-automatic-prefix"></a>
-
-### F5 Big IP AWS Service Nodes Automatic Prefix
 
 <a id="f5-big-ip-aws-service-nodes-mgmt-subnet"></a>
 
@@ -312,19 +244,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `existing_subnet_id` - (Optional) Existing Subnet ID. Information about existing subnet ID (`String`).
 
-`subnet_param` - (Optional) New Cloud Subnet Parameters. Parameters for creating a new cloud subnet. See [Subnet Param](#f5-big-ip-aws-service-nodes-mgmt-subnet-subnet-param) below.
-
-<a id="f5-big-ip-aws-service-nodes-mgmt-subnet-subnet-param"></a>
-
-### F5 Big IP AWS Service Nodes Mgmt Subnet Subnet Param
-
-<a id="f5-big-ip-aws-service-nodes-reserved-mgmt-subnet"></a>
-
-### F5 Big IP AWS Service Nodes Reserved Mgmt Subnet
-
-<a id="f5-big-ip-aws-service-tags"></a>
-
-### F5 Big IP AWS Service Tags
+`subnet_param` - (Optional) New Cloud Subnet Parameters. Parameters for creating a new cloud subnet (`Block`).
 
 <a id="https-management"></a>
 
@@ -332,7 +252,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `advertise_on_internet` - (Optional) Advertise Public. This defines a way to advertise a load balancer on public. If optional public_ip is provided, it will only be advertised on RE sites where that public_ip is available. See [Advertise On Internet](#https-management-advertise-on-internet) below.
 
-`advertise_on_internet_default_vip` - (Optional) Empty. This can be used for messages where no values are needed. See [Advertise On Internet Default VIP](#https-management-advertise-on-internet-default-vip) below.
+`advertise_on_internet_default_vip` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `advertise_on_sli_vip` - (Optional) Inline TLS Parameters. Inline TLS parameters. See [Advertise On Sli VIP](#https-management-advertise-on-sli-vip) below.
 
@@ -342,7 +262,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `advertise_on_slo_vip` - (Optional) Inline TLS Parameters. Inline TLS parameters. See [Advertise On Slo VIP](#https-management-advertise-on-slo-vip) below.
 
-`default_https_port` - (Optional) Empty. This can be used for messages where no values are needed. See [Default HTTPS Port](#https-management-default-https-port) below.
+`default_https_port` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `domain_suffix` - (Optional) Domain Suffix. Domain suffix will be used along with node name to form URL to access node management (`String`).
 
@@ -364,15 +284,11 @@ In addition to all arguments above, the following attributes are exported:
 
 `tenant` - (Optional) Tenant. When a configuration object(e.g. virtual_host) refers to another(e.g route) then tenant will hold the referred object's(e.g. route's) tenant (`String`).
 
-<a id="https-management-advertise-on-internet-default-vip"></a>
-
-### HTTPS Management Advertise On Internet Default VIP
-
 <a id="https-management-advertise-on-sli-vip"></a>
 
 ### HTTPS Management Advertise On Sli VIP
 
-`no_mtls` - (Optional) Empty. This can be used for messages where no values are needed. See [No mTLS](#https-management-advertise-on-sli-vip-no-mtls) below.
+`no_mtls` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `tls_certificates` - (Optional) TLS Certificates. Users can add one or more certificates that share the same set of domains. for example, domain.com and *.domain.com - but use different signature algorithms. See [TLS Certificates](#https-management-advertise-on-sli-vip-tls-certificates) below.
 
@@ -380,69 +296,33 @@ In addition to all arguments above, the following attributes are exported:
 
 `use_mtls` - (Optional) Clients TLS validation context. Validation context for downstream client TLS connections. See [Use mTLS](#https-management-advertise-on-sli-vip-use-mtls) below.
 
-<a id="https-management-advertise-on-sli-vip-no-mtls"></a>
-
-### HTTPS Management Advertise On Sli VIP No mTLS
-
 <a id="https-management-advertise-on-sli-vip-tls-certificates"></a>
 
 ### HTTPS Management Advertise On Sli VIP TLS Certificates
 
 `certificate_url` - (Optional) Certificate. TLS certificate. Certificate or certificate chain in PEM format including the PEM headers (`String`).
 
-`custom_hash_algorithms` - (Optional) Hash Algorithms. Specifies the hash algorithms to be used. See [Custom Hash Algorithms](#https-management-advertise-on-sli-vip-tls-certificates-custom-hash-algorithms) below.
+`custom_hash_algorithms` - (Optional) Hash Algorithms. Specifies the hash algorithms to be used (`Block`).
 
 `description` - (Optional) Configuration for description (`String`).
 
-`disable_ocsp_stapling` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable OCSP Stapling](#https-management-advertise-on-sli-vip-tls-certificates-disable-ocsp-stapling) below.
+`disable_ocsp_stapling` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`private_key` - (Optional) Secret. SecretType is used in an object to indicate a sensitive/confidential field. See [Private Key](#https-management-advertise-on-sli-vip-tls-certificates-private-key) below.
+`private_key` - (Optional) Secret. SecretType is used in an object to indicate a sensitive/confidential field (`Block`).
 
-`use_system_defaults` - (Optional) Empty. This can be used for messages where no values are needed. See [Use System Defaults](#https-management-advertise-on-sli-vip-tls-certificates-use-system-defaults) below.
-
-<a id="https-management-advertise-on-sli-vip-tls-certificates-custom-hash-algorithms"></a>
-
-### HTTPS Management Advertise On Sli VIP TLS Certificates Custom Hash Algorithms
-
-<a id="https-management-advertise-on-sli-vip-tls-certificates-disable-ocsp-stapling"></a>
-
-### HTTPS Management Advertise On Sli VIP TLS Certificates Disable OCSP Stapling
-
-<a id="https-management-advertise-on-sli-vip-tls-certificates-private-key"></a>
-
-### HTTPS Management Advertise On Sli VIP TLS Certificates Private Key
-
-<a id="https-management-advertise-on-sli-vip-tls-certificates-use-system-defaults"></a>
-
-### HTTPS Management Advertise On Sli VIP TLS Certificates Use System Defaults
+`use_system_defaults` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="https-management-advertise-on-sli-vip-tls-config"></a>
 
 ### HTTPS Management Advertise On Sli VIP TLS Config
 
-`custom_security` - (Optional) Custom Ciphers. This defines TLS protocol config including min/max versions and allowed ciphers. See [Custom Security](#https-management-advertise-on-sli-vip-tls-config-custom-security) below.
+`custom_security` - (Optional) Custom Ciphers. This defines TLS protocol config including min/max versions and allowed ciphers (`Block`).
 
-`default_security` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Security](#https-management-advertise-on-sli-vip-tls-config-default-security) below.
+`default_security` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`low_security` - (Optional) Empty. This can be used for messages where no values are needed. See [Low Security](#https-management-advertise-on-sli-vip-tls-config-low-security) below.
+`low_security` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`medium_security` - (Optional) Empty. This can be used for messages where no values are needed. See [Medium Security](#https-management-advertise-on-sli-vip-tls-config-medium-security) below.
-
-<a id="https-management-advertise-on-sli-vip-tls-config-custom-security"></a>
-
-### HTTPS Management Advertise On Sli VIP TLS Config Custom Security
-
-<a id="https-management-advertise-on-sli-vip-tls-config-default-security"></a>
-
-### HTTPS Management Advertise On Sli VIP TLS Config Default Security
-
-<a id="https-management-advertise-on-sli-vip-tls-config-low-security"></a>
-
-### HTTPS Management Advertise On Sli VIP TLS Config Low Security
-
-<a id="https-management-advertise-on-sli-vip-tls-config-medium-security"></a>
-
-### HTTPS Management Advertise On Sli VIP TLS Config Medium Security
+`medium_security` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="https-management-advertise-on-sli-vip-use-mtls"></a>
 
@@ -450,43 +330,23 @@ In addition to all arguments above, the following attributes are exported:
 
 `client_certificate_optional` - (Optional) Client Certificate Optional. Client certificate is optional. If the client has provided a certificate, the load balancer will verify it. If certification verification fails, the connection will be terminated. If the client does not provide a certificate, the connection will be accepted (`Bool`).
 
-`crl` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [CRL](#https-management-advertise-on-sli-vip-use-mtls-crl) below.
+`crl` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name (`Block`).
 
-`no_crl` - (Optional) Empty. This can be used for messages where no values are needed. See [No CRL](#https-management-advertise-on-sli-vip-use-mtls-no-crl) below.
+`no_crl` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`trusted_ca` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Trusted CA](#https-management-advertise-on-sli-vip-use-mtls-trusted-ca) below.
+`trusted_ca` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name (`Block`).
 
 `trusted_ca_url` - (Optional) Inline Root CA Certificate (legacy). Upload a Root CA Certificate specifically for this Load Balancer (`String`).
 
-`xfcc_disabled` - (Optional) Empty. This can be used for messages where no values are needed. See [Xfcc Disabled](#https-management-advertise-on-sli-vip-use-mtls-xfcc-disabled) below.
+`xfcc_disabled` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`xfcc_options` - (Optional) XFCC Header Elements. X-Forwarded-Client-Cert header elements to be added to requests. See [Xfcc Options](#https-management-advertise-on-sli-vip-use-mtls-xfcc-options) below.
-
-<a id="https-management-advertise-on-sli-vip-use-mtls-crl"></a>
-
-### HTTPS Management Advertise On Sli VIP Use mTLS CRL
-
-<a id="https-management-advertise-on-sli-vip-use-mtls-no-crl"></a>
-
-### HTTPS Management Advertise On Sli VIP Use mTLS No CRL
-
-<a id="https-management-advertise-on-sli-vip-use-mtls-trusted-ca"></a>
-
-### HTTPS Management Advertise On Sli VIP Use mTLS Trusted CA
-
-<a id="https-management-advertise-on-sli-vip-use-mtls-xfcc-disabled"></a>
-
-### HTTPS Management Advertise On Sli VIP Use mTLS Xfcc Disabled
-
-<a id="https-management-advertise-on-sli-vip-use-mtls-xfcc-options"></a>
-
-### HTTPS Management Advertise On Sli VIP Use mTLS Xfcc Options
+`xfcc_options` - (Optional) XFCC Header Elements. X-Forwarded-Client-Cert header elements to be added to requests (`Block`).
 
 <a id="https-management-advertise-on-slo-internet-vip"></a>
 
 ### HTTPS Management Advertise On Slo Internet VIP
 
-`no_mtls` - (Optional) Empty. This can be used for messages where no values are needed. See [No mTLS](#https-management-advertise-on-slo-internet-vip-no-mtls) below.
+`no_mtls` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `tls_certificates` - (Optional) TLS Certificates. Users can add one or more certificates that share the same set of domains. for example, domain.com and *.domain.com - but use different signature algorithms. See [TLS Certificates](#https-management-advertise-on-slo-internet-vip-tls-certificates) below.
 
@@ -494,69 +354,33 @@ In addition to all arguments above, the following attributes are exported:
 
 `use_mtls` - (Optional) Clients TLS validation context. Validation context for downstream client TLS connections. See [Use mTLS](#https-management-advertise-on-slo-internet-vip-use-mtls) below.
 
-<a id="https-management-advertise-on-slo-internet-vip-no-mtls"></a>
-
-### HTTPS Management Advertise On Slo Internet VIP No mTLS
-
 <a id="https-management-advertise-on-slo-internet-vip-tls-certificates"></a>
 
 ### HTTPS Management Advertise On Slo Internet VIP TLS Certificates
 
 `certificate_url` - (Optional) Certificate. TLS certificate. Certificate or certificate chain in PEM format including the PEM headers (`String`).
 
-`custom_hash_algorithms` - (Optional) Hash Algorithms. Specifies the hash algorithms to be used. See [Custom Hash Algorithms](#https-management-advertise-on-slo-internet-vip-tls-certificates-custom-hash-algorithms) below.
+`custom_hash_algorithms` - (Optional) Hash Algorithms. Specifies the hash algorithms to be used (`Block`).
 
 `description` - (Optional) Configuration for description (`String`).
 
-`disable_ocsp_stapling` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable OCSP Stapling](#https-management-advertise-on-slo-internet-vip-tls-certificates-disable-ocsp-stapling) below.
+`disable_ocsp_stapling` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`private_key` - (Optional) Secret. SecretType is used in an object to indicate a sensitive/confidential field. See [Private Key](#https-management-advertise-on-slo-internet-vip-tls-certificates-private-key) below.
+`private_key` - (Optional) Secret. SecretType is used in an object to indicate a sensitive/confidential field (`Block`).
 
-`use_system_defaults` - (Optional) Empty. This can be used for messages where no values are needed. See [Use System Defaults](#https-management-advertise-on-slo-internet-vip-tls-certificates-use-system-defaults) below.
-
-<a id="https-management-advertise-on-slo-internet-vip-tls-certificates-custom-hash-algorithms"></a>
-
-### HTTPS Management Advertise On Slo Internet VIP TLS Certificates Custom Hash Algorithms
-
-<a id="https-management-advertise-on-slo-internet-vip-tls-certificates-disable-ocsp-stapling"></a>
-
-### HTTPS Management Advertise On Slo Internet VIP TLS Certificates Disable OCSP Stapling
-
-<a id="https-management-advertise-on-slo-internet-vip-tls-certificates-private-key"></a>
-
-### HTTPS Management Advertise On Slo Internet VIP TLS Certificates Private Key
-
-<a id="https-management-advertise-on-slo-internet-vip-tls-certificates-use-system-defaults"></a>
-
-### HTTPS Management Advertise On Slo Internet VIP TLS Certificates Use System Defaults
+`use_system_defaults` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="https-management-advertise-on-slo-internet-vip-tls-config"></a>
 
 ### HTTPS Management Advertise On Slo Internet VIP TLS Config
 
-`custom_security` - (Optional) Custom Ciphers. This defines TLS protocol config including min/max versions and allowed ciphers. See [Custom Security](#https-management-advertise-on-slo-internet-vip-tls-config-custom-security) below.
+`custom_security` - (Optional) Custom Ciphers. This defines TLS protocol config including min/max versions and allowed ciphers (`Block`).
 
-`default_security` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Security](#https-management-advertise-on-slo-internet-vip-tls-config-default-security) below.
+`default_security` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`low_security` - (Optional) Empty. This can be used for messages where no values are needed. See [Low Security](#https-management-advertise-on-slo-internet-vip-tls-config-low-security) below.
+`low_security` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`medium_security` - (Optional) Empty. This can be used for messages where no values are needed. See [Medium Security](#https-management-advertise-on-slo-internet-vip-tls-config-medium-security) below.
-
-<a id="https-management-advertise-on-slo-internet-vip-tls-config-custom-security"></a>
-
-### HTTPS Management Advertise On Slo Internet VIP TLS Config Custom Security
-
-<a id="https-management-advertise-on-slo-internet-vip-tls-config-default-security"></a>
-
-### HTTPS Management Advertise On Slo Internet VIP TLS Config Default Security
-
-<a id="https-management-advertise-on-slo-internet-vip-tls-config-low-security"></a>
-
-### HTTPS Management Advertise On Slo Internet VIP TLS Config Low Security
-
-<a id="https-management-advertise-on-slo-internet-vip-tls-config-medium-security"></a>
-
-### HTTPS Management Advertise On Slo Internet VIP TLS Config Medium Security
+`medium_security` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="https-management-advertise-on-slo-internet-vip-use-mtls"></a>
 
@@ -564,43 +388,23 @@ In addition to all arguments above, the following attributes are exported:
 
 `client_certificate_optional` - (Optional) Client Certificate Optional. Client certificate is optional. If the client has provided a certificate, the load balancer will verify it. If certification verification fails, the connection will be terminated. If the client does not provide a certificate, the connection will be accepted (`Bool`).
 
-`crl` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [CRL](#https-management-advertise-on-slo-internet-vip-use-mtls-crl) below.
+`crl` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name (`Block`).
 
-`no_crl` - (Optional) Empty. This can be used for messages where no values are needed. See [No CRL](#https-management-advertise-on-slo-internet-vip-use-mtls-no-crl) below.
+`no_crl` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`trusted_ca` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Trusted CA](#https-management-advertise-on-slo-internet-vip-use-mtls-trusted-ca) below.
+`trusted_ca` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name (`Block`).
 
 `trusted_ca_url` - (Optional) Inline Root CA Certificate (legacy). Upload a Root CA Certificate specifically for this Load Balancer (`String`).
 
-`xfcc_disabled` - (Optional) Empty. This can be used for messages where no values are needed. See [Xfcc Disabled](#https-management-advertise-on-slo-internet-vip-use-mtls-xfcc-disabled) below.
+`xfcc_disabled` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`xfcc_options` - (Optional) XFCC Header Elements. X-Forwarded-Client-Cert header elements to be added to requests. See [Xfcc Options](#https-management-advertise-on-slo-internet-vip-use-mtls-xfcc-options) below.
-
-<a id="https-management-advertise-on-slo-internet-vip-use-mtls-crl"></a>
-
-### HTTPS Management Advertise On Slo Internet VIP Use mTLS CRL
-
-<a id="https-management-advertise-on-slo-internet-vip-use-mtls-no-crl"></a>
-
-### HTTPS Management Advertise On Slo Internet VIP Use mTLS No CRL
-
-<a id="https-management-advertise-on-slo-internet-vip-use-mtls-trusted-ca"></a>
-
-### HTTPS Management Advertise On Slo Internet VIP Use mTLS Trusted CA
-
-<a id="https-management-advertise-on-slo-internet-vip-use-mtls-xfcc-disabled"></a>
-
-### HTTPS Management Advertise On Slo Internet VIP Use mTLS Xfcc Disabled
-
-<a id="https-management-advertise-on-slo-internet-vip-use-mtls-xfcc-options"></a>
-
-### HTTPS Management Advertise On Slo Internet VIP Use mTLS Xfcc Options
+`xfcc_options` - (Optional) XFCC Header Elements. X-Forwarded-Client-Cert header elements to be added to requests (`Block`).
 
 <a id="https-management-advertise-on-slo-sli"></a>
 
 ### HTTPS Management Advertise On Slo Sli
 
-`no_mtls` - (Optional) Empty. This can be used for messages where no values are needed. See [No mTLS](#https-management-advertise-on-slo-sli-no-mtls) below.
+`no_mtls` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `tls_certificates` - (Optional) TLS Certificates. Users can add one or more certificates that share the same set of domains. for example, domain.com and *.domain.com - but use different signature algorithms. See [TLS Certificates](#https-management-advertise-on-slo-sli-tls-certificates) below.
 
@@ -608,69 +412,33 @@ In addition to all arguments above, the following attributes are exported:
 
 `use_mtls` - (Optional) Clients TLS validation context. Validation context for downstream client TLS connections. See [Use mTLS](#https-management-advertise-on-slo-sli-use-mtls) below.
 
-<a id="https-management-advertise-on-slo-sli-no-mtls"></a>
-
-### HTTPS Management Advertise On Slo Sli No mTLS
-
 <a id="https-management-advertise-on-slo-sli-tls-certificates"></a>
 
 ### HTTPS Management Advertise On Slo Sli TLS Certificates
 
 `certificate_url` - (Optional) Certificate. TLS certificate. Certificate or certificate chain in PEM format including the PEM headers (`String`).
 
-`custom_hash_algorithms` - (Optional) Hash Algorithms. Specifies the hash algorithms to be used. See [Custom Hash Algorithms](#https-management-advertise-on-slo-sli-tls-certificates-custom-hash-algorithms) below.
+`custom_hash_algorithms` - (Optional) Hash Algorithms. Specifies the hash algorithms to be used (`Block`).
 
 `description` - (Optional) Configuration for description (`String`).
 
-`disable_ocsp_stapling` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable OCSP Stapling](#https-management-advertise-on-slo-sli-tls-certificates-disable-ocsp-stapling) below.
+`disable_ocsp_stapling` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`private_key` - (Optional) Secret. SecretType is used in an object to indicate a sensitive/confidential field. See [Private Key](#https-management-advertise-on-slo-sli-tls-certificates-private-key) below.
+`private_key` - (Optional) Secret. SecretType is used in an object to indicate a sensitive/confidential field (`Block`).
 
-`use_system_defaults` - (Optional) Empty. This can be used for messages where no values are needed. See [Use System Defaults](#https-management-advertise-on-slo-sli-tls-certificates-use-system-defaults) below.
-
-<a id="https-management-advertise-on-slo-sli-tls-certificates-custom-hash-algorithms"></a>
-
-### HTTPS Management Advertise On Slo Sli TLS Certificates Custom Hash Algorithms
-
-<a id="https-management-advertise-on-slo-sli-tls-certificates-disable-ocsp-stapling"></a>
-
-### HTTPS Management Advertise On Slo Sli TLS Certificates Disable OCSP Stapling
-
-<a id="https-management-advertise-on-slo-sli-tls-certificates-private-key"></a>
-
-### HTTPS Management Advertise On Slo Sli TLS Certificates Private Key
-
-<a id="https-management-advertise-on-slo-sli-tls-certificates-use-system-defaults"></a>
-
-### HTTPS Management Advertise On Slo Sli TLS Certificates Use System Defaults
+`use_system_defaults` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="https-management-advertise-on-slo-sli-tls-config"></a>
 
 ### HTTPS Management Advertise On Slo Sli TLS Config
 
-`custom_security` - (Optional) Custom Ciphers. This defines TLS protocol config including min/max versions and allowed ciphers. See [Custom Security](#https-management-advertise-on-slo-sli-tls-config-custom-security) below.
+`custom_security` - (Optional) Custom Ciphers. This defines TLS protocol config including min/max versions and allowed ciphers (`Block`).
 
-`default_security` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Security](#https-management-advertise-on-slo-sli-tls-config-default-security) below.
+`default_security` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`low_security` - (Optional) Empty. This can be used for messages where no values are needed. See [Low Security](#https-management-advertise-on-slo-sli-tls-config-low-security) below.
+`low_security` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`medium_security` - (Optional) Empty. This can be used for messages where no values are needed. See [Medium Security](#https-management-advertise-on-slo-sli-tls-config-medium-security) below.
-
-<a id="https-management-advertise-on-slo-sli-tls-config-custom-security"></a>
-
-### HTTPS Management Advertise On Slo Sli TLS Config Custom Security
-
-<a id="https-management-advertise-on-slo-sli-tls-config-default-security"></a>
-
-### HTTPS Management Advertise On Slo Sli TLS Config Default Security
-
-<a id="https-management-advertise-on-slo-sli-tls-config-low-security"></a>
-
-### HTTPS Management Advertise On Slo Sli TLS Config Low Security
-
-<a id="https-management-advertise-on-slo-sli-tls-config-medium-security"></a>
-
-### HTTPS Management Advertise On Slo Sli TLS Config Medium Security
+`medium_security` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="https-management-advertise-on-slo-sli-use-mtls"></a>
 
@@ -678,43 +446,23 @@ In addition to all arguments above, the following attributes are exported:
 
 `client_certificate_optional` - (Optional) Client Certificate Optional. Client certificate is optional. If the client has provided a certificate, the load balancer will verify it. If certification verification fails, the connection will be terminated. If the client does not provide a certificate, the connection will be accepted (`Bool`).
 
-`crl` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [CRL](#https-management-advertise-on-slo-sli-use-mtls-crl) below.
+`crl` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name (`Block`).
 
-`no_crl` - (Optional) Empty. This can be used for messages where no values are needed. See [No CRL](#https-management-advertise-on-slo-sli-use-mtls-no-crl) below.
+`no_crl` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`trusted_ca` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Trusted CA](#https-management-advertise-on-slo-sli-use-mtls-trusted-ca) below.
+`trusted_ca` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name (`Block`).
 
 `trusted_ca_url` - (Optional) Inline Root CA Certificate (legacy). Upload a Root CA Certificate specifically for this Load Balancer (`String`).
 
-`xfcc_disabled` - (Optional) Empty. This can be used for messages where no values are needed. See [Xfcc Disabled](#https-management-advertise-on-slo-sli-use-mtls-xfcc-disabled) below.
+`xfcc_disabled` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`xfcc_options` - (Optional) XFCC Header Elements. X-Forwarded-Client-Cert header elements to be added to requests. See [Xfcc Options](#https-management-advertise-on-slo-sli-use-mtls-xfcc-options) below.
-
-<a id="https-management-advertise-on-slo-sli-use-mtls-crl"></a>
-
-### HTTPS Management Advertise On Slo Sli Use mTLS CRL
-
-<a id="https-management-advertise-on-slo-sli-use-mtls-no-crl"></a>
-
-### HTTPS Management Advertise On Slo Sli Use mTLS No CRL
-
-<a id="https-management-advertise-on-slo-sli-use-mtls-trusted-ca"></a>
-
-### HTTPS Management Advertise On Slo Sli Use mTLS Trusted CA
-
-<a id="https-management-advertise-on-slo-sli-use-mtls-xfcc-disabled"></a>
-
-### HTTPS Management Advertise On Slo Sli Use mTLS Xfcc Disabled
-
-<a id="https-management-advertise-on-slo-sli-use-mtls-xfcc-options"></a>
-
-### HTTPS Management Advertise On Slo Sli Use mTLS Xfcc Options
+`xfcc_options` - (Optional) XFCC Header Elements. X-Forwarded-Client-Cert header elements to be added to requests (`Block`).
 
 <a id="https-management-advertise-on-slo-vip"></a>
 
 ### HTTPS Management Advertise On Slo VIP
 
-`no_mtls` - (Optional) Empty. This can be used for messages where no values are needed. See [No mTLS](#https-management-advertise-on-slo-vip-no-mtls) below.
+`no_mtls` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `tls_certificates` - (Optional) TLS Certificates. Users can add one or more certificates that share the same set of domains. for example, domain.com and *.domain.com - but use different signature algorithms. See [TLS Certificates](#https-management-advertise-on-slo-vip-tls-certificates) below.
 
@@ -722,69 +470,33 @@ In addition to all arguments above, the following attributes are exported:
 
 `use_mtls` - (Optional) Clients TLS validation context. Validation context for downstream client TLS connections. See [Use mTLS](#https-management-advertise-on-slo-vip-use-mtls) below.
 
-<a id="https-management-advertise-on-slo-vip-no-mtls"></a>
-
-### HTTPS Management Advertise On Slo VIP No mTLS
-
 <a id="https-management-advertise-on-slo-vip-tls-certificates"></a>
 
 ### HTTPS Management Advertise On Slo VIP TLS Certificates
 
 `certificate_url` - (Optional) Certificate. TLS certificate. Certificate or certificate chain in PEM format including the PEM headers (`String`).
 
-`custom_hash_algorithms` - (Optional) Hash Algorithms. Specifies the hash algorithms to be used. See [Custom Hash Algorithms](#https-management-advertise-on-slo-vip-tls-certificates-custom-hash-algorithms) below.
+`custom_hash_algorithms` - (Optional) Hash Algorithms. Specifies the hash algorithms to be used (`Block`).
 
 `description` - (Optional) Configuration for description (`String`).
 
-`disable_ocsp_stapling` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable OCSP Stapling](#https-management-advertise-on-slo-vip-tls-certificates-disable-ocsp-stapling) below.
+`disable_ocsp_stapling` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`private_key` - (Optional) Secret. SecretType is used in an object to indicate a sensitive/confidential field. See [Private Key](#https-management-advertise-on-slo-vip-tls-certificates-private-key) below.
+`private_key` - (Optional) Secret. SecretType is used in an object to indicate a sensitive/confidential field (`Block`).
 
-`use_system_defaults` - (Optional) Empty. This can be used for messages where no values are needed. See [Use System Defaults](#https-management-advertise-on-slo-vip-tls-certificates-use-system-defaults) below.
-
-<a id="https-management-advertise-on-slo-vip-tls-certificates-custom-hash-algorithms"></a>
-
-### HTTPS Management Advertise On Slo VIP TLS Certificates Custom Hash Algorithms
-
-<a id="https-management-advertise-on-slo-vip-tls-certificates-disable-ocsp-stapling"></a>
-
-### HTTPS Management Advertise On Slo VIP TLS Certificates Disable OCSP Stapling
-
-<a id="https-management-advertise-on-slo-vip-tls-certificates-private-key"></a>
-
-### HTTPS Management Advertise On Slo VIP TLS Certificates Private Key
-
-<a id="https-management-advertise-on-slo-vip-tls-certificates-use-system-defaults"></a>
-
-### HTTPS Management Advertise On Slo VIP TLS Certificates Use System Defaults
+`use_system_defaults` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="https-management-advertise-on-slo-vip-tls-config"></a>
 
 ### HTTPS Management Advertise On Slo VIP TLS Config
 
-`custom_security` - (Optional) Custom Ciphers. This defines TLS protocol config including min/max versions and allowed ciphers. See [Custom Security](#https-management-advertise-on-slo-vip-tls-config-custom-security) below.
+`custom_security` - (Optional) Custom Ciphers. This defines TLS protocol config including min/max versions and allowed ciphers (`Block`).
 
-`default_security` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Security](#https-management-advertise-on-slo-vip-tls-config-default-security) below.
+`default_security` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`low_security` - (Optional) Empty. This can be used for messages where no values are needed. See [Low Security](#https-management-advertise-on-slo-vip-tls-config-low-security) below.
+`low_security` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`medium_security` - (Optional) Empty. This can be used for messages where no values are needed. See [Medium Security](#https-management-advertise-on-slo-vip-tls-config-medium-security) below.
-
-<a id="https-management-advertise-on-slo-vip-tls-config-custom-security"></a>
-
-### HTTPS Management Advertise On Slo VIP TLS Config Custom Security
-
-<a id="https-management-advertise-on-slo-vip-tls-config-default-security"></a>
-
-### HTTPS Management Advertise On Slo VIP TLS Config Default Security
-
-<a id="https-management-advertise-on-slo-vip-tls-config-low-security"></a>
-
-### HTTPS Management Advertise On Slo VIP TLS Config Low Security
-
-<a id="https-management-advertise-on-slo-vip-tls-config-medium-security"></a>
-
-### HTTPS Management Advertise On Slo VIP TLS Config Medium Security
+`medium_security` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="https-management-advertise-on-slo-vip-use-mtls"></a>
 
@@ -792,41 +504,17 @@ In addition to all arguments above, the following attributes are exported:
 
 `client_certificate_optional` - (Optional) Client Certificate Optional. Client certificate is optional. If the client has provided a certificate, the load balancer will verify it. If certification verification fails, the connection will be terminated. If the client does not provide a certificate, the connection will be accepted (`Bool`).
 
-`crl` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [CRL](#https-management-advertise-on-slo-vip-use-mtls-crl) below.
+`crl` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name (`Block`).
 
-`no_crl` - (Optional) Empty. This can be used for messages where no values are needed. See [No CRL](#https-management-advertise-on-slo-vip-use-mtls-no-crl) below.
+`no_crl` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`trusted_ca` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Trusted CA](#https-management-advertise-on-slo-vip-use-mtls-trusted-ca) below.
+`trusted_ca` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name (`Block`).
 
 `trusted_ca_url` - (Optional) Inline Root CA Certificate (legacy). Upload a Root CA Certificate specifically for this Load Balancer (`String`).
 
-`xfcc_disabled` - (Optional) Empty. This can be used for messages where no values are needed. See [Xfcc Disabled](#https-management-advertise-on-slo-vip-use-mtls-xfcc-disabled) below.
+`xfcc_disabled` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`xfcc_options` - (Optional) XFCC Header Elements. X-Forwarded-Client-Cert header elements to be added to requests. See [Xfcc Options](#https-management-advertise-on-slo-vip-use-mtls-xfcc-options) below.
-
-<a id="https-management-advertise-on-slo-vip-use-mtls-crl"></a>
-
-### HTTPS Management Advertise On Slo VIP Use mTLS CRL
-
-<a id="https-management-advertise-on-slo-vip-use-mtls-no-crl"></a>
-
-### HTTPS Management Advertise On Slo VIP Use mTLS No CRL
-
-<a id="https-management-advertise-on-slo-vip-use-mtls-trusted-ca"></a>
-
-### HTTPS Management Advertise On Slo VIP Use mTLS Trusted CA
-
-<a id="https-management-advertise-on-slo-vip-use-mtls-xfcc-disabled"></a>
-
-### HTTPS Management Advertise On Slo VIP Use mTLS Xfcc Disabled
-
-<a id="https-management-advertise-on-slo-vip-use-mtls-xfcc-options"></a>
-
-### HTTPS Management Advertise On Slo VIP Use mTLS Xfcc Options
-
-<a id="https-management-default-https-port"></a>
-
-### HTTPS Management Default HTTPS Port
+`xfcc_options` - (Optional) XFCC Header Elements. X-Forwarded-Client-Cert header elements to be added to requests (`Block`).
 
 <a id="palo-alto-fw-service"></a>
 
@@ -836,13 +524,13 @@ In addition to all arguments above, the following attributes are exported:
 
 `aws_tgw_site` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [AWS Tgw Site](#palo-alto-fw-service-aws-tgw-site) below.
 
-`disable_panaroma` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Panaroma](#palo-alto-fw-service-disable-panaroma) below.
+`disable_panaroma` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `instance_type` - (Optional) Palo Alto Networks VM-Series Instance Typ. - PALO_ALTO_FW_AWS_INSTANCE_TYPE_M4_XLARGE: m4.xlarge - PALO_ALTO_FW_AWS_INSTANCE_TYPE_M4_2XLARGE: m4.2xlarge - PALO_ALTO_FW_AWS_INSTANCE_TYPE_M4_4XLARGE: m4.4xlarge - PALO_ALTO_FW_AWS_INSTANCE_TYPE_M5_LARGE: m5.large - PALO_ALTO_FW_AWS_INSTANCE_TYPE_M5_XLARGE: m5.xlarge - PALO_ALTO_FW_AWS_INSTANCE_TYPE_M5_2XLARGE: m5.2xlarge - PALO_ALTO_FW_AWS_INSTANCE_TYPE_M5_4XLARGE: m5.4xlarge - PALO_ALTO_FW_AWS_INSTANCE_TYPE_M5_12XLARGE: m5.12xlarge - PALO_ALTO_... Possible values include `PALO_ALTO_FW_AWS_INSTANCE_TYPE_M4_XLARGE`, `PALO_ALTO_FW_AWS_INSTANCE_TYPE_M4_2XLARGE`, `PALO_ALTO_FW_AWS_INSTANCE_TYPE_M4_4XLARGE`, `PALO_ALTO_FW_AWS_INSTANCE_TYPE_M5_LARGE`, `PALO_ALTO_FW_AWS_INSTANCE_TYPE_M5_XLARGE`, `PALO_ALTO_FW_AWS_INSTANCE_TYPE_M5_2XLARGE`, `PALO_ALTO_FW_AWS_INSTANCE_TYPE_M5_4XLARGE`, `PALO_ALTO_FW_AWS_INSTANCE_TYPE_M5_12XLARGE`, `PALO_ALTO_FW_AWS_INSTANCE_TYPE_M5N_LARGE`, `PALO_ALTO_FW_AWS_INSTANCE_TYPE_M5N_XLARGE`, and others. Defaults to `PALO_ALTO_FW_AWS_INSTANCE_TYPE_M4_XLARGE` (`String`).
 
-`pan_ami_bundle1` - (Optional) Empty. This can be used for messages where no values are needed. See [Pan Ami Bundle1](#palo-alto-fw-service-pan-ami-bundle1) below.
+`pan_ami_bundle1` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`pan_ami_bundle2` - (Optional) Empty. This can be used for messages where no values are needed. See [Pan Ami Bundle2](#palo-alto-fw-service-pan-ami-bundle2) below.
+`pan_ami_bundle2` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `panorama_server` - (Optional) Panorama Server Type. Panorama Server Type. See [Panorama Server](#palo-alto-fw-service-panorama-server) below.
 
@@ -850,7 +538,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `ssh_key` - (Optional) Setup Authorized Public SSH key. Setup Authorized Public SSH key. User will be able to SSH to the vmseries nodes using its corresponding SSH private key (`String`).
 
-`tags` - (Optional) AWS Tags. AWS Tags is a label consisting of a user-defined key and value. It helps to manage, identify, organize, search for, and filter resources in AWS console. See [Tags](#palo-alto-fw-service-tags) below.
+`tags` - (Optional) AWS Tags. AWS Tags is a label consisting of a user-defined key and value. It helps to manage, identify, organize, search for, and filter resources in AWS console (`Block`).
 
 `version` - (Optional) PAN VM-Series version. PAN-OS version (`String`).
 
@@ -868,29 +556,17 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Palo Alto Fw Service Auto Setup Admin Password
 
-`blindfold_secret_info` - (Optional) Blindfold Secret. BlindfoldSecretInfoType specifies information about the Secret managed by F5XC Secret Management. See [Blindfold Secret Info](#palo-alto-fw-service-auto-setup-admin-password-blindfold-secret-info) below.
+`blindfold_secret_info` - (Optional) Blindfold Secret. BlindfoldSecretInfoType specifies information about the Secret managed by F5XC Secret Management (`Block`).
 
-`clear_secret_info` - (Optional) In-Clear Secret. ClearSecretInfoType specifies information about the Secret that is not encrypted. See [Clear Secret Info](#palo-alto-fw-service-auto-setup-admin-password-clear-secret-info) below.
-
-<a id="palo-alto-fw-service-auto-setup-admin-password-blindfold-secret-info"></a>
-
-### Palo Alto Fw Service Auto Setup Admin Password Blindfold Secret Info
-
-<a id="palo-alto-fw-service-auto-setup-admin-password-clear-secret-info"></a>
-
-### Palo Alto Fw Service Auto Setup Admin Password Clear Secret Info
+`clear_secret_info` - (Optional) In-Clear Secret. ClearSecretInfoType specifies information about the Secret that is not encrypted (`Block`).
 
 <a id="palo-alto-fw-service-auto-setup-manual-ssh-keys"></a>
 
 ### Palo Alto Fw Service Auto Setup Manual SSH Keys
 
-`private_key` - (Optional) Secret. SecretType is used in an object to indicate a sensitive/confidential field. See [Private Key](#palo-alto-fw-service-auto-setup-manual-ssh-keys-private-key) below.
+`private_key` - (Optional) Secret. SecretType is used in an object to indicate a sensitive/confidential field (`Block`).
 
 `public_key` - (Optional) Public SSH key. Authorized Public SSH key which will be programmed on the node (`String`).
-
-<a id="palo-alto-fw-service-auto-setup-manual-ssh-keys-private-key"></a>
-
-### Palo Alto Fw Service Auto Setup Manual SSH Keys Private Key
 
 <a id="palo-alto-fw-service-aws-tgw-site"></a>
 
@@ -901,18 +577,6 @@ In addition to all arguments above, the following attributes are exported:
 `namespace` - (Optional) Namespace. When a configuration object(e.g. virtual_host) refers to another(e.g route) then namespace will hold the referred object's(e.g. route's) namespace (`String`).
 
 `tenant` - (Optional) Tenant. When a configuration object(e.g. virtual_host) refers to another(e.g route) then tenant will hold the referred object's(e.g. route's) tenant (`String`).
-
-<a id="palo-alto-fw-service-disable-panaroma"></a>
-
-### Palo Alto Fw Service Disable Panaroma
-
-<a id="palo-alto-fw-service-pan-ami-bundle1"></a>
-
-### Palo Alto Fw Service Pan Ami Bundle1
-
-<a id="palo-alto-fw-service-pan-ami-bundle2"></a>
-
-### Palo Alto Fw Service Pan Ami Bundle2
 
 <a id="palo-alto-fw-service-panorama-server"></a>
 
@@ -930,17 +594,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Palo Alto Fw Service Panorama Server Authorization Key
 
-`blindfold_secret_info` - (Optional) Blindfold Secret. BlindfoldSecretInfoType specifies information about the Secret managed by F5XC Secret Management. See [Blindfold Secret Info](#palo-alto-fw-service-panorama-server-authorization-key-blindfold-secret-info) below.
+`blindfold_secret_info` - (Optional) Blindfold Secret. BlindfoldSecretInfoType specifies information about the Secret managed by F5XC Secret Management (`Block`).
 
-`clear_secret_info` - (Optional) In-Clear Secret. ClearSecretInfoType specifies information about the Secret that is not encrypted. See [Clear Secret Info](#palo-alto-fw-service-panorama-server-authorization-key-clear-secret-info) below.
-
-<a id="palo-alto-fw-service-panorama-server-authorization-key-blindfold-secret-info"></a>
-
-### Palo Alto Fw Service Panorama Server Authorization Key Blindfold Secret Info
-
-<a id="palo-alto-fw-service-panorama-server-authorization-key-clear-secret-info"></a>
-
-### Palo Alto Fw Service Panorama Server Authorization Key Clear Secret Info
+`clear_secret_info` - (Optional) In-Clear Secret. ClearSecretInfoType specifies information about the Secret that is not encrypted (`Block`).
 
 <a id="palo-alto-fw-service-service-nodes"></a>
 
@@ -954,23 +610,11 @@ In addition to all arguments above, the following attributes are exported:
 
 `aws_az_name` - (Optional) AWS AZ Name. AWS availability zone, must be consistent with the selected AWS region. It is recommended that AZ is one of the AZ for sites (`String`).
 
-`mgmt_subnet` - (Optional) AWS Subnet. Parameters for AWS subnet. See [Mgmt Subnet](#palo-alto-fw-service-service-nodes-nodes-mgmt-subnet) below.
+`mgmt_subnet` - (Optional) AWS Subnet. Parameters for AWS subnet (`Block`).
 
 `node_name` - (Optional) Node Name. Node Name will be used to assign as hostname to the service (`String`).
 
-`reserved_mgmt_subnet` - (Optional) Empty. This can be used for messages where no values are needed. See [Reserved Mgmt Subnet](#palo-alto-fw-service-service-nodes-nodes-reserved-mgmt-subnet) below.
-
-<a id="palo-alto-fw-service-service-nodes-nodes-mgmt-subnet"></a>
-
-### Palo Alto Fw Service Service Nodes Nodes Mgmt Subnet
-
-<a id="palo-alto-fw-service-service-nodes-nodes-reserved-mgmt-subnet"></a>
-
-### Palo Alto Fw Service Service Nodes Nodes Reserved Mgmt Subnet
-
-<a id="palo-alto-fw-service-tags"></a>
-
-### Palo Alto Fw Service Tags
+`reserved_mgmt_subnet` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="timeouts"></a>
 

--- a/docs/resources/origin_pool.md
+++ b/docs/resources/origin_pool.md
@@ -74,9 +74,9 @@ resource "f5xc_origin_pool" "example" {
 
 > **Note:** One of the arguments from this list "automatic_port, lb_port, port" must be set.
 
-`automatic_port` - (Optional) Empty. This can be used for messages where no values are needed. See [Automatic Port](#automatic-port) below for details.
+`automatic_port` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`lb_port` - (Optional) Empty. This can be used for messages where no values are needed. See [LB Port](#lb-port) below for details.
+`lb_port` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `port` - (Optional) Port. Endpoint service is available on this port (`Number`).
 
@@ -86,7 +86,7 @@ resource "f5xc_origin_pool" "example" {
 
 `health_check_port` - (Optional) Health check port. Port used for performing health check (`Number`).
 
-`same_as_endpoint_port` - (Optional) Empty. This can be used for messages where no values are needed. See [Same As Endpoint Port](#same-as-endpoint-port) below for details.
+`same_as_endpoint_port` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `healthcheck` - (Optional) Health Check object. Reference to healthcheck configuration objects. See [Healthcheck](#healthcheck) below for details.
 
@@ -94,7 +94,7 @@ resource "f5xc_origin_pool" "example" {
 
 > **Note:** One of the arguments from this list "no_tls, use_tls" must be set.
 
-`no_tls` - (Optional) Empty. This can be used for messages where no values are needed. See [No TLS](#no-tls) below for details.
+`no_tls` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `use_tls` - (Optional) TLS Parameters for Origin Servers. Upstream TLS Parameters. See [Use TLS](#use-tls) below for details.
 
@@ -116,25 +116,25 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Advanced Options
 
-`auto_http_config` - (Optional) Empty. This can be used for messages where no values are needed. See [Auto HTTP Config](#advanced-options-auto-http-config) below.
+`auto_http_config` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `circuit_breaker` - (Optional) Circuit Breaker. CircuitBreaker provides a mechanism for watching failures in upstream connections or requests and if the failures reach a certain threshold, automatically fail subsequent requests which allows to apply back pressure on downstream quickly. See [Circuit Breaker](#advanced-options-circuit-breaker) below.
 
 `connection_timeout` - (Optional) Connection Timeout. The timeout for new network connections to endpoints in the cluster. This is specified in milliseconds. The default value is 2 seconds (`Number`).
 
-`default_circuit_breaker` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Circuit Breaker](#advanced-options-default-circuit-breaker) below.
+`default_circuit_breaker` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`disable_circuit_breaker` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Circuit Breaker](#advanced-options-disable-circuit-breaker) below.
+`disable_circuit_breaker` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`disable_lb_source_ip_persistance` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable LB Source IP Persistance](#advanced-options-disable-lb-source-ip-persistance) below.
+`disable_lb_source_ip_persistance` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`disable_outlier_detection` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Outlier Detection](#advanced-options-disable-outlier-detection) below.
+`disable_outlier_detection` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`disable_proxy_protocol` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Proxy Protocol](#advanced-options-disable-proxy-protocol) below.
+`disable_proxy_protocol` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`disable_subsets` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Subsets](#advanced-options-disable-subsets) below.
+`disable_subsets` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`enable_lb_source_ip_persistance` - (Optional) Empty. This can be used for messages where no values are needed. See [Enable LB Source IP Persistance](#advanced-options-enable-lb-source-ip-persistance) below.
+`enable_lb_source_ip_persistance` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `enable_subsets` - (Optional) Origin Pool Subset Options. Configure subset options for origin pool. See [Enable Subsets](#advanced-options-enable-subsets) below.
 
@@ -144,19 +144,15 @@ In addition to all arguments above, the following attributes are exported:
 
 `http_idle_timeout` - (Optional) HTTP Idle Timeout. The idle timeout for upstream connection pool connections. The idle timeout is defined as the period in which there are no active requests. When the idle timeout is reached the connection will be closed. Note that request based timeouts mean that HTTP/2 PINGs will not keep the connection alive. This is specified in milliseconds. The default value is 5 minutes (`Number`).
 
-`no_panic_threshold` - (Optional) Empty. This can be used for messages where no values are needed. See [No Panic Threshold](#advanced-options-no-panic-threshold) below.
+`no_panic_threshold` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `outlier_detection` - (Optional) Outlier Detection. Outlier detection and ejection is the process of dynamically determining whether some number of hosts in an upstream cluster are performing unlike the others and removing them from the healthy load balancing set. Outlier detection is a form of passive health checking. Algorithm 1. A endpoint is determined to be an outlier (based on configured number of consecutive_5xx or consecutive_gateway_failures) . 2. If no endpoints have been ejected, loadbalancer will eject the host i. See [Outlier Detection](#advanced-options-outlier-detection) below.
 
 `panic_threshold` - (Optional) Panic threshold. x-example:'25' Configure a threshold (percentage of unhealthy endpoints) below which all endpoints will be considered for load balancing ignoring its health status (`Number`).
 
-`proxy_protocol_v1` - (Optional) Empty. This can be used for messages where no values are needed. See [Proxy Protocol V1](#advanced-options-proxy-protocol-v1) below.
+`proxy_protocol_v1` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`proxy_protocol_v2` - (Optional) Empty. This can be used for messages where no values are needed. See [Proxy Protocol V2](#advanced-options-proxy-protocol-v2) below.
-
-<a id="advanced-options-auto-http-config"></a>
-
-### Advanced Options Auto HTTP Config
+`proxy_protocol_v2` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="advanced-options-circuit-breaker"></a>
 
@@ -172,69 +168,29 @@ In addition to all arguments above, the following attributes are exported:
 
 `retries` - (Optional) Retry Count. The maximum number of retries that can be outstanding to all hosts in a cluster at any given time. Remove endpoint out of load balancing decision, if retries for request exceed this count (`Number`).
 
-<a id="advanced-options-default-circuit-breaker"></a>
-
-### Advanced Options Default Circuit Breaker
-
-<a id="advanced-options-disable-circuit-breaker"></a>
-
-### Advanced Options Disable Circuit Breaker
-
-<a id="advanced-options-disable-lb-source-ip-persistance"></a>
-
-### Advanced Options Disable LB Source IP Persistance
-
-<a id="advanced-options-disable-outlier-detection"></a>
-
-### Advanced Options Disable Outlier Detection
-
-<a id="advanced-options-disable-proxy-protocol"></a>
-
-### Advanced Options Disable Proxy Protocol
-
-<a id="advanced-options-disable-subsets"></a>
-
-### Advanced Options Disable Subsets
-
-<a id="advanced-options-enable-lb-source-ip-persistance"></a>
-
-### Advanced Options Enable LB Source IP Persistance
-
 <a id="advanced-options-enable-subsets"></a>
 
 ### Advanced Options Enable Subsets
 
-`any_endpoint` - (Optional) Empty. This can be used for messages where no values are needed. See [Any Endpoint](#advanced-options-enable-subsets-any-endpoint) below.
+`any_endpoint` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `default_subset` - (Optional) Origin Pool Default Subset. Default Subset definition. See [Default Subset](#advanced-options-enable-subsets-default-subset) below.
 
 `endpoint_subsets` - (Optional) Origin Server Subsets Classes. List of subset class. Subsets class is defined using list of keys. Every unique combination of values of these keys form a subset withing the class. See [Endpoint Subsets](#advanced-options-enable-subsets-endpoint-subsets) below.
 
-`fail_request` - (Optional) Empty. This can be used for messages where no values are needed. See [Fail Request](#advanced-options-enable-subsets-fail-request) below.
-
-<a id="advanced-options-enable-subsets-any-endpoint"></a>
-
-### Advanced Options Enable Subsets Any Endpoint
+`fail_request` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="advanced-options-enable-subsets-default-subset"></a>
 
 ### Advanced Options Enable Subsets Default Subset
 
-`default_subset` - (Optional) Default Subset for Origin Pool. List of key-value pairs that define default subset. which gets used when route specifies no metadata or no subset matching the metadata exists. See [Default Subset](#advanced-options-enable-subsets-default-subset-default-subset) below.
-
-<a id="advanced-options-enable-subsets-default-subset-default-subset"></a>
-
-### Advanced Options Enable Subsets Default Subset Default Subset
+`default_subset` - (Optional) Default Subset for Origin Pool. List of key-value pairs that define default subset. which gets used when route specifies no metadata or no subset matching the metadata exists (`Block`).
 
 <a id="advanced-options-enable-subsets-endpoint-subsets"></a>
 
 ### Advanced Options Enable Subsets Endpoint Subsets
 
 `keys` - (Optional) Keys. List of keys that define a cluster subset class (`List`).
-
-<a id="advanced-options-enable-subsets-fail-request"></a>
-
-### Advanced Options Enable Subsets Fail Request
 
 <a id="advanced-options-http1-config"></a>
 
@@ -246,39 +202,19 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Advanced Options Http1 Config Header Transformation
 
-`default_header_transformation` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Header Transformation](#advanced-options-http1-config-header-transformation-default-header-transformation) below.
+`default_header_transformation` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`legacy_header_transformation` - (Optional) Empty. This can be used for messages where no values are needed. See [Legacy Header Transformation](#advanced-options-http1-config-header-transformation-legacy-header-transformation) below.
+`legacy_header_transformation` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`preserve_case_header_transformation` - (Optional) Empty. This can be used for messages where no values are needed. See [Preserve Case Header Transformation](#advanced-options-http1-config-header-transformation-preserve-case-header-transformation) below.
+`preserve_case_header_transformation` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`proper_case_header_transformation` - (Optional) Empty. This can be used for messages where no values are needed. See [Proper Case Header Transformation](#advanced-options-http1-config-header-transformation-proper-case-header-transformation) below.
-
-<a id="advanced-options-http1-config-header-transformation-default-header-transformation"></a>
-
-### Advanced Options Http1 Config Header Transformation Default Header Transformation
-
-<a id="advanced-options-http1-config-header-transformation-legacy-header-transformation"></a>
-
-### Advanced Options Http1 Config Header Transformation Legacy Header Transformation
-
-<a id="advanced-options-http1-config-header-transformation-preserve-case-header-transformation"></a>
-
-### Advanced Options Http1 Config Header Transformation Preserve Case Header Transformation
-
-<a id="advanced-options-http1-config-header-transformation-proper-case-header-transformation"></a>
-
-### Advanced Options Http1 Config Header Transformation Proper Case Header Transformation
+`proper_case_header_transformation` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="advanced-options-http2-options"></a>
 
 ### Advanced Options Http2 Options
 
 `enabled` - (Optional) HTTP2 Enabled. Enable/disable HTTP2 Protocol for upstream connections (`Bool`).
-
-<a id="advanced-options-no-panic-threshold"></a>
-
-### Advanced Options No Panic Threshold
 
 <a id="advanced-options-outlier-detection"></a>
 
@@ -294,18 +230,6 @@ In addition to all arguments above, the following attributes are exported:
 
 `max_ejection_percent` - (Optional) Max Ejection Percentage. The maximum % of an upstream cluster that can be ejected due to outlier detection. Defaults to 10% but will eject at least one host regardless of the value (`Number`).
 
-<a id="advanced-options-proxy-protocol-v1"></a>
-
-### Advanced Options Proxy Protocol V1
-
-<a id="advanced-options-proxy-protocol-v2"></a>
-
-### Advanced Options Proxy Protocol V2
-
-<a id="automatic-port"></a>
-
-### Automatic Port
-
 <a id="healthcheck"></a>
 
 ### Healthcheck
@@ -315,14 +239,6 @@ In addition to all arguments above, the following attributes are exported:
 `namespace` - (Optional) Namespace. When a configuration object(e.g. virtual_host) refers to another(e.g route) then namespace will hold the referred object's(e.g. route's) namespace (`String`).
 
 `tenant` - (Optional) Tenant. When a configuration object(e.g. virtual_host) refers to another(e.g route) then tenant will hold the referred object's(e.g. route's) tenant (`String`).
-
-<a id="lb-port"></a>
-
-### LB Port
-
-<a id="no-tls"></a>
-
-### No TLS
 
 <a id="origin-servers"></a>
 
@@ -336,7 +252,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `k8s_service` - (Optional) K8s Service Name on given Sites. Specify origin server with K8s service name and site information. See [K8s Service](#origin-servers-k8s-service) below.
 
-`labels` - (Optional) Origin Server Labels. Add Labels for this origin server, these labels can be used to form subset. See [Labels](#origin-servers-labels) below.
+`labels` - (Optional) Origin Server Labels. Add Labels for this origin server, these labels can be used to form subset (`Block`).
 
 `private_ip` - (Optional) IP address on given Sites. Specify origin server with private or public IP address and site information. See [Private IP](#origin-servers-private-ip) below.
 
@@ -360,9 +276,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Origin Servers Consul Service
 
-`inside_network` - (Optional) Empty. This can be used for messages where no values are needed. See [Inside Network](#origin-servers-consul-service-inside-network) below.
+`inside_network` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`outside_network` - (Optional) Empty. This can be used for messages where no values are needed. See [Outside Network](#origin-servers-consul-service-outside-network) below.
+`outside_network` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `service_name` - (Optional) Service Name. Consul service name of this origin server will be listed, including cluster-id. The format is servicename:cluster-id (`String`).
 
@@ -370,45 +286,21 @@ In addition to all arguments above, the following attributes are exported:
 
 `snat_pool` - (Optional) Snat Pool. Snat Pool configuration. See [Snat Pool](#origin-servers-consul-service-snat-pool) below.
 
-<a id="origin-servers-consul-service-inside-network"></a>
-
-### Origin Servers Consul Service Inside Network
-
-<a id="origin-servers-consul-service-outside-network"></a>
-
-### Origin Servers Consul Service Outside Network
-
 <a id="origin-servers-consul-service-site-locator"></a>
 
 ### Origin Servers Consul Service Site Locator
 
-`site` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Site](#origin-servers-consul-service-site-locator-site) below.
+`site` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name (`Block`).
 
-`virtual_site` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Virtual Site](#origin-servers-consul-service-site-locator-virtual-site) below.
-
-<a id="origin-servers-consul-service-site-locator-site"></a>
-
-### Origin Servers Consul Service Site Locator Site
-
-<a id="origin-servers-consul-service-site-locator-virtual-site"></a>
-
-### Origin Servers Consul Service Site Locator Virtual Site
+`virtual_site` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name (`Block`).
 
 <a id="origin-servers-consul-service-snat-pool"></a>
 
 ### Origin Servers Consul Service Snat Pool
 
-`no_snat_pool` - (Optional) Empty. This can be used for messages where no values are needed. See [No Snat Pool](#origin-servers-consul-service-snat-pool-no-snat-pool) below.
+`no_snat_pool` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`snat_pool` - (Optional) IPv4 Prefix List. x-example: '192.168.20.0/24' List of IPv4 prefixes that represent an endpoint. See [Snat Pool](#origin-servers-consul-service-snat-pool-snat-pool) below.
-
-<a id="origin-servers-consul-service-snat-pool-no-snat-pool"></a>
-
-### Origin Servers Consul Service Snat Pool No Snat Pool
-
-<a id="origin-servers-consul-service-snat-pool-snat-pool"></a>
-
-### Origin Servers Consul Service Snat Pool Snat Pool
+`snat_pool` - (Optional) IPv4 Prefix List. x-example: '192.168.20.0/24' List of IPv4 prefixes that represent an endpoint (`Block`).
 
 <a id="origin-servers-custom-endpoint-object"></a>
 
@@ -430,9 +322,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Origin Servers K8s Service
 
-`inside_network` - (Optional) Empty. This can be used for messages where no values are needed. See [Inside Network](#origin-servers-k8s-service-inside-network) below.
+`inside_network` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`outside_network` - (Optional) Empty. This can be used for messages where no values are needed. See [Outside Network](#origin-servers-k8s-service-outside-network) below.
+`outside_network` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `protocol` - (Optional) Protocol Type. Type of protocol - PROTOCOL_TCP: TCP - PROTOCOL_UDP: UDP. Possible values are `PROTOCOL_TCP`, `PROTOCOL_UDP`. Defaults to `PROTOCOL_TCP` (`String`).
 
@@ -442,79 +334,39 @@ In addition to all arguments above, the following attributes are exported:
 
 `snat_pool` - (Optional) Snat Pool. Snat Pool configuration. See [Snat Pool](#origin-servers-k8s-service-snat-pool) below.
 
-`vk8s_networks` - (Optional) Empty. This can be used for messages where no values are needed. See [Vk8s Networks](#origin-servers-k8s-service-vk8s-networks) below.
-
-<a id="origin-servers-k8s-service-inside-network"></a>
-
-### Origin Servers K8s Service Inside Network
-
-<a id="origin-servers-k8s-service-outside-network"></a>
-
-### Origin Servers K8s Service Outside Network
+`vk8s_networks` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="origin-servers-k8s-service-site-locator"></a>
 
 ### Origin Servers K8s Service Site Locator
 
-`site` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Site](#origin-servers-k8s-service-site-locator-site) below.
+`site` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name (`Block`).
 
-`virtual_site` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Virtual Site](#origin-servers-k8s-service-site-locator-virtual-site) below.
-
-<a id="origin-servers-k8s-service-site-locator-site"></a>
-
-### Origin Servers K8s Service Site Locator Site
-
-<a id="origin-servers-k8s-service-site-locator-virtual-site"></a>
-
-### Origin Servers K8s Service Site Locator Virtual Site
+`virtual_site` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name (`Block`).
 
 <a id="origin-servers-k8s-service-snat-pool"></a>
 
 ### Origin Servers K8s Service Snat Pool
 
-`no_snat_pool` - (Optional) Empty. This can be used for messages where no values are needed. See [No Snat Pool](#origin-servers-k8s-service-snat-pool-no-snat-pool) below.
+`no_snat_pool` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`snat_pool` - (Optional) IPv4 Prefix List. x-example: '192.168.20.0/24' List of IPv4 prefixes that represent an endpoint. See [Snat Pool](#origin-servers-k8s-service-snat-pool-snat-pool) below.
-
-<a id="origin-servers-k8s-service-snat-pool-no-snat-pool"></a>
-
-### Origin Servers K8s Service Snat Pool No Snat Pool
-
-<a id="origin-servers-k8s-service-snat-pool-snat-pool"></a>
-
-### Origin Servers K8s Service Snat Pool Snat Pool
-
-<a id="origin-servers-k8s-service-vk8s-networks"></a>
-
-### Origin Servers K8s Service Vk8s Networks
-
-<a id="origin-servers-labels"></a>
-
-### Origin Servers Labels
+`snat_pool` - (Optional) IPv4 Prefix List. x-example: '192.168.20.0/24' List of IPv4 prefixes that represent an endpoint (`Block`).
 
 <a id="origin-servers-private-ip"></a>
 
 ### Origin Servers Private IP
 
-`inside_network` - (Optional) Empty. This can be used for messages where no values are needed. See [Inside Network](#origin-servers-private-ip-inside-network) below.
+`inside_network` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `ip` - (Optional) IP. Private IPv4 address (`String`).
 
-`outside_network` - (Optional) Empty. This can be used for messages where no values are needed. See [Outside Network](#origin-servers-private-ip-outside-network) below.
+`outside_network` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `segment` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Segment](#origin-servers-private-ip-segment) below.
 
 `site_locator` - (Optional) Site or Virtual Site. This message defines a reference to a site or virtual site object. See [Site Locator](#origin-servers-private-ip-site-locator) below.
 
 `snat_pool` - (Optional) Snat Pool. Snat Pool configuration. See [Snat Pool](#origin-servers-private-ip-snat-pool) below.
-
-<a id="origin-servers-private-ip-inside-network"></a>
-
-### Origin Servers Private IP Inside Network
-
-<a id="origin-servers-private-ip-outside-network"></a>
-
-### Origin Servers Private IP Outside Network
 
 <a id="origin-servers-private-ip-segment"></a>
 
@@ -530,33 +382,17 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Origin Servers Private IP Site Locator
 
-`site` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Site](#origin-servers-private-ip-site-locator-site) below.
+`site` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name (`Block`).
 
-`virtual_site` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Virtual Site](#origin-servers-private-ip-site-locator-virtual-site) below.
-
-<a id="origin-servers-private-ip-site-locator-site"></a>
-
-### Origin Servers Private IP Site Locator Site
-
-<a id="origin-servers-private-ip-site-locator-virtual-site"></a>
-
-### Origin Servers Private IP Site Locator Virtual Site
+`virtual_site` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name (`Block`).
 
 <a id="origin-servers-private-ip-snat-pool"></a>
 
 ### Origin Servers Private IP Snat Pool
 
-`no_snat_pool` - (Optional) Empty. This can be used for messages where no values are needed. See [No Snat Pool](#origin-servers-private-ip-snat-pool-no-snat-pool) below.
+`no_snat_pool` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`snat_pool` - (Optional) IPv4 Prefix List. x-example: '192.168.20.0/24' List of IPv4 prefixes that represent an endpoint. See [Snat Pool](#origin-servers-private-ip-snat-pool-snat-pool) below.
-
-<a id="origin-servers-private-ip-snat-pool-no-snat-pool"></a>
-
-### Origin Servers Private IP Snat Pool No Snat Pool
-
-<a id="origin-servers-private-ip-snat-pool-snat-pool"></a>
-
-### Origin Servers Private IP Snat Pool Snat Pool
+`snat_pool` - (Optional) IPv4 Prefix List. x-example: '192.168.20.0/24' List of IPv4 prefixes that represent an endpoint (`Block`).
 
 <a id="origin-servers-private-name"></a>
 
@@ -564,9 +400,9 @@ In addition to all arguments above, the following attributes are exported:
 
 `dns_name` - (Optional) DNS Name. DNS Name (`String`).
 
-`inside_network` - (Optional) Empty. This can be used for messages where no values are needed. See [Inside Network](#origin-servers-private-name-inside-network) below.
+`inside_network` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`outside_network` - (Optional) Empty. This can be used for messages where no values are needed. See [Outside Network](#origin-servers-private-name-outside-network) below.
+`outside_network` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `refresh_interval` - (Optional) DNS Refresh Interval. Interval for DNS refresh in seconds. Max value is 7 days as per `HTTPS://datatracker.ietf.org/doc/HTML/rfc8767` (`Number`).
 
@@ -575,14 +411,6 @@ In addition to all arguments above, the following attributes are exported:
 `site_locator` - (Optional) Site or Virtual Site. This message defines a reference to a site or virtual site object. See [Site Locator](#origin-servers-private-name-site-locator) below.
 
 `snat_pool` - (Optional) Snat Pool. Snat Pool configuration. See [Snat Pool](#origin-servers-private-name-snat-pool) below.
-
-<a id="origin-servers-private-name-inside-network"></a>
-
-### Origin Servers Private Name Inside Network
-
-<a id="origin-servers-private-name-outside-network"></a>
-
-### Origin Servers Private Name Outside Network
 
 <a id="origin-servers-private-name-segment"></a>
 
@@ -598,33 +426,17 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Origin Servers Private Name Site Locator
 
-`site` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Site](#origin-servers-private-name-site-locator-site) below.
+`site` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name (`Block`).
 
-`virtual_site` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Virtual Site](#origin-servers-private-name-site-locator-virtual-site) below.
-
-<a id="origin-servers-private-name-site-locator-site"></a>
-
-### Origin Servers Private Name Site Locator Site
-
-<a id="origin-servers-private-name-site-locator-virtual-site"></a>
-
-### Origin Servers Private Name Site Locator Virtual Site
+`virtual_site` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name (`Block`).
 
 <a id="origin-servers-private-name-snat-pool"></a>
 
 ### Origin Servers Private Name Snat Pool
 
-`no_snat_pool` - (Optional) Empty. This can be used for messages where no values are needed. See [No Snat Pool](#origin-servers-private-name-snat-pool-no-snat-pool) below.
+`no_snat_pool` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`snat_pool` - (Optional) IPv4 Prefix List. x-example: '192.168.20.0/24' List of IPv4 prefixes that represent an endpoint. See [Snat Pool](#origin-servers-private-name-snat-pool-snat-pool) below.
-
-<a id="origin-servers-private-name-snat-pool-no-snat-pool"></a>
-
-### Origin Servers Private Name Snat Pool No Snat Pool
-
-<a id="origin-servers-private-name-snat-pool-snat-pool"></a>
-
-### Origin Servers Private Name Snat Pool Snat Pool
+`snat_pool` - (Optional) IPv4 Prefix List. x-example: '192.168.20.0/24' List of IPv4 prefixes that represent an endpoint (`Block`).
 
 <a id="origin-servers-public-ip"></a>
 
@@ -676,10 +488,6 @@ In addition to all arguments above, the following attributes are exported:
 
 `tenant` - (Optional) Tenant. When a configuration object(e.g. virtual_host) refers to another(e.g route) then tenant will hold the referred object's(e.g. route's) tenant (`String`).
 
-<a id="same-as-endpoint-port"></a>
-
-### Same As Endpoint Port
-
 <a id="timeouts"></a>
 
 ### Timeouts
@@ -696,39 +504,31 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Upstream Conn Pool Reuse Type
 
-`disable_conn_pool_reuse` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Conn Pool Reuse](#upstream-conn-pool-reuse-type-disable-conn-pool-reuse) below.
+`disable_conn_pool_reuse` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`enable_conn_pool_reuse` - (Optional) Empty. This can be used for messages where no values are needed. See [Enable Conn Pool Reuse](#upstream-conn-pool-reuse-type-enable-conn-pool-reuse) below.
-
-<a id="upstream-conn-pool-reuse-type-disable-conn-pool-reuse"></a>
-
-### Upstream Conn Pool Reuse Type Disable Conn Pool Reuse
-
-<a id="upstream-conn-pool-reuse-type-enable-conn-pool-reuse"></a>
-
-### Upstream Conn Pool Reuse Type Enable Conn Pool Reuse
+`enable_conn_pool_reuse` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="use-tls"></a>
 
 ### Use TLS
 
-`default_session_key_caching` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Session Key Caching](#use-tls-default-session-key-caching) below.
+`default_session_key_caching` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`disable_session_key_caching` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Session Key Caching](#use-tls-disable-session-key-caching) below.
+`disable_session_key_caching` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`disable_sni` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Sni](#use-tls-disable-sni) below.
+`disable_sni` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `max_session_keys` - (Optional) Max Session Keys Cached. x-example:'25' Number of session keys that are cached (`Number`).
 
-`no_mtls` - (Optional) Empty. This can be used for messages where no values are needed. See [No mTLS](#use-tls-no-mtls) below.
+`no_mtls` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`skip_server_verification` - (Optional) Empty. This can be used for messages where no values are needed. See [Skip Server Verification](#use-tls-skip-server-verification) below.
+`skip_server_verification` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `sni` - (Optional) SNI Value. SNI value to be used (`String`).
 
 `tls_config` - (Optional) TLS Config. This defines various options to configure TLS configuration parameters. See [TLS Config](#use-tls-tls-config) below.
 
-`use_host_header_as_sni` - (Optional) Empty. This can be used for messages where no values are needed. See [Use Host Header As Sni](#use-tls-use-host-header-as-sni) below.
+`use_host_header_as_sni` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `use_mtls` - (Optional) mTLS Certificate. mTLS Client Certificate. See [Use mTLS](#use-tls-use-mtls) below.
 
@@ -736,27 +536,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `use_server_verification` - (Optional) TLS Validation Context for Origin Servers. Upstream TLS Validation Context. See [Use Server Verification](#use-tls-use-server-verification) below.
 
-`volterra_trusted_ca` - (Optional) Empty. This can be used for messages where no values are needed. See [Volterra Trusted CA](#use-tls-volterra-trusted-ca) below.
-
-<a id="use-tls-default-session-key-caching"></a>
-
-### Use TLS Default Session Key Caching
-
-<a id="use-tls-disable-session-key-caching"></a>
-
-### Use TLS Disable Session Key Caching
-
-<a id="use-tls-disable-sni"></a>
-
-### Use TLS Disable Sni
-
-<a id="use-tls-no-mtls"></a>
-
-### Use TLS No mTLS
-
-<a id="use-tls-skip-server-verification"></a>
-
-### Use TLS Skip Server Verification
+`volterra_trusted_ca` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="use-tls-tls-config"></a>
 
@@ -764,11 +544,11 @@ In addition to all arguments above, the following attributes are exported:
 
 `custom_security` - (Optional) Custom Ciphers. This defines TLS protocol config including min/max versions and allowed ciphers. See [Custom Security](#use-tls-tls-config-custom-security) below.
 
-`default_security` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Security](#use-tls-tls-config-default-security) below.
+`default_security` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`low_security` - (Optional) Empty. This can be used for messages where no values are needed. See [Low Security](#use-tls-tls-config-low-security) below.
+`low_security` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`medium_security` - (Optional) Empty. This can be used for messages where no values are needed. See [Medium Security](#use-tls-tls-config-medium-security) below.
+`medium_security` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="use-tls-tls-config-custom-security"></a>
 
@@ -779,22 +559,6 @@ In addition to all arguments above, the following attributes are exported:
 `max_version` - (Optional) TLS Protocol. TlsProtocol is enumeration of supported TLS versions F5 Distributed Cloud will choose the optimal TLS version. Possible values are `TLS_AUTO`, `TLSv1_0`, `TLSv1_1`, `TLSv1_2`, `TLSv1_3`. Defaults to `TLS_AUTO` (`String`).
 
 `min_version` - (Optional) TLS Protocol. TlsProtocol is enumeration of supported TLS versions F5 Distributed Cloud will choose the optimal TLS version. Possible values are `TLS_AUTO`, `TLSv1_0`, `TLSv1_1`, `TLSv1_2`, `TLSv1_3`. Defaults to `TLS_AUTO` (`String`).
-
-<a id="use-tls-tls-config-default-security"></a>
-
-### Use TLS TLS Config Default Security
-
-<a id="use-tls-tls-config-low-security"></a>
-
-### Use TLS TLS Config Low Security
-
-<a id="use-tls-tls-config-medium-security"></a>
-
-### Use TLS TLS Config Medium Security
-
-<a id="use-tls-use-host-header-as-sni"></a>
-
-### Use TLS Use Host Header As Sni
 
 <a id="use-tls-use-mtls"></a>
 
@@ -808,31 +572,15 @@ In addition to all arguments above, the following attributes are exported:
 
 `certificate_url` - (Optional) Certificate. TLS certificate. Certificate or certificate chain in PEM format including the PEM headers (`String`).
 
-`custom_hash_algorithms` - (Optional) Hash Algorithms. Specifies the hash algorithms to be used. See [Custom Hash Algorithms](#use-tls-use-mtls-tls-certificates-custom-hash-algorithms) below.
+`custom_hash_algorithms` - (Optional) Hash Algorithms. Specifies the hash algorithms to be used (`Block`).
 
 `description` - (Optional) Configuration for description (`String`).
 
-`disable_ocsp_stapling` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable OCSP Stapling](#use-tls-use-mtls-tls-certificates-disable-ocsp-stapling) below.
+`disable_ocsp_stapling` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`private_key` - (Optional) Secret. SecretType is used in an object to indicate a sensitive/confidential field. See [Private Key](#use-tls-use-mtls-tls-certificates-private-key) below.
+`private_key` - (Optional) Secret. SecretType is used in an object to indicate a sensitive/confidential field (`Block`).
 
-`use_system_defaults` - (Optional) Empty. This can be used for messages where no values are needed. See [Use System Defaults](#use-tls-use-mtls-tls-certificates-use-system-defaults) below.
-
-<a id="use-tls-use-mtls-tls-certificates-custom-hash-algorithms"></a>
-
-### Use TLS Use mTLS TLS Certificates Custom Hash Algorithms
-
-<a id="use-tls-use-mtls-tls-certificates-disable-ocsp-stapling"></a>
-
-### Use TLS Use mTLS TLS Certificates Disable OCSP Stapling
-
-<a id="use-tls-use-mtls-tls-certificates-private-key"></a>
-
-### Use TLS Use mTLS TLS Certificates Private Key
-
-<a id="use-tls-use-mtls-tls-certificates-use-system-defaults"></a>
-
-### Use TLS Use mTLS TLS Certificates Use System Defaults
+`use_system_defaults` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="use-tls-use-mtls-obj"></a>
 
@@ -861,10 +609,6 @@ In addition to all arguments above, the following attributes are exported:
 `namespace` - (Optional) Namespace. When a configuration object(e.g. virtual_host) refers to another(e.g route) then namespace will hold the referred object's(e.g. route's) namespace (`String`).
 
 `tenant` - (Optional) Tenant. When a configuration object(e.g. virtual_host) refers to another(e.g route) then tenant will hold the referred object's(e.g. route's) tenant (`String`).
-
-<a id="use-tls-volterra-trusted-ca"></a>
-
-### Use TLS Volterra Trusted CA
 
 ## Import
 

--- a/docs/resources/policy_based_routing.md
+++ b/docs/resources/policy_based_routing.md
@@ -90,9 +90,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Forward Proxy Pbr Forward Proxy Pbr Rules
 
-`all_destinations` - (Optional) Empty. This can be used for messages where no values are needed. See [All Destinations](#forward-proxy-pbr-forward-proxy-pbr-rules-all-destinations) below.
+`all_destinations` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`all_sources` - (Optional) Empty. This can be used for messages where no values are needed. See [All Sources](#forward-proxy-pbr-forward-proxy-pbr-rules-all-sources) below.
+`all_sources` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `forwarding_class_list` - (Optional) Forwarding Class. Ordered list of forwarding Class to be used if no rule match. See [Forwarding Class List](#forward-proxy-pbr-forward-proxy-pbr-rules-forwarding-class-list) below.
 
@@ -108,14 +108,6 @@ In addition to all arguments above, the following attributes are exported:
 
 `tls_list` - (Optional) DomainListType. See [TLS List](#forward-proxy-pbr-forward-proxy-pbr-rules-tls-list) below.
 
-<a id="forward-proxy-pbr-forward-proxy-pbr-rules-all-destinations"></a>
-
-### Forward Proxy Pbr Forward Proxy Pbr Rules All Destinations
-
-<a id="forward-proxy-pbr-forward-proxy-pbr-rules-all-sources"></a>
-
-### Forward Proxy Pbr Forward Proxy Pbr Rules All Sources
-
 <a id="forward-proxy-pbr-forward-proxy-pbr-rules-forwarding-class-list"></a>
 
 ### Forward Proxy Pbr Forward Proxy Pbr Rules Forwarding Class List
@@ -130,11 +122,7 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Forward Proxy Pbr Forward Proxy Pbr Rules HTTP List
 
-`http_list` - (Optional) HTTP URLs. URLs for HTTP connections. See [HTTP List](#forward-proxy-pbr-forward-proxy-pbr-rules-http-list-http-list) below.
-
-<a id="forward-proxy-pbr-forward-proxy-pbr-rules-http-list-http-list"></a>
-
-### Forward Proxy Pbr Forward Proxy Pbr Rules HTTP List HTTP List
+`http_list` - (Optional) HTTP URLs. URLs for HTTP connections (`Block`).
 
 <a id="forward-proxy-pbr-forward-proxy-pbr-rules-ip-prefix-set"></a>
 
@@ -170,11 +158,7 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Forward Proxy Pbr Forward Proxy Pbr Rules TLS List
 
-`tls_list` - (Optional) TLS Domains. Domains in SNI for TLS connections. See [TLS List](#forward-proxy-pbr-forward-proxy-pbr-rules-tls-list-tls-list) below.
-
-<a id="forward-proxy-pbr-forward-proxy-pbr-rules-tls-list-tls-list"></a>
-
-### Forward Proxy Pbr Forward Proxy Pbr Rules TLS List TLS List
+`tls_list` - (Optional) TLS Domains. Domains in SNI for TLS connections (`Block`).
 
 <a id="forwarding-class-list"></a>
 
@@ -190,17 +174,13 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Network Pbr
 
-`any` - (Optional) Empty. This can be used for messages where no values are needed. See [Any](#network-pbr-any) below.
+`any` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `label_selector` - (Optional) Label Selector. This type can be used to establish a 'selector reference' from one object(called selector) to a set of other objects(called selectees) based on the value of expresssions. A label selector is a label query over a set of resources. An empty label selector matches all objects. A null label selector matches no objects. Label selector is immutable. expressions is a list of strings of label selection expression. Each string has ',' separated values which are 'AND' and all strings ar. See [Label Selector](#network-pbr-label-selector) below.
 
 `network_pbr_rules` - (Optional) L3/L4 Destination Routing Rules. Network(L3/L4) routing policy rule. See [Network Pbr Rules](#network-pbr-network-pbr-rules) below.
 
 `prefix_list` - (Optional) IPv4 Prefix List. x-example: '192.168.20.0/24' List of IPv4 prefixes that represent an endpoint. See [Prefix List](#network-pbr-prefix-list) below.
-
-<a id="network-pbr-any"></a>
-
-### Network Pbr Any
 
 <a id="network-pbr-label-selector"></a>
 
@@ -212,13 +192,13 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Network Pbr Network Pbr Rules
 
-`all_tcp_traffic` - (Optional) Empty. This can be used for messages where no values are needed. See [All TCP Traffic](#network-pbr-network-pbr-rules-all-tcp-traffic) below.
+`all_tcp_traffic` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`all_traffic` - (Optional) Empty. This can be used for messages where no values are needed. See [All Traffic](#network-pbr-network-pbr-rules-all-traffic) below.
+`all_traffic` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`all_udp_traffic` - (Optional) Empty. This can be used for messages where no values are needed. See [All UDP Traffic](#network-pbr-network-pbr-rules-all-udp-traffic) below.
+`all_udp_traffic` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`any` - (Optional) Empty. This can be used for messages where no values are needed. See [Any](#network-pbr-network-pbr-rules-any) below.
+`any` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `applications` - (Optional) Applications. Application protocols like HTTP, SNMP. See [Applications](#network-pbr-network-pbr-rules-applications) below.
 
@@ -233,22 +213,6 @@ In addition to all arguments above, the following attributes are exported:
 `prefix_list` - (Optional) IPv4 Prefix List. x-example: '192.168.20.0/24' List of IPv4 prefixes that represent an endpoint. See [Prefix List](#network-pbr-network-pbr-rules-prefix-list) below.
 
 `protocol_port_range` - (Optional) Protocol and Port. Protocol and Port ranges. See [Protocol Port Range](#network-pbr-network-pbr-rules-protocol-port-range) below.
-
-<a id="network-pbr-network-pbr-rules-all-tcp-traffic"></a>
-
-### Network Pbr Network Pbr Rules All TCP Traffic
-
-<a id="network-pbr-network-pbr-rules-all-traffic"></a>
-
-### Network Pbr Network Pbr Rules All Traffic
-
-<a id="network-pbr-network-pbr-rules-all-udp-traffic"></a>
-
-### Network Pbr Network Pbr Rules All UDP Traffic
-
-<a id="network-pbr-network-pbr-rules-any"></a>
-
-### Network Pbr Network Pbr Rules Any
 
 <a id="network-pbr-network-pbr-rules-applications"></a>
 
@@ -270,11 +234,7 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Network Pbr Network Pbr Rules IP Prefix Set
 
-`ref` - (Optional) Reference. A list of references to ip_prefix_set objects. See [Ref](#network-pbr-network-pbr-rules-ip-prefix-set-ref) below.
-
-<a id="network-pbr-network-pbr-rules-ip-prefix-set-ref"></a>
-
-### Network Pbr Network Pbr Rules IP Prefix Set Ref
+`ref` - (Optional) Reference. A list of references to ip_prefix_set objects (`Block`).
 
 <a id="network-pbr-network-pbr-rules-metadata"></a>
 

--- a/docs/resources/protocol_inspection.md
+++ b/docs/resources/protocol_inspection.md
@@ -82,13 +82,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Enable Disable Compliance Checks
 
-`disable_compliance_checks` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Compliance Checks](#enable-disable-compliance-checks-disable-compliance-checks) below.
+`disable_compliance_checks` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `enable_compliance_checks` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Enable Compliance Checks](#enable-disable-compliance-checks-enable-compliance-checks) below.
-
-<a id="enable-disable-compliance-checks-disable-compliance-checks"></a>
-
-### Enable Disable Compliance Checks Disable Compliance Checks
 
 <a id="enable-disable-compliance-checks-enable-compliance-checks"></a>
 
@@ -104,17 +100,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Enable Disable Signatures
 
-`disable_signature` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Signature](#enable-disable-signatures-disable-signature) below.
+`disable_signature` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`enable_signature` - (Optional) Empty. This can be used for messages where no values are needed. See [Enable Signature](#enable-disable-signatures-enable-signature) below.
-
-<a id="enable-disable-signatures-disable-signature"></a>
-
-### Enable Disable Signatures Disable Signature
-
-<a id="enable-disable-signatures-enable-signature"></a>
-
-### Enable Disable Signatures Enable Signature
+`enable_signature` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="timeouts"></a>
 

--- a/docs/resources/protocol_policer.md
+++ b/docs/resources/protocol_policer.md
@@ -100,17 +100,13 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Protocol Policer Protocol
 
-`dns` - (Optional) DNS Packets. Match all DNS packets inclusing UDP and TCP. See [DNS](#protocol-policer-protocol-dns) below.
+`dns` - (Optional) DNS Packets. Match all DNS packets inclusing UDP and TCP (`Block`).
 
 `icmp` - (Optional) ICMP Packet Type. ICMP message type to match in packet. See [ICMP](#protocol-policer-protocol-icmp) below.
 
 `tcp` - (Optional) TCP Packet Type. Specification of TCP flag to be matched in a TCP packet. See [TCP](#protocol-policer-protocol-tcp) below.
 
-`udp` - (Optional) UDP Packets. Match all UDP packets. See [UDP](#protocol-policer-protocol-udp) below.
-
-<a id="protocol-policer-protocol-dns"></a>
-
-### Protocol Policer Protocol DNS
+`udp` - (Optional) UDP Packets. Match all UDP packets (`Block`).
 
 <a id="protocol-policer-protocol-icmp"></a>
 
@@ -123,10 +119,6 @@ In addition to all arguments above, the following attributes are exported:
 ### Protocol Policer Protocol TCP
 
 `flags` - (Optional) TCP flags. TCP flag to be matched in a TCP packet (`List`).
-
-<a id="protocol-policer-protocol-udp"></a>
-
-### Protocol Policer Protocol UDP
 
 <a id="timeouts"></a>
 

--- a/docs/resources/proxy.md
+++ b/docs/resources/proxy.md
@@ -55,13 +55,13 @@ resource "f5xc_proxy" "example" {
 
 `active_forward_proxy_policies` - (Optional) Active Forward Proxy Policies Type. Ordered List of Forward Proxy Policies active. See [Active Forward Proxy Policies](#active-forward-proxy-policies) below for details.
 
-`no_forward_proxy_policy` - (Optional) Empty. This can be used for messages where no values are needed. See [No Forward Proxy Policy](#no-forward-proxy-policy) below for details.
+`no_forward_proxy_policy` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `connection_timeout` - (Optional) Connection Timeout. The timeout for new network connections to upstream server. This is specified in milliseconds. The default value is 2000 (2 seconds) (`Number`).
 
 > **Note:** One of the arguments from this list "do_not_advertise, site_virtual_sites" must be set.
 
-`do_not_advertise` - (Optional) Empty. This can be used for messages where no values are needed. See [Do Not Advertise](#do-not-advertise) below for details.
+`do_not_advertise` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `site_virtual_sites` - (Optional) Advertise Site or Virtual Site. This defines a way to advertise a VIP on specific sites. See [Site Virtual Sites](#site-virtual-sites) below for details.
 
@@ -73,15 +73,15 @@ resource "f5xc_proxy" "example" {
 
 > **Note:** One of the arguments from this list "no_interception, tls_intercept" must be set.
 
-`no_interception` - (Optional) Empty. This can be used for messages where no values are needed. See [No Interception](#no-interception) below for details.
+`no_interception` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `tls_intercept` - (Optional) Configuration for TLS interception. Configuration to enable TLS interception. See [TLS Intercept](#tls-intercept) below for details.
 
 > **Note:** One of the arguments from this list "site_local_inside_network, site_local_network" must be set.
 
-`site_local_inside_network` - (Optional) Empty. This can be used for messages where no values are needed. See [Site Local Inside Network](#site-local-inside-network) below for details.
+`site_local_inside_network` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`site_local_network` - (Optional) Empty. This can be used for messages where no values are needed. See [Site Local Network](#site-local-network) below for details.
+`site_local_network` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `timeouts` - (Optional) See [Timeouts](#timeouts) below for details.
 
@@ -109,33 +109,21 @@ In addition to all arguments above, the following attributes are exported:
 
 `tenant` - (Optional) Tenant. When a configuration object(e.g. virtual_host) refers to another(e.g route) then tenant will hold the referred object's(e.g. route's) tenant (`String`).
 
-<a id="do-not-advertise"></a>
-
-### Do Not Advertise
-
 <a id="dynamic-proxy"></a>
 
 ### Dynamic Proxy
 
-`disable_dns_masquerade` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable DNS Masquerade](#dynamic-proxy-disable-dns-masquerade) below.
+`disable_dns_masquerade` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `domains` - (Optional) Domains. A list of Domains to be proxied. Wildcard hosts are supported in the suffix or prefix form Supported Domains and search order: 1. Exact Domain names: `www.foo.com.` 2. Domains starting with a Wildcard: *.foo.com. Not supported Domains: - Just a Wildcard: * - A Wildcard and TLD with no root Domain: *.com. - A Wildcard not matching a whole DNS label. e.g. *.foo.com and *.bar.foo.com are valid Wildcards however *bar.foo.com, *-bar.foo.com, and bar*.foo.com are all invalid. Additional note (`List`).
 
-`enable_dns_masquerade` - (Optional) Empty. This can be used for messages where no values are needed. See [Enable DNS Masquerade](#dynamic-proxy-enable-dns-masquerade) below.
+`enable_dns_masquerade` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `http_proxy` - (Optional) Dynamic HTTP Proxy Type. Parameters for dynamic HTTP proxy. See [HTTP Proxy](#dynamic-proxy-http-proxy) below.
 
 `https_proxy` - (Optional) Dynamic HTTPS Proxy Type. Parameters for dynamic HTTPS proxy. See [HTTPS Proxy](#dynamic-proxy-https-proxy) below.
 
 `sni_proxy` - (Optional) Dynamic SNI Proxy Type. Parameters for dynamic SNI proxy. See [Sni Proxy](#dynamic-proxy-sni-proxy) below.
-
-<a id="dynamic-proxy-disable-dns-masquerade"></a>
-
-### Dynamic Proxy Disable DNS Masquerade
-
-<a id="dynamic-proxy-enable-dns-masquerade"></a>
-
-### Dynamic Proxy Enable DNS Masquerade
 
 <a id="dynamic-proxy-http-proxy"></a>
 
@@ -147,73 +135,37 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Dynamic Proxy HTTP Proxy More Option
 
-`buffer_policy` - (Optional) Buffer Configuration. Some upstream applications are not capable of handling streamed data. This config enables buffering the entire request before sending to upstream application. We can specify the maximum buffer size and buffer interval with this config. Buffering can be enabled and disabled at VirtualHost and Route levels Route level buffer configuration takes precedence. See [Buffer Policy](#dynamic-proxy-http-proxy-more-option-buffer-policy) below.
+`buffer_policy` - (Optional) Buffer Configuration. Some upstream applications are not capable of handling streamed data. This config enables buffering the entire request before sending to upstream application. We can specify the maximum buffer size and buffer interval with this config. Buffering can be enabled and disabled at VirtualHost and Route levels Route level buffer configuration takes precedence (`Block`).
 
-`compression_params` - (Optional) Compression Parameters. Enables loadbalancer to compress dispatched data from an upstream service upon client request. The content is compressed and then sent to the client with the appropriate headers if either response and request allow. Only GZIP compression is supported. By default compression will be skipped when: A request does NOT contain accept-encoding header. A request includes accept-encoding header, but it does not contain “gzip” or “*”. A request includes accept-encoding. See [Compression Params](#dynamic-proxy-http-proxy-more-option-compression-params) below.
+`compression_params` - (Optional) Compression Parameters. Enables loadbalancer to compress dispatched data from an upstream service upon client request. The content is compressed and then sent to the client with the appropriate headers if either response and request allow. Only GZIP compression is supported. By default compression will be skipped when: A request does NOT contain accept-encoding header. A request includes accept-encoding header, but it does not contain “gzip” or “*”. A request includes accept-encoding (`Block`).
 
-`custom_errors` - (Optional) Custom Error Responses. Map of integer error codes as keys and string values that can be used to provide custom HTTP pages for each error code. Key of the map can be either response code class or HTTP Error code. Response code classes for key is configured as follows 3 -- for 3xx response code class 4 -- for 4xx response code class 5 -- for 5xx response code class Value of the map is string which represents custom HTTP responses. Specific response code takes preference when both response code. See [Custom Errors](#dynamic-proxy-http-proxy-more-option-custom-errors) below.
+`custom_errors` - (Optional) Custom Error Responses. Map of integer error codes as keys and string values that can be used to provide custom HTTP pages for each error code. Key of the map can be either response code class or HTTP Error code. Response code classes for key is configured as follows 3 -- for 3xx response code class 4 -- for 4xx response code class 5 -- for 5xx response code class Value of the map is string which represents custom HTTP responses. Specific response code takes preference when both response code (`Block`).
 
 `disable_default_error_pages` - (Optional) Disable Default Error Pages. Disable the use of default F5XC error pages (`Bool`).
 
-`disable_path_normalize` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Path Normalize](#dynamic-proxy-http-proxy-more-option-disable-path-normalize) below.
+`disable_path_normalize` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`enable_path_normalize` - (Optional) Empty. This can be used for messages where no values are needed. See [Enable Path Normalize](#dynamic-proxy-http-proxy-more-option-enable-path-normalize) below.
+`enable_path_normalize` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `idle_timeout` - (Optional) Idle Timeout. The amount of time that a stream can exist without upstream or downstream activity, in milliseconds. The stream is terminated with a HTTP 504 (Gateway Timeout) error code if no upstream response header has been received, otherwise the stream is reset (`Number`).
 
 `max_request_header_size` - (Optional) Maximum Request Header Size. The maximum request header size for downstream connections, in KiB. A HTTP 431 (Request Header Fields Too Large) error code is sent for requests that exceed this size. If multiple load balancers share the same advertise_policy, the highest value configured across all such load balancers is used for all the load balancers in question (`Number`).
 
-`request_cookies_to_add` - (Optional) Add Cookies in Cookie Header. Cookies are key-value pairs to be added to HTTP request being routed towards upstream. Cookies specified at this level are applied after cookies from matched Route are applied. See [Request Cookies To Add](#dynamic-proxy-http-proxy-more-option-request-cookies-to-add) below.
+`request_cookies_to_add` - (Optional) Add Cookies in Cookie Header. Cookies are key-value pairs to be added to HTTP request being routed towards upstream. Cookies specified at this level are applied after cookies from matched Route are applied (`Block`).
 
 `request_cookies_to_remove` - (Optional) Remove Cookies from Cookie Header. List of keys of Cookies to be removed from the HTTP request being sent towards upstream (`List`).
 
-`request_headers_to_add` - (Optional) Add Request Headers. Headers are key-value pairs to be added to HTTP request being routed towards upstream. Headers specified at this level are applied after headers from matched Route are applied. See [Request Headers To Add](#dynamic-proxy-http-proxy-more-option-request-headers-to-add) below.
+`request_headers_to_add` - (Optional) Add Request Headers. Headers are key-value pairs to be added to HTTP request being routed towards upstream. Headers specified at this level are applied after headers from matched Route are applied (`Block`).
 
 `request_headers_to_remove` - (Optional) Remove Request Headers. List of keys of Headers to be removed from the HTTP request being sent towards upstream (`List`).
 
-`response_cookies_to_add` - (Optional) Add Set-Cookie Headers. Cookies are name-value pairs along with optional attribute parameters to be added to HTTP response being sent towards downstream. Cookies specified at this level are applied after cookies from matched Route are applied. See [Response Cookies To Add](#dynamic-proxy-http-proxy-more-option-response-cookies-to-add) below.
+`response_cookies_to_add` - (Optional) Add Set-Cookie Headers. Cookies are name-value pairs along with optional attribute parameters to be added to HTTP response being sent towards downstream. Cookies specified at this level are applied after cookies from matched Route are applied (`Block`).
 
 `response_cookies_to_remove` - (Optional) Remove Cookies from Set-Cookie Headers. List of name of Cookies to be removed from the HTTP response being sent towards downstream. Entire set-cookie header will be removed (`List`).
 
-`response_headers_to_add` - (Optional) Add Response Headers. Headers are key-value pairs to be added to HTTP response being sent towards downstream. Headers specified at this level are applied after headers from matched Route are applied. See [Response Headers To Add](#dynamic-proxy-http-proxy-more-option-response-headers-to-add) below.
+`response_headers_to_add` - (Optional) Add Response Headers. Headers are key-value pairs to be added to HTTP response being sent towards downstream. Headers specified at this level are applied after headers from matched Route are applied (`Block`).
 
 `response_headers_to_remove` - (Optional) Remove Response Headers. List of keys of Headers to be removed from the HTTP response being sent towards downstream (`List`).
-
-<a id="dynamic-proxy-http-proxy-more-option-buffer-policy"></a>
-
-### Dynamic Proxy HTTP Proxy More Option Buffer Policy
-
-<a id="dynamic-proxy-http-proxy-more-option-compression-params"></a>
-
-### Dynamic Proxy HTTP Proxy More Option Compression Params
-
-<a id="dynamic-proxy-http-proxy-more-option-custom-errors"></a>
-
-### Dynamic Proxy HTTP Proxy More Option Custom Errors
-
-<a id="dynamic-proxy-http-proxy-more-option-disable-path-normalize"></a>
-
-### Dynamic Proxy HTTP Proxy More Option Disable Path Normalize
-
-<a id="dynamic-proxy-http-proxy-more-option-enable-path-normalize"></a>
-
-### Dynamic Proxy HTTP Proxy More Option Enable Path Normalize
-
-<a id="dynamic-proxy-http-proxy-more-option-request-cookies-to-add"></a>
-
-### Dynamic Proxy HTTP Proxy More Option Request Cookies To Add
-
-<a id="dynamic-proxy-http-proxy-more-option-request-headers-to-add"></a>
-
-### Dynamic Proxy HTTP Proxy More Option Request Headers To Add
-
-<a id="dynamic-proxy-http-proxy-more-option-response-cookies-to-add"></a>
-
-### Dynamic Proxy HTTP Proxy More Option Response Cookies To Add
-
-<a id="dynamic-proxy-http-proxy-more-option-response-headers-to-add"></a>
-
-### Dynamic Proxy HTTP Proxy More Option Response Headers To Add
 
 <a id="dynamic-proxy-https-proxy"></a>
 
@@ -227,101 +179,49 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Dynamic Proxy HTTPS Proxy More Option
 
-`buffer_policy` - (Optional) Buffer Configuration. Some upstream applications are not capable of handling streamed data. This config enables buffering the entire request before sending to upstream application. We can specify the maximum buffer size and buffer interval with this config. Buffering can be enabled and disabled at VirtualHost and Route levels Route level buffer configuration takes precedence. See [Buffer Policy](#dynamic-proxy-https-proxy-more-option-buffer-policy) below.
+`buffer_policy` - (Optional) Buffer Configuration. Some upstream applications are not capable of handling streamed data. This config enables buffering the entire request before sending to upstream application. We can specify the maximum buffer size and buffer interval with this config. Buffering can be enabled and disabled at VirtualHost and Route levels Route level buffer configuration takes precedence (`Block`).
 
-`compression_params` - (Optional) Compression Parameters. Enables loadbalancer to compress dispatched data from an upstream service upon client request. The content is compressed and then sent to the client with the appropriate headers if either response and request allow. Only GZIP compression is supported. By default compression will be skipped when: A request does NOT contain accept-encoding header. A request includes accept-encoding header, but it does not contain “gzip” or “*”. A request includes accept-encoding. See [Compression Params](#dynamic-proxy-https-proxy-more-option-compression-params) below.
+`compression_params` - (Optional) Compression Parameters. Enables loadbalancer to compress dispatched data from an upstream service upon client request. The content is compressed and then sent to the client with the appropriate headers if either response and request allow. Only GZIP compression is supported. By default compression will be skipped when: A request does NOT contain accept-encoding header. A request includes accept-encoding header, but it does not contain “gzip” or “*”. A request includes accept-encoding (`Block`).
 
-`custom_errors` - (Optional) Custom Error Responses. Map of integer error codes as keys and string values that can be used to provide custom HTTP pages for each error code. Key of the map can be either response code class or HTTP Error code. Response code classes for key is configured as follows 3 -- for 3xx response code class 4 -- for 4xx response code class 5 -- for 5xx response code class Value of the map is string which represents custom HTTP responses. Specific response code takes preference when both response code. See [Custom Errors](#dynamic-proxy-https-proxy-more-option-custom-errors) below.
+`custom_errors` - (Optional) Custom Error Responses. Map of integer error codes as keys and string values that can be used to provide custom HTTP pages for each error code. Key of the map can be either response code class or HTTP Error code. Response code classes for key is configured as follows 3 -- for 3xx response code class 4 -- for 4xx response code class 5 -- for 5xx response code class Value of the map is string which represents custom HTTP responses. Specific response code takes preference when both response code (`Block`).
 
 `disable_default_error_pages` - (Optional) Disable Default Error Pages. Disable the use of default F5XC error pages (`Bool`).
 
-`disable_path_normalize` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Path Normalize](#dynamic-proxy-https-proxy-more-option-disable-path-normalize) below.
+`disable_path_normalize` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`enable_path_normalize` - (Optional) Empty. This can be used for messages where no values are needed. See [Enable Path Normalize](#dynamic-proxy-https-proxy-more-option-enable-path-normalize) below.
+`enable_path_normalize` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `idle_timeout` - (Optional) Idle Timeout. The amount of time that a stream can exist without upstream or downstream activity, in milliseconds. The stream is terminated with a HTTP 504 (Gateway Timeout) error code if no upstream response header has been received, otherwise the stream is reset (`Number`).
 
 `max_request_header_size` - (Optional) Maximum Request Header Size. The maximum request header size for downstream connections, in KiB. A HTTP 431 (Request Header Fields Too Large) error code is sent for requests that exceed this size. If multiple load balancers share the same advertise_policy, the highest value configured across all such load balancers is used for all the load balancers in question (`Number`).
 
-`request_cookies_to_add` - (Optional) Add Cookies in Cookie Header. Cookies are key-value pairs to be added to HTTP request being routed towards upstream. Cookies specified at this level are applied after cookies from matched Route are applied. See [Request Cookies To Add](#dynamic-proxy-https-proxy-more-option-request-cookies-to-add) below.
+`request_cookies_to_add` - (Optional) Add Cookies in Cookie Header. Cookies are key-value pairs to be added to HTTP request being routed towards upstream. Cookies specified at this level are applied after cookies from matched Route are applied (`Block`).
 
 `request_cookies_to_remove` - (Optional) Remove Cookies from Cookie Header. List of keys of Cookies to be removed from the HTTP request being sent towards upstream (`List`).
 
-`request_headers_to_add` - (Optional) Add Request Headers. Headers are key-value pairs to be added to HTTP request being routed towards upstream. Headers specified at this level are applied after headers from matched Route are applied. See [Request Headers To Add](#dynamic-proxy-https-proxy-more-option-request-headers-to-add) below.
+`request_headers_to_add` - (Optional) Add Request Headers. Headers are key-value pairs to be added to HTTP request being routed towards upstream. Headers specified at this level are applied after headers from matched Route are applied (`Block`).
 
 `request_headers_to_remove` - (Optional) Remove Request Headers. List of keys of Headers to be removed from the HTTP request being sent towards upstream (`List`).
 
-`response_cookies_to_add` - (Optional) Add Set-Cookie Headers. Cookies are name-value pairs along with optional attribute parameters to be added to HTTP response being sent towards downstream. Cookies specified at this level are applied after cookies from matched Route are applied. See [Response Cookies To Add](#dynamic-proxy-https-proxy-more-option-response-cookies-to-add) below.
+`response_cookies_to_add` - (Optional) Add Set-Cookie Headers. Cookies are name-value pairs along with optional attribute parameters to be added to HTTP response being sent towards downstream. Cookies specified at this level are applied after cookies from matched Route are applied (`Block`).
 
 `response_cookies_to_remove` - (Optional) Remove Cookies from Set-Cookie Headers. List of name of Cookies to be removed from the HTTP response being sent towards downstream. Entire set-cookie header will be removed (`List`).
 
-`response_headers_to_add` - (Optional) Add Response Headers. Headers are key-value pairs to be added to HTTP response being sent towards downstream. Headers specified at this level are applied after headers from matched Route are applied. See [Response Headers To Add](#dynamic-proxy-https-proxy-more-option-response-headers-to-add) below.
+`response_headers_to_add` - (Optional) Add Response Headers. Headers are key-value pairs to be added to HTTP response being sent towards downstream. Headers specified at this level are applied after headers from matched Route are applied (`Block`).
 
 `response_headers_to_remove` - (Optional) Remove Response Headers. List of keys of Headers to be removed from the HTTP response being sent towards downstream (`List`).
-
-<a id="dynamic-proxy-https-proxy-more-option-buffer-policy"></a>
-
-### Dynamic Proxy HTTPS Proxy More Option Buffer Policy
-
-<a id="dynamic-proxy-https-proxy-more-option-compression-params"></a>
-
-### Dynamic Proxy HTTPS Proxy More Option Compression Params
-
-<a id="dynamic-proxy-https-proxy-more-option-custom-errors"></a>
-
-### Dynamic Proxy HTTPS Proxy More Option Custom Errors
-
-<a id="dynamic-proxy-https-proxy-more-option-disable-path-normalize"></a>
-
-### Dynamic Proxy HTTPS Proxy More Option Disable Path Normalize
-
-<a id="dynamic-proxy-https-proxy-more-option-enable-path-normalize"></a>
-
-### Dynamic Proxy HTTPS Proxy More Option Enable Path Normalize
-
-<a id="dynamic-proxy-https-proxy-more-option-request-cookies-to-add"></a>
-
-### Dynamic Proxy HTTPS Proxy More Option Request Cookies To Add
-
-<a id="dynamic-proxy-https-proxy-more-option-request-headers-to-add"></a>
-
-### Dynamic Proxy HTTPS Proxy More Option Request Headers To Add
-
-<a id="dynamic-proxy-https-proxy-more-option-response-cookies-to-add"></a>
-
-### Dynamic Proxy HTTPS Proxy More Option Response Cookies To Add
-
-<a id="dynamic-proxy-https-proxy-more-option-response-headers-to-add"></a>
-
-### Dynamic Proxy HTTPS Proxy More Option Response Headers To Add
 
 <a id="dynamic-proxy-https-proxy-tls-params"></a>
 
 ### Dynamic Proxy HTTPS Proxy TLS Params
 
-`no_mtls` - (Optional) Empty. This can be used for messages where no values are needed. See [No mTLS](#dynamic-proxy-https-proxy-tls-params-no-mtls) below.
+`no_mtls` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`tls_certificates` - (Optional) TLS Certificates. Users can add one or more certificates that share the same set of domains. for example, domain.com and *.domain.com - but use different signature algorithms. See [TLS Certificates](#dynamic-proxy-https-proxy-tls-params-tls-certificates) below.
+`tls_certificates` - (Optional) TLS Certificates. Users can add one or more certificates that share the same set of domains. for example, domain.com and *.domain.com - but use different signature algorithms (`Block`).
 
-`tls_config` - (Optional) TLS Config. This defines various options to configure TLS configuration parameters. See [TLS Config](#dynamic-proxy-https-proxy-tls-params-tls-config) below.
+`tls_config` - (Optional) TLS Config. This defines various options to configure TLS configuration parameters (`Block`).
 
-`use_mtls` - (Optional) Clients TLS validation context. Validation context for downstream client TLS connections. See [Use mTLS](#dynamic-proxy-https-proxy-tls-params-use-mtls) below.
-
-<a id="dynamic-proxy-https-proxy-tls-params-no-mtls"></a>
-
-### Dynamic Proxy HTTPS Proxy TLS Params No mTLS
-
-<a id="dynamic-proxy-https-proxy-tls-params-tls-certificates"></a>
-
-### Dynamic Proxy HTTPS Proxy TLS Params TLS Certificates
-
-<a id="dynamic-proxy-https-proxy-tls-params-tls-config"></a>
-
-### Dynamic Proxy HTTPS Proxy TLS Params TLS Config
-
-<a id="dynamic-proxy-https-proxy-tls-params-use-mtls"></a>
-
-### Dynamic Proxy HTTPS Proxy TLS Params Use mTLS
+`use_mtls` - (Optional) Clients TLS validation context. Validation context for downstream client TLS connections (`Block`).
 
 <a id="dynamic-proxy-sni-proxy"></a>
 
@@ -333,13 +233,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ### HTTP Proxy
 
-`enable_http` - (Optional) Empty. This can be used for messages where no values are needed. See [Enable HTTP](#http-proxy-enable-http) below.
+`enable_http` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `more_option` - (Optional) Advanced Options. This defines various options to define a route. See [More Option](#http-proxy-more-option) below.
-
-<a id="http-proxy-enable-http"></a>
-
-### HTTP Proxy Enable HTTP
 
 <a id="http-proxy-more-option"></a>
 
@@ -349,13 +245,13 @@ In addition to all arguments above, the following attributes are exported:
 
 `compression_params` - (Optional) Compression Parameters. Enables loadbalancer to compress dispatched data from an upstream service upon client request. The content is compressed and then sent to the client with the appropriate headers if either response and request allow. Only GZIP compression is supported. By default compression will be skipped when: A request does NOT contain accept-encoding header. A request includes accept-encoding header, but it does not contain “gzip” or “*”. A request includes accept-encoding. See [Compression Params](#http-proxy-more-option-compression-params) below.
 
-`custom_errors` - (Optional) Custom Error Responses. Map of integer error codes as keys and string values that can be used to provide custom HTTP pages for each error code. Key of the map can be either response code class or HTTP Error code. Response code classes for key is configured as follows 3 -- for 3xx response code class 4 -- for 4xx response code class 5 -- for 5xx response code class Value of the map is string which represents custom HTTP responses. Specific response code takes preference when both response code. See [Custom Errors](#http-proxy-more-option-custom-errors) below.
+`custom_errors` - (Optional) Custom Error Responses. Map of integer error codes as keys and string values that can be used to provide custom HTTP pages for each error code. Key of the map can be either response code class or HTTP Error code. Response code classes for key is configured as follows 3 -- for 3xx response code class 4 -- for 4xx response code class 5 -- for 5xx response code class Value of the map is string which represents custom HTTP responses. Specific response code takes preference when both response code (`Block`).
 
 `disable_default_error_pages` - (Optional) Disable Default Error Pages. Disable the use of default F5XC error pages (`Bool`).
 
-`disable_path_normalize` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Path Normalize](#http-proxy-more-option-disable-path-normalize) below.
+`disable_path_normalize` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`enable_path_normalize` - (Optional) Empty. This can be used for messages where no values are needed. See [Enable Path Normalize](#http-proxy-more-option-enable-path-normalize) below.
+`enable_path_normalize` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `idle_timeout` - (Optional) Idle Timeout. The amount of time that a stream can exist without upstream or downstream activity, in milliseconds. The stream is terminated with a HTTP 504 (Gateway Timeout) error code if no upstream response header has been received, otherwise the stream is reset (`Number`).
 
@@ -397,18 +293,6 @@ In addition to all arguments above, the following attributes are exported:
 
 `remove_accept_encoding_header` - (Optional) Remove Accept-Encoding Header. If true, removes accept-encoding from the request headers before dispatching it to the upstream so that responses do not get compressed before reaching the filter (`Bool`).
 
-<a id="http-proxy-more-option-custom-errors"></a>
-
-### HTTP Proxy More Option Custom Errors
-
-<a id="http-proxy-more-option-disable-path-normalize"></a>
-
-### HTTP Proxy More Option Disable Path Normalize
-
-<a id="http-proxy-more-option-enable-path-normalize"></a>
-
-### HTTP Proxy More Option Enable Path Normalize
-
 <a id="http-proxy-more-option-request-cookies-to-add"></a>
 
 ### HTTP Proxy More Option Request Cookies To Add
@@ -417,13 +301,9 @@ In addition to all arguments above, the following attributes are exported:
 
 `overwrite` - (Optional) Overwrite. Should the value be overwritten? If true, the value is overwritten to existing values. Default value is do not overwrite (`Bool`).
 
-`secret_value` - (Optional) Secret. SecretType is used in an object to indicate a sensitive/confidential field. See [Secret Value](#http-proxy-more-option-request-cookies-to-add-secret-value) below.
+`secret_value` - (Optional) Secret. SecretType is used in an object to indicate a sensitive/confidential field (`Block`).
 
 `value` - (Optional) Value. Value of the Cookie header (`String`).
-
-<a id="http-proxy-more-option-request-cookies-to-add-secret-value"></a>
-
-### HTTP Proxy More Option Request Cookies To Add Secret Value
 
 <a id="http-proxy-more-option-request-headers-to-add"></a>
 
@@ -433,13 +313,9 @@ In addition to all arguments above, the following attributes are exported:
 
 `name` - (Optional) Name. Name of the HTTP header (`String`).
 
-`secret_value` - (Optional) Secret. SecretType is used in an object to indicate a sensitive/confidential field. See [Secret Value](#http-proxy-more-option-request-headers-to-add-secret-value) below.
+`secret_value` - (Optional) Secret. SecretType is used in an object to indicate a sensitive/confidential field (`Block`).
 
 `value` - (Optional) Value. Value of the HTTP header (`String`).
-
-<a id="http-proxy-more-option-request-headers-to-add-secret-value"></a>
-
-### HTTP Proxy More Option Request Headers To Add Secret Value
 
 <a id="http-proxy-more-option-response-cookies-to-add"></a>
 
@@ -449,31 +325,31 @@ In addition to all arguments above, the following attributes are exported:
 
 `add_expiry` - (Optional) Configuration for add_expiry (`String`).
 
-`add_httponly` - (Optional) Empty. This can be used for messages where no values are needed. See [Add Httponly](#http-proxy-more-option-response-cookies-to-add-add-httponly) below.
+`add_httponly` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`add_partitioned` - (Optional) Empty. This can be used for messages where no values are needed. See [Add Partitioned](#http-proxy-more-option-response-cookies-to-add-add-partitioned) below.
+`add_partitioned` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `add_path` - (Optional) Configuration for add_path (`String`).
 
-`add_secure` - (Optional) Empty. This can be used for messages where no values are needed. See [Add Secure](#http-proxy-more-option-response-cookies-to-add-add-secure) below.
+`add_secure` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`ignore_domain` - (Optional) Empty. This can be used for messages where no values are needed. See [Ignore Domain](#http-proxy-more-option-response-cookies-to-add-ignore-domain) below.
+`ignore_domain` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`ignore_expiry` - (Optional) Empty. This can be used for messages where no values are needed. See [Ignore Expiry](#http-proxy-more-option-response-cookies-to-add-ignore-expiry) below.
+`ignore_expiry` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`ignore_httponly` - (Optional) Empty. This can be used for messages where no values are needed. See [Ignore Httponly](#http-proxy-more-option-response-cookies-to-add-ignore-httponly) below.
+`ignore_httponly` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`ignore_max_age` - (Optional) Empty. This can be used for messages where no values are needed. See [Ignore Max Age](#http-proxy-more-option-response-cookies-to-add-ignore-max-age) below.
+`ignore_max_age` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`ignore_partitioned` - (Optional) Empty. This can be used for messages where no values are needed. See [Ignore Partitioned](#http-proxy-more-option-response-cookies-to-add-ignore-partitioned) below.
+`ignore_partitioned` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`ignore_path` - (Optional) Empty. This can be used for messages where no values are needed. See [Ignore Path](#http-proxy-more-option-response-cookies-to-add-ignore-path) below.
+`ignore_path` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`ignore_samesite` - (Optional) Empty. This can be used for messages where no values are needed. See [Ignore Samesite](#http-proxy-more-option-response-cookies-to-add-ignore-samesite) below.
+`ignore_samesite` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`ignore_secure` - (Optional) Empty. This can be used for messages where no values are needed. See [Ignore Secure](#http-proxy-more-option-response-cookies-to-add-ignore-secure) below.
+`ignore_secure` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`ignore_value` - (Optional) Empty. This can be used for messages where no values are needed. See [Ignore Value](#http-proxy-more-option-response-cookies-to-add-ignore-value) below.
+`ignore_value` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `max_age_value` - (Optional) Add Max Age. Add max age attribute (`Number`).
 
@@ -481,79 +357,15 @@ In addition to all arguments above, the following attributes are exported:
 
 `overwrite` - (Optional) Overwrite. Should the value be overwritten? If true, the value is overwritten to existing values. Default value is do not overwrite (`Bool`).
 
-`samesite_lax` - (Optional) Empty. This can be used for messages where no values are needed. See [Samesite Lax](#http-proxy-more-option-response-cookies-to-add-samesite-lax) below.
+`samesite_lax` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`samesite_none` - (Optional) Empty. This can be used for messages where no values are needed. See [Samesite None](#http-proxy-more-option-response-cookies-to-add-samesite-none) below.
+`samesite_none` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`samesite_strict` - (Optional) Empty. This can be used for messages where no values are needed. See [Samesite Strict](#http-proxy-more-option-response-cookies-to-add-samesite-strict) below.
+`samesite_strict` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`secret_value` - (Optional) Secret. SecretType is used in an object to indicate a sensitive/confidential field. See [Secret Value](#http-proxy-more-option-response-cookies-to-add-secret-value) below.
+`secret_value` - (Optional) Secret. SecretType is used in an object to indicate a sensitive/confidential field (`Block`).
 
 `value` - (Optional) Value. Value of the Cookie header (`String`).
-
-<a id="http-proxy-more-option-response-cookies-to-add-add-httponly"></a>
-
-### HTTP Proxy More Option Response Cookies To Add Add Httponly
-
-<a id="http-proxy-more-option-response-cookies-to-add-add-partitioned"></a>
-
-### HTTP Proxy More Option Response Cookies To Add Add Partitioned
-
-<a id="http-proxy-more-option-response-cookies-to-add-add-secure"></a>
-
-### HTTP Proxy More Option Response Cookies To Add Add Secure
-
-<a id="http-proxy-more-option-response-cookies-to-add-ignore-domain"></a>
-
-### HTTP Proxy More Option Response Cookies To Add Ignore Domain
-
-<a id="http-proxy-more-option-response-cookies-to-add-ignore-expiry"></a>
-
-### HTTP Proxy More Option Response Cookies To Add Ignore Expiry
-
-<a id="http-proxy-more-option-response-cookies-to-add-ignore-httponly"></a>
-
-### HTTP Proxy More Option Response Cookies To Add Ignore Httponly
-
-<a id="http-proxy-more-option-response-cookies-to-add-ignore-max-age"></a>
-
-### HTTP Proxy More Option Response Cookies To Add Ignore Max Age
-
-<a id="http-proxy-more-option-response-cookies-to-add-ignore-partitioned"></a>
-
-### HTTP Proxy More Option Response Cookies To Add Ignore Partitioned
-
-<a id="http-proxy-more-option-response-cookies-to-add-ignore-path"></a>
-
-### HTTP Proxy More Option Response Cookies To Add Ignore Path
-
-<a id="http-proxy-more-option-response-cookies-to-add-ignore-samesite"></a>
-
-### HTTP Proxy More Option Response Cookies To Add Ignore Samesite
-
-<a id="http-proxy-more-option-response-cookies-to-add-ignore-secure"></a>
-
-### HTTP Proxy More Option Response Cookies To Add Ignore Secure
-
-<a id="http-proxy-more-option-response-cookies-to-add-ignore-value"></a>
-
-### HTTP Proxy More Option Response Cookies To Add Ignore Value
-
-<a id="http-proxy-more-option-response-cookies-to-add-samesite-lax"></a>
-
-### HTTP Proxy More Option Response Cookies To Add Samesite Lax
-
-<a id="http-proxy-more-option-response-cookies-to-add-samesite-none"></a>
-
-### HTTP Proxy More Option Response Cookies To Add Samesite None
-
-<a id="http-proxy-more-option-response-cookies-to-add-samesite-strict"></a>
-
-### HTTP Proxy More Option Response Cookies To Add Samesite Strict
-
-<a id="http-proxy-more-option-response-cookies-to-add-secret-value"></a>
-
-### HTTP Proxy More Option Response Cookies To Add Secret Value
 
 <a id="http-proxy-more-option-response-headers-to-add"></a>
 
@@ -563,29 +375,9 @@ In addition to all arguments above, the following attributes are exported:
 
 `name` - (Optional) Name. Name of the HTTP header (`String`).
 
-`secret_value` - (Optional) Secret. SecretType is used in an object to indicate a sensitive/confidential field. See [Secret Value](#http-proxy-more-option-response-headers-to-add-secret-value) below.
+`secret_value` - (Optional) Secret. SecretType is used in an object to indicate a sensitive/confidential field (`Block`).
 
 `value` - (Optional) Value. Value of the HTTP header (`String`).
-
-<a id="http-proxy-more-option-response-headers-to-add-secret-value"></a>
-
-### HTTP Proxy More Option Response Headers To Add Secret Value
-
-<a id="no-forward-proxy-policy"></a>
-
-### No Forward Proxy Policy
-
-<a id="no-interception"></a>
-
-### No Interception
-
-<a id="site-local-inside-network"></a>
-
-### Site Local Inside Network
-
-<a id="site-local-network"></a>
-
-### Site Local Network
 
 <a id="site-virtual-sites"></a>
 
@@ -601,7 +393,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `site` - (Optional) Site. This defines a reference to a CE site along with network type and an optional IP address where a load balancer could be advertised. See [Site](#site-virtual-sites-advertise-where-site) below.
 
-`use_default_port` - (Optional) Empty. This can be used for messages where no values are needed. See [Use Default Port](#site-virtual-sites-advertise-where-use-default-port) below.
+`use_default_port` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `virtual_site` - (Optional) Virtual Site. This defines a reference to a customer site virtual site along with network type where a load balancer could be advertised. See [Virtual Site](#site-virtual-sites-advertise-where-virtual-site) below.
 
@@ -613,15 +405,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `network` - (Optional) Site Network. This defines network types to be used on site All inside and outside networks. All inside and outside networks with internet VIP support. All inside networks. All outside networks. All outside networks with internet VIP support. vK8s service network. - SITE_NETWORK_IP_FABRIC: VER IP Fabric network for the site This Virtual network type is used for exposing virtual host on IP Fabric network on the VER site or for endpoint in IP Fabric network. Possible values are `SITE_NETWORK_INSIDE_AND_OUTSIDE`, `SITE_NETWORK_INSIDE`, `SITE_NETWORK_OUTSIDE`, `SITE_NETWORK_SERVICE`, `SITE_NETWORK_OUTSIDE_WITH_INTERNET_VIP`, `SITE_NETWORK_INSIDE_AND_OUTSIDE_WITH_INTERNET_VIP`, `SITE_NETWORK_IP_FABRIC`. Defaults to `SITE_NETWORK_INSIDE_AND_OUTSIDE` (`String`).
 
-`site` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Site](#site-virtual-sites-advertise-where-site-site) below.
-
-<a id="site-virtual-sites-advertise-where-site-site"></a>
-
-### Site Virtual Sites Advertise Where Site Site
-
-<a id="site-virtual-sites-advertise-where-use-default-port"></a>
-
-### Site Virtual Sites Advertise Where Use Default Port
+`site` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name (`Block`).
 
 <a id="site-virtual-sites-advertise-where-virtual-site"></a>
 
@@ -629,11 +413,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `network` - (Optional) Site Network. This defines network types to be used on site All inside and outside networks. All inside and outside networks with internet VIP support. All inside networks. All outside networks. All outside networks with internet VIP support. vK8s service network. - SITE_NETWORK_IP_FABRIC: VER IP Fabric network for the site This Virtual network type is used for exposing virtual host on IP Fabric network on the VER site or for endpoint in IP Fabric network. Possible values are `SITE_NETWORK_INSIDE_AND_OUTSIDE`, `SITE_NETWORK_INSIDE`, `SITE_NETWORK_OUTSIDE`, `SITE_NETWORK_SERVICE`, `SITE_NETWORK_OUTSIDE_WITH_INTERNET_VIP`, `SITE_NETWORK_INSIDE_AND_OUTSIDE_WITH_INTERNET_VIP`, `SITE_NETWORK_IP_FABRIC`. Defaults to `SITE_NETWORK_INSIDE_AND_OUTSIDE` (`String`).
 
-`virtual_site` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Virtual Site](#site-virtual-sites-advertise-where-virtual-site-virtual-site) below.
-
-<a id="site-virtual-sites-advertise-where-virtual-site-virtual-site"></a>
-
-### Site Virtual Sites Advertise Where Virtual Site Virtual Site
+`virtual_site` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name (`Block`).
 
 <a id="timeouts"></a>
 
@@ -653,15 +433,15 @@ In addition to all arguments above, the following attributes are exported:
 
 `custom_certificate` - (Optional) TLS Certificate. Handle to fetch certificate and key. See [Custom Certificate](#tls-intercept-custom-certificate) below.
 
-`enable_for_all_domains` - (Optional) Empty. This can be used for messages where no values are needed. See [Enable For All Domains](#tls-intercept-enable-for-all-domains) below.
+`enable_for_all_domains` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `policy` - (Optional) TLS Interception Policy. Policy to enable or disable TLS interception. See [Policy](#tls-intercept-policy) below.
 
 `trusted_ca_url` - (Optional) Custom Root CA Certificate. Custom Root CA Certificate for validating upstream server certificate (`String`).
 
-`volterra_certificate` - (Optional) Empty. This can be used for messages where no values are needed. See [Volterra Certificate](#tls-intercept-volterra-certificate) below.
+`volterra_certificate` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`volterra_trusted_ca` - (Optional) Empty. This can be used for messages where no values are needed. See [Volterra Trusted CA](#tls-intercept-volterra-trusted-ca) below.
+`volterra_trusted_ca` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="tls-intercept-custom-certificate"></a>
 
@@ -673,11 +453,11 @@ In addition to all arguments above, the following attributes are exported:
 
 `description` - (Optional) Configuration for description (`String`).
 
-`disable_ocsp_stapling` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable OCSP Stapling](#tls-intercept-custom-certificate-disable-ocsp-stapling) below.
+`disable_ocsp_stapling` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `private_key` - (Optional) Secret. SecretType is used in an object to indicate a sensitive/confidential field. See [Private Key](#tls-intercept-custom-certificate-private-key) below.
 
-`use_system_defaults` - (Optional) Empty. This can be used for messages where no values are needed. See [Use System Defaults](#tls-intercept-custom-certificate-use-system-defaults) below.
+`use_system_defaults` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="tls-intercept-custom-certificate-custom-hash-algorithms"></a>
 
@@ -685,33 +465,13 @@ In addition to all arguments above, the following attributes are exported:
 
 `hash_algorithms` - (Optional) Hash Algorithms. Ordered list of hash algorithms to be used (`List`).
 
-<a id="tls-intercept-custom-certificate-disable-ocsp-stapling"></a>
-
-### TLS Intercept Custom Certificate Disable OCSP Stapling
-
 <a id="tls-intercept-custom-certificate-private-key"></a>
 
 ### TLS Intercept Custom Certificate Private Key
 
-`blindfold_secret_info` - (Optional) Blindfold Secret. BlindfoldSecretInfoType specifies information about the Secret managed by F5XC Secret Management. See [Blindfold Secret Info](#tls-intercept-custom-certificate-private-key-blindfold-secret-info) below.
+`blindfold_secret_info` - (Optional) Blindfold Secret. BlindfoldSecretInfoType specifies information about the Secret managed by F5XC Secret Management (`Block`).
 
-`clear_secret_info` - (Optional) In-Clear Secret. ClearSecretInfoType specifies information about the Secret that is not encrypted. See [Clear Secret Info](#tls-intercept-custom-certificate-private-key-clear-secret-info) below.
-
-<a id="tls-intercept-custom-certificate-private-key-blindfold-secret-info"></a>
-
-### TLS Intercept Custom Certificate Private Key Blindfold Secret Info
-
-<a id="tls-intercept-custom-certificate-private-key-clear-secret-info"></a>
-
-### TLS Intercept Custom Certificate Private Key Clear Secret Info
-
-<a id="tls-intercept-custom-certificate-use-system-defaults"></a>
-
-### TLS Intercept Custom Certificate Use System Defaults
-
-<a id="tls-intercept-enable-for-all-domains"></a>
-
-### TLS Intercept Enable For All Domains
+`clear_secret_info` - (Optional) In-Clear Secret. ClearSecretInfoType specifies information about the Secret that is not encrypted (`Block`).
 
 <a id="tls-intercept-policy"></a>
 
@@ -723,31 +483,11 @@ In addition to all arguments above, the following attributes are exported:
 
 ### TLS Intercept Policy Interception Rules
 
-`disable_interception` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Interception](#tls-intercept-policy-interception-rules-disable-interception) below.
+`disable_interception` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`domain_match` - (Optional) Configuration for domain_match. See [Domain Match](#tls-intercept-policy-interception-rules-domain-match) below.
+`domain_match` - (Optional) Configuration for domain_match (`Block`).
 
-`enable_interception` - (Optional) Empty. This can be used for messages where no values are needed. See [Enable Interception](#tls-intercept-policy-interception-rules-enable-interception) below.
-
-<a id="tls-intercept-policy-interception-rules-disable-interception"></a>
-
-### TLS Intercept Policy Interception Rules Disable Interception
-
-<a id="tls-intercept-policy-interception-rules-domain-match"></a>
-
-### TLS Intercept Policy Interception Rules Domain Match
-
-<a id="tls-intercept-policy-interception-rules-enable-interception"></a>
-
-### TLS Intercept Policy Interception Rules Enable Interception
-
-<a id="tls-intercept-volterra-certificate"></a>
-
-### TLS Intercept Volterra Certificate
-
-<a id="tls-intercept-volterra-trusted-ca"></a>
-
-### TLS Intercept Volterra Trusted CA
+`enable_interception` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 ## Import
 

--- a/docs/resources/quota.md
+++ b/docs/resources/quota.md
@@ -62,11 +62,11 @@ resource "f5xc_quota" "example" {
 
 ### Spec Argument Reference
 
-`api_limits` - (Optional) API Limits. API Limits defines ratelimit parameters for an API at the stdlib service The key of the api_limits map is rpc FQN e.g. 'ves.io.schema.advertise_policy.API.Create'. See [API Limits](#api-limits) below for details.
+`api_limits` - (Optional) API Limits. API Limits defines ratelimit parameters for an API at the stdlib service The key of the api_limits map is rpc FQN e.g. 'ves.io.schema.advertise_policy.API.Create' (`Block`).
 
-`object_limits` - (Optional) Object Limits. Object Limits define maximum number of instances that can be present per object kind for the tenant The key of the object_limits map is object kind e.g. 'virtual_host'. See [Object Limits](#object-limits) below for details.
+`object_limits` - (Optional) Object Limits. Object Limits define maximum number of instances that can be present per object kind for the tenant The key of the object_limits map is object kind e.g. 'virtual_host' (`Block`).
 
-`resource_limits` - (Optional) Resource Limits. Resource Limits define maximum value of resources in the appropriate units that can be present. The key of the resource limits is the resource name. See [Resource Limits](#resource-limits) below for details.
+`resource_limits` - (Optional) Resource Limits. Resource Limits define maximum value of resources in the appropriate units that can be present. The key of the resource limits is the resource name (`Block`).
 
 `timeouts` - (Optional) See [Timeouts](#timeouts) below for details.
 
@@ -77,18 +77,6 @@ In addition to all arguments above, the following attributes are exported:
 `id` - (Optional) Unique identifier for the resource (`String`).
 
 ---
-
-<a id="api-limits"></a>
-
-### API Limits
-
-<a id="object-limits"></a>
-
-### Object Limits
-
-<a id="resource-limits"></a>
-
-### Resource Limits
 
 <a id="timeouts"></a>
 

--- a/docs/resources/rate_limiter.md
+++ b/docs/resources/rate_limiter.md
@@ -75,13 +75,13 @@ In addition to all arguments above, the following attributes are exported:
 
 `burst_multiplier` - (Optional) Burst Multiplier. The maximum burst of requests to accommodate, expressed as a multiple of the rate (`Number`).
 
-`disabled` - (Optional) Empty. This can be used for messages where no values are needed. See [Disabled](#limits-disabled) below.
+`disabled` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`leaky_bucket` - (Optional) Leaky Bucket Rate Limiter. Leaky-Bucket is the default rate limiter algorithm for F5. See [Leaky Bucket](#limits-leaky-bucket) below.
+`leaky_bucket` - (Optional) Leaky Bucket Rate Limiter. Leaky-Bucket is the default rate limiter algorithm for F5 (`Block`).
 
 `period_multiplier` - (Optional) Periods. This setting, combined with Per Period units, provides a duration (`Number`).
 
-`token_bucket` - (Optional) Token Bucket Rate Limiter. Token-Bucket is a rate limiter algorithm that is stricter with enforcing limits. See [Token Bucket](#limits-token-bucket) below.
+`token_bucket` - (Optional) Token Bucket Rate Limiter. Token-Bucket is a rate limiter algorithm that is stricter with enforcing limits (`Block`).
 
 `total_number` - (Optional) Number Of Requests. The total number of allowed requests per rate-limiting period (`Number`).
 
@@ -114,18 +114,6 @@ In addition to all arguments above, the following attributes are exported:
 ### Limits Action Block Seconds
 
 `duration` - (Optional) Duration (`Number`).
-
-<a id="limits-disabled"></a>
-
-### Limits Disabled
-
-<a id="limits-leaky-bucket"></a>
-
-### Limits Leaky Bucket
-
-<a id="limits-token-bucket"></a>
-
-### Limits Token Bucket
 
 <a id="timeouts"></a>
 

--- a/docs/resources/rate_limiter_policy.md
+++ b/docs/resources/rate_limiter_policy.md
@@ -60,7 +60,7 @@ resource "f5xc_rate_limiter_policy" "example" {
 
 > **Note:** One of the arguments from this list "any_server, server_name, server_name_matcher, server_selector" must be set.
 
-`any_server` - (Optional) Empty. This can be used for messages where no values are needed. See [Any Server](#any-server) below for details.
+`any_server` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `server_name` - (Optional) Server Name. The expected name of the server. The actual names for the server are extracted from the HTTP Host header and the name of the virtual_host for the request (`String`).
 
@@ -79,10 +79,6 @@ In addition to all arguments above, the following attributes are exported:
 `id` - (Optional) Unique identifier for the resource (`String`).
 
 ---
-
-<a id="any-server"></a>
-
-### Any Server
 
 <a id="rules"></a>
 
@@ -104,19 +100,19 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Rules Spec
 
-`any_asn` - (Optional) Empty. This can be used for messages where no values are needed. See [Any Asn](#rules-spec-any-asn) below.
+`any_asn` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`any_country` - (Optional) Empty. This can be used for messages where no values are needed. See [Any Country](#rules-spec-any-country) below.
+`any_country` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`any_ip` - (Optional) Empty. This can be used for messages where no values are needed. See [Any IP](#rules-spec-any-ip) below.
+`any_ip` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`apply_rate_limiter` - (Optional) Empty. This can be used for messages where no values are needed. See [Apply Rate Limiter](#rules-spec-apply-rate-limiter) below.
+`apply_rate_limiter` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `asn_list` - (Optional) ASN Match List. An unordered set of RFC 6793 defined 4-byte AS numbers that can be used to create allow or deny lists for use in network policy or service policy. It can be used to create the allow list only for DNS Load Balancer. See [Asn List](#rules-spec-asn-list) below.
 
 `asn_matcher` - (Optional) ASN Matcher. Match any AS number contained in the list of bgp_asn_sets. See [Asn Matcher](#rules-spec-asn-matcher) below.
 
-`bypass_rate_limiter` - (Optional) Empty. This can be used for messages where no values are needed. See [Bypass Rate Limiter](#rules-spec-bypass-rate-limiter) below.
+`bypass_rate_limiter` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `country_list` - (Optional) Country Codes List. List of Country Codes to match against. See [Country List](#rules-spec-country-list) below.
 
@@ -134,22 +130,6 @@ In addition to all arguments above, the following attributes are exported:
 
 `path` - (Optional) Path Matcher. A path matcher specifies multiple criteria for matching an HTTP path string. The match is considered successful if any of the criteria are satisfied. The set of supported match criteria includes a list of path prefixes, a list of exact path values and a list of regular expressions. See [Path](#rules-spec-path) below.
 
-<a id="rules-spec-any-asn"></a>
-
-### Rules Spec Any Asn
-
-<a id="rules-spec-any-country"></a>
-
-### Rules Spec Any Country
-
-<a id="rules-spec-any-ip"></a>
-
-### Rules Spec Any IP
-
-<a id="rules-spec-apply-rate-limiter"></a>
-
-### Rules Spec Apply Rate Limiter
-
 <a id="rules-spec-asn-list"></a>
 
 ### Rules Spec Asn List
@@ -160,15 +140,7 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Rules Spec Asn Matcher
 
-`asn_sets` - (Optional) BGP ASN Sets. A list of references to bgp_asn_set objects. See [Asn Sets](#rules-spec-asn-matcher-asn-sets) below.
-
-<a id="rules-spec-asn-matcher-asn-sets"></a>
-
-### Rules Spec Asn Matcher Asn Sets
-
-<a id="rules-spec-bypass-rate-limiter"></a>
-
-### Rules Spec Bypass Rate Limiter
+`asn_sets` - (Optional) BGP ASN Sets. A list of references to bgp_asn_set objects (`Block`).
 
 <a id="rules-spec-country-list"></a>
 
@@ -200,27 +172,15 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Rules Spec Headers
 
-`check_not_present` - (Optional) Empty. This can be used for messages where no values are needed. See [Check Not Present](#rules-spec-headers-check-not-present) below.
+`check_not_present` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`check_present` - (Optional) Empty. This can be used for messages where no values are needed. See [Check Present](#rules-spec-headers-check-present) below.
+`check_present` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `invert_matcher` - (Optional) Invert Header Matcher. Invert the match result (`Bool`).
 
-`item` - (Optional) Matcher. A matcher specifies multiple criteria for matching an input string. The match is considered successful if any of the criteria are satisfied. The set of supported match criteria includes a list of exact values and a list of regular expressions. See [Item](#rules-spec-headers-item) below.
+`item` - (Optional) Matcher. A matcher specifies multiple criteria for matching an input string. The match is considered successful if any of the criteria are satisfied. The set of supported match criteria includes a list of exact values and a list of regular expressions (`Block`).
 
 `name` - (Optional) Header Name. A case-insensitive HTTP header name (`String`).
-
-<a id="rules-spec-headers-check-not-present"></a>
-
-### Rules Spec Headers Check Not Present
-
-<a id="rules-spec-headers-check-present"></a>
-
-### Rules Spec Headers Check Present
-
-<a id="rules-spec-headers-item"></a>
-
-### Rules Spec Headers Item
 
 <a id="rules-spec-http-method"></a>
 
@@ -236,11 +196,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `invert_matcher` - (Optional) Invert IP Matcher. Invert the match result (`Bool`).
 
-`prefix_sets` - (Optional) IP Prefix Sets. A list of references to ip_prefix_set objects. See [Prefix Sets](#rules-spec-ip-matcher-prefix-sets) below.
-
-<a id="rules-spec-ip-matcher-prefix-sets"></a>
-
-### Rules Spec IP Matcher Prefix Sets
+`prefix_sets` - (Optional) IP Prefix Sets. A list of references to ip_prefix_set objects (`Block`).
 
 <a id="rules-spec-ip-prefix-list"></a>
 

--- a/docs/resources/registration.md
+++ b/docs/resources/registration.md
@@ -94,7 +94,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `instance_id` - (Optional) Instance ID. Instance id (assigned by infrastructure provider) (`String`).
 
-`interfaces` - (Optional) Interfaces. Machine interfaces present during registration time. See [Interfaces](#infra-interfaces) below.
+`interfaces` - (Optional) Interfaces. Machine interfaces present during registration time (`Block`).
 
 `internet_proxy` - (Optional) Internet Proxy Configuration. Proxy describes options for HTTP or HTTPS proxy configurations. See [Internet Proxy](#infra-internet-proxy) below.
 
@@ -202,11 +202,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `driver_version` - (Optional) Driver Version. GPU Driver Version (`String`).
 
-`gpu_device` - (Optional) GPU devices. List of GPU devices in server. See [GPU Device](#infra-hw-info-gpu-gpu-device) below.
-
-<a id="infra-hw-info-gpu-gpu-device"></a>
-
-### Infra Hw Info GPU GPU Device
+`gpu_device` - (Optional) GPU devices. List of GPU devices in server (`Block`).
 
 <a id="infra-hw-info-kernel"></a>
 
@@ -332,10 +328,6 @@ In addition to all arguments above, the following attributes are exported:
 
 `vendor_name` - (Optional) Vendor name. Vendor ID translated to name (if available) (`String`).
 
-<a id="infra-interfaces"></a>
-
-### Infra Interfaces
-
 <a id="infra-internet-proxy"></a>
 
 ### Infra Internet Proxy
@@ -364,9 +356,9 @@ In addition to all arguments above, the following attributes are exported:
 
 `cluster_type` - (Optional) Cluster Type (`String`).
 
-`default_os_version` - (Optional) Empty. This can be used for messages where no values are needed. See [Default OS Version](#passport-default-os-version) below.
+`default_os_version` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`default_sw_version` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Sw Version](#passport-default-sw-version) below.
+`default_sw_version` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `latitude` - (Optional) Latitude. Geographic location of this site (`Number`).
 
@@ -377,14 +369,6 @@ In addition to all arguments above, the following attributes are exported:
 `private_network_name` - (Optional) Private Network Name. Private Network name for private access connectivity to F5XC ADN. It is used for PrivateLink, CloudLink and L3VPN (`String`).
 
 `volterra_software_version` - (Optional) F5XC Software Version. F5XC Software Version is optional parameter, which allows to specify target SW version for particular site e.g. crt-20210329-1002 (`String`).
-
-<a id="passport-default-os-version"></a>
-
-### Passport Default OS Version
-
-<a id="passport-default-sw-version"></a>
-
-### Passport Default Sw Version
 
 <a id="timeouts"></a>
 

--- a/docs/resources/report_config.md
+++ b/docs/resources/report_config.md
@@ -108,7 +108,7 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Waap
 
-`current_namespace` - (Optional) Empty. This can be used for messages where no values are needed. See [Current Namespace](#waap-current-namespace) below.
+`current_namespace` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `daily` - (Optional) Report Frequency Daily. create report daily. See [Daily](#waap-daily) below.
 
@@ -117,10 +117,6 @@ In addition to all arguments above, the following attributes are exported:
 `namespaces` - (Optional) Namespaces. namespaces. See [Namespaces](#waap-namespaces) below.
 
 `weekly` - (Optional) Report Frequency Weekly. create report weekly. See [Weekly](#waap-weekly) below.
-
-<a id="waap-current-namespace"></a>
-
-### Waap Current Namespace
 
 <a id="waap-daily"></a>
 

--- a/docs/resources/route.md
+++ b/docs/resources/route.md
@@ -86,9 +86,9 @@ In addition to all arguments above, the following attributes are exported:
 
 `disable_location_add` - (Optional) Disable Location Addition. disables append of x-volterra-location = <RE-site-name> at route level, if it is configured at virtual-host level. This configuration is ignored on CE sites (`Bool`).
 
-`inherited_bot_defense_javascript_injection` - (Optional) Empty. This can be used for messages where no values are needed. See [Inherited Bot Defense Javascript Injection](#routes-inherited-bot-defense-javascript-injection) below.
+`inherited_bot_defense_javascript_injection` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`inherited_waf_exclusion` - (Optional) Empty. This can be used for messages where no values are needed. See [Inherited WAF Exclusion](#routes-inherited-waf-exclusion) below.
+`inherited_waf_exclusion` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `match` - (Optional) Match. route match condition. See [Match](#routes-match) below.
 
@@ -134,19 +134,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `javascript_url` - (Optional) URL. Please enter the full URL (include domain and path), or relative path (`String`).
 
-`tag_attributes` - (Optional) Tag Attributes. Add the tag attributes you want to include in your Javascript tag. See [Tag Attributes](#routes-bot-defense-javascript-injection-javascript-tags-tag-attributes) below.
-
-<a id="routes-bot-defense-javascript-injection-javascript-tags-tag-attributes"></a>
-
-### Routes Bot Defense Javascript Injection Javascript Tags Tag Attributes
-
-<a id="routes-inherited-bot-defense-javascript-injection"></a>
-
-### Routes Inherited Bot Defense Javascript Injection
-
-<a id="routes-inherited-waf-exclusion"></a>
-
-### Routes Inherited WAF Exclusion
+`tag_attributes` - (Optional) Tag Attributes. Add the tag attributes you want to include in your Javascript tag (`Block`).
 
 <a id="routes-match"></a>
 
@@ -180,15 +168,11 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Routes Match Incoming Port
 
-`no_port_match` - (Optional) Empty. This can be used for messages where no values are needed. See [No Port Match](#routes-match-incoming-port-no-port-match) below.
+`no_port_match` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `port` - (Optional) Port. Exact Port to match (`Number`).
 
 `port_ranges` - (Optional) Configuration for port_ranges (`String`).
-
-<a id="routes-match-incoming-port-no-port-match"></a>
-
-### Routes Match Incoming Port No Port Match
 
 <a id="routes-match-path"></a>
 
@@ -226,17 +210,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Routes Request Cookies To Add Secret Value
 
-`blindfold_secret_info` - (Optional) Blindfold Secret. BlindfoldSecretInfoType specifies information about the Secret managed by F5XC Secret Management. See [Blindfold Secret Info](#routes-request-cookies-to-add-secret-value-blindfold-secret-info) below.
+`blindfold_secret_info` - (Optional) Blindfold Secret. BlindfoldSecretInfoType specifies information about the Secret managed by F5XC Secret Management (`Block`).
 
-`clear_secret_info` - (Optional) In-Clear Secret. ClearSecretInfoType specifies information about the Secret that is not encrypted. See [Clear Secret Info](#routes-request-cookies-to-add-secret-value-clear-secret-info) below.
-
-<a id="routes-request-cookies-to-add-secret-value-blindfold-secret-info"></a>
-
-### Routes Request Cookies To Add Secret Value Blindfold Secret Info
-
-<a id="routes-request-cookies-to-add-secret-value-clear-secret-info"></a>
-
-### Routes Request Cookies To Add Secret Value Clear Secret Info
+`clear_secret_info` - (Optional) In-Clear Secret. ClearSecretInfoType specifies information about the Secret that is not encrypted (`Block`).
 
 <a id="routes-request-headers-to-add"></a>
 
@@ -254,17 +230,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Routes Request Headers To Add Secret Value
 
-`blindfold_secret_info` - (Optional) Blindfold Secret. BlindfoldSecretInfoType specifies information about the Secret managed by F5XC Secret Management. See [Blindfold Secret Info](#routes-request-headers-to-add-secret-value-blindfold-secret-info) below.
+`blindfold_secret_info` - (Optional) Blindfold Secret. BlindfoldSecretInfoType specifies information about the Secret managed by F5XC Secret Management (`Block`).
 
-`clear_secret_info` - (Optional) In-Clear Secret. ClearSecretInfoType specifies information about the Secret that is not encrypted. See [Clear Secret Info](#routes-request-headers-to-add-secret-value-clear-secret-info) below.
-
-<a id="routes-request-headers-to-add-secret-value-blindfold-secret-info"></a>
-
-### Routes Request Headers To Add Secret Value Blindfold Secret Info
-
-<a id="routes-request-headers-to-add-secret-value-clear-secret-info"></a>
-
-### Routes Request Headers To Add Secret Value Clear Secret Info
+`clear_secret_info` - (Optional) In-Clear Secret. ClearSecretInfoType specifies information about the Secret that is not encrypted (`Block`).
 
 <a id="routes-response-cookies-to-add"></a>
 
@@ -274,31 +242,31 @@ In addition to all arguments above, the following attributes are exported:
 
 `add_expiry` - (Optional) Configuration for add_expiry (`String`).
 
-`add_httponly` - (Optional) Empty. This can be used for messages where no values are needed. See [Add Httponly](#routes-response-cookies-to-add-add-httponly) below.
+`add_httponly` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`add_partitioned` - (Optional) Empty. This can be used for messages where no values are needed. See [Add Partitioned](#routes-response-cookies-to-add-add-partitioned) below.
+`add_partitioned` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `add_path` - (Optional) Configuration for add_path (`String`).
 
-`add_secure` - (Optional) Empty. This can be used for messages where no values are needed. See [Add Secure](#routes-response-cookies-to-add-add-secure) below.
+`add_secure` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`ignore_domain` - (Optional) Empty. This can be used for messages where no values are needed. See [Ignore Domain](#routes-response-cookies-to-add-ignore-domain) below.
+`ignore_domain` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`ignore_expiry` - (Optional) Empty. This can be used for messages where no values are needed. See [Ignore Expiry](#routes-response-cookies-to-add-ignore-expiry) below.
+`ignore_expiry` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`ignore_httponly` - (Optional) Empty. This can be used for messages where no values are needed. See [Ignore Httponly](#routes-response-cookies-to-add-ignore-httponly) below.
+`ignore_httponly` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`ignore_max_age` - (Optional) Empty. This can be used for messages where no values are needed. See [Ignore Max Age](#routes-response-cookies-to-add-ignore-max-age) below.
+`ignore_max_age` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`ignore_partitioned` - (Optional) Empty. This can be used for messages where no values are needed. See [Ignore Partitioned](#routes-response-cookies-to-add-ignore-partitioned) below.
+`ignore_partitioned` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`ignore_path` - (Optional) Empty. This can be used for messages where no values are needed. See [Ignore Path](#routes-response-cookies-to-add-ignore-path) below.
+`ignore_path` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`ignore_samesite` - (Optional) Empty. This can be used for messages where no values are needed. See [Ignore Samesite](#routes-response-cookies-to-add-ignore-samesite) below.
+`ignore_samesite` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`ignore_secure` - (Optional) Empty. This can be used for messages where no values are needed. See [Ignore Secure](#routes-response-cookies-to-add-ignore-secure) below.
+`ignore_secure` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`ignore_value` - (Optional) Empty. This can be used for messages where no values are needed. See [Ignore Value](#routes-response-cookies-to-add-ignore-value) below.
+`ignore_value` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `max_age_value` - (Optional) Add Max Age. Add max age attribute (`Number`).
 
@@ -306,91 +274,23 @@ In addition to all arguments above, the following attributes are exported:
 
 `overwrite` - (Optional) Overwrite. Should the value be overwritten? If true, the value is overwritten to existing values. Default value is do not overwrite (`Bool`).
 
-`samesite_lax` - (Optional) Empty. This can be used for messages where no values are needed. See [Samesite Lax](#routes-response-cookies-to-add-samesite-lax) below.
+`samesite_lax` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`samesite_none` - (Optional) Empty. This can be used for messages where no values are needed. See [Samesite None](#routes-response-cookies-to-add-samesite-none) below.
+`samesite_none` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`samesite_strict` - (Optional) Empty. This can be used for messages where no values are needed. See [Samesite Strict](#routes-response-cookies-to-add-samesite-strict) below.
+`samesite_strict` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `secret_value` - (Optional) Secret. SecretType is used in an object to indicate a sensitive/confidential field. See [Secret Value](#routes-response-cookies-to-add-secret-value) below.
 
 `value` - (Optional) Value. Value of the Cookie header (`String`).
 
-<a id="routes-response-cookies-to-add-add-httponly"></a>
-
-### Routes Response Cookies To Add Add Httponly
-
-<a id="routes-response-cookies-to-add-add-partitioned"></a>
-
-### Routes Response Cookies To Add Add Partitioned
-
-<a id="routes-response-cookies-to-add-add-secure"></a>
-
-### Routes Response Cookies To Add Add Secure
-
-<a id="routes-response-cookies-to-add-ignore-domain"></a>
-
-### Routes Response Cookies To Add Ignore Domain
-
-<a id="routes-response-cookies-to-add-ignore-expiry"></a>
-
-### Routes Response Cookies To Add Ignore Expiry
-
-<a id="routes-response-cookies-to-add-ignore-httponly"></a>
-
-### Routes Response Cookies To Add Ignore Httponly
-
-<a id="routes-response-cookies-to-add-ignore-max-age"></a>
-
-### Routes Response Cookies To Add Ignore Max Age
-
-<a id="routes-response-cookies-to-add-ignore-partitioned"></a>
-
-### Routes Response Cookies To Add Ignore Partitioned
-
-<a id="routes-response-cookies-to-add-ignore-path"></a>
-
-### Routes Response Cookies To Add Ignore Path
-
-<a id="routes-response-cookies-to-add-ignore-samesite"></a>
-
-### Routes Response Cookies To Add Ignore Samesite
-
-<a id="routes-response-cookies-to-add-ignore-secure"></a>
-
-### Routes Response Cookies To Add Ignore Secure
-
-<a id="routes-response-cookies-to-add-ignore-value"></a>
-
-### Routes Response Cookies To Add Ignore Value
-
-<a id="routes-response-cookies-to-add-samesite-lax"></a>
-
-### Routes Response Cookies To Add Samesite Lax
-
-<a id="routes-response-cookies-to-add-samesite-none"></a>
-
-### Routes Response Cookies To Add Samesite None
-
-<a id="routes-response-cookies-to-add-samesite-strict"></a>
-
-### Routes Response Cookies To Add Samesite Strict
-
 <a id="routes-response-cookies-to-add-secret-value"></a>
 
 ### Routes Response Cookies To Add Secret Value
 
-`blindfold_secret_info` - (Optional) Blindfold Secret. BlindfoldSecretInfoType specifies information about the Secret managed by F5XC Secret Management. See [Blindfold Secret Info](#routes-response-cookies-to-add-secret-value-blindfold-secret-info) below.
+`blindfold_secret_info` - (Optional) Blindfold Secret. BlindfoldSecretInfoType specifies information about the Secret managed by F5XC Secret Management (`Block`).
 
-`clear_secret_info` - (Optional) In-Clear Secret. ClearSecretInfoType specifies information about the Secret that is not encrypted. See [Clear Secret Info](#routes-response-cookies-to-add-secret-value-clear-secret-info) below.
-
-<a id="routes-response-cookies-to-add-secret-value-blindfold-secret-info"></a>
-
-### Routes Response Cookies To Add Secret Value Blindfold Secret Info
-
-<a id="routes-response-cookies-to-add-secret-value-clear-secret-info"></a>
-
-### Routes Response Cookies To Add Secret Value Clear Secret Info
+`clear_secret_info` - (Optional) In-Clear Secret. ClearSecretInfoType specifies information about the Secret that is not encrypted (`Block`).
 
 <a id="routes-response-headers-to-add"></a>
 
@@ -408,17 +308,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Routes Response Headers To Add Secret Value
 
-`blindfold_secret_info` - (Optional) Blindfold Secret. BlindfoldSecretInfoType specifies information about the Secret managed by F5XC Secret Management. See [Blindfold Secret Info](#routes-response-headers-to-add-secret-value-blindfold-secret-info) below.
+`blindfold_secret_info` - (Optional) Blindfold Secret. BlindfoldSecretInfoType specifies information about the Secret managed by F5XC Secret Management (`Block`).
 
-`clear_secret_info` - (Optional) In-Clear Secret. ClearSecretInfoType specifies information about the Secret that is not encrypted. See [Clear Secret Info](#routes-response-headers-to-add-secret-value-clear-secret-info) below.
-
-<a id="routes-response-headers-to-add-secret-value-blindfold-secret-info"></a>
-
-### Routes Response Headers To Add Secret Value Blindfold Secret Info
-
-<a id="routes-response-headers-to-add-secret-value-clear-secret-info"></a>
-
-### Routes Response Headers To Add Secret Value Clear Secret Info
+`clear_secret_info` - (Optional) In-Clear Secret. ClearSecretInfoType specifies information about the Secret that is not encrypted (`Block`).
 
 <a id="routes-route-destination"></a>
 
@@ -434,9 +326,9 @@ In addition to all arguments above, the following attributes are exported:
 
 `destinations` - (Optional) Destination Origin pools (clusters). When requests have to distributed among multiple upstream clusters, multiple destinations are configured, each having its own cluster and weight. Traffic is distributed among clusters based on the weight configured. destinations: - cluster: - kind: ves.io.vega.cfg.adc.cluster.Object uid: cluster-1 weight: 20 - cluster: - kind: ves.io.vega.cfg.adc.cluster.Object uid: cluster-2 weight: 30 - cluster: - kind: ves.io.vega.cfg.adc.cluster.Object uid: cluster-3 w. See [Destinations](#routes-route-destination-destinations) below.
 
-`do_not_retract_cluster` - (Optional) Empty. This can be used for messages where no values are needed. See [Do Not Retract Cluster](#routes-route-destination-do-not-retract-cluster) below.
+`do_not_retract_cluster` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`endpoint_subsets` - (Optional) Endpoint Subsets. Upstream cluster may be configured to divide its endpoints into subsets based on metadata attached to the endpoints. Routes may then specify the metadata that a endpoint must match in order to be selected by the load balancer Labels field of endpoint object's metadata is used for subset matching. For endpoint's which are discovered in K8S or Consul cluster, the label of the service is merged with endpoint's labels. In case of Consul, the label is derived from the 'Tag' field. See [Endpoint Subsets](#routes-route-destination-endpoint-subsets) below.
+`endpoint_subsets` - (Optional) Endpoint Subsets. Upstream cluster may be configured to divide its endpoints into subsets based on metadata attached to the endpoints. Routes may then specify the metadata that a endpoint must match in order to be selected by the load balancer Labels field of endpoint object's metadata is used for subset matching. For endpoint's which are discovered in K8S or Consul cluster, the label of the service is merged with endpoint's labels. In case of Consul, the label is derived from the 'Tag' field (`Block`).
 
 `hash_policy` - (Optional) Hash Policy. Specifies a list of hash policies to use for ring hash load balancing. Each hash policy is evaluated individually and the combined result is used to route the request. See [Hash Policy](#routes-route-destination-hash-policy) below.
 
@@ -452,7 +344,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `regex_rewrite` - (Optional) Regex Match Rewrite. RegexMatchRewrite describes how to match a string and then produce a new string using a regular expression and a substitution string. See [Regex Rewrite](#routes-route-destination-regex-rewrite) below.
 
-`retract_cluster` - (Optional) Empty. This can be used for messages where no values are needed. See [Retract Cluster](#routes-route-destination-retract-cluster) below.
+`retract_cluster` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `retry_policy` - (Optional) Retry Policy. Retry policy configuration for route destination. See [Retry Policy](#routes-route-destination-retry-policy) below.
 
@@ -494,57 +386,29 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Routes Route Destination CSRF Policy
 
-`all_load_balancer_domains` - (Optional) Empty. This can be used for messages where no values are needed. See [All Load Balancer Domains](#routes-route-destination-csrf-policy-all-load-balancer-domains) below.
+`all_load_balancer_domains` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`custom_domain_list` - (Optional) Domain name list. List of domain names used for Host header matching. See [Custom Domain List](#routes-route-destination-csrf-policy-custom-domain-list) below.
+`custom_domain_list` - (Optional) Domain name list. List of domain names used for Host header matching (`Block`).
 
-`disabled` - (Optional) Empty. This can be used for messages where no values are needed. See [Disabled](#routes-route-destination-csrf-policy-disabled) below.
-
-<a id="routes-route-destination-csrf-policy-all-load-balancer-domains"></a>
-
-### Routes Route Destination CSRF Policy All Load Balancer Domains
-
-<a id="routes-route-destination-csrf-policy-custom-domain-list"></a>
-
-### Routes Route Destination CSRF Policy Custom Domain List
-
-<a id="routes-route-destination-csrf-policy-disabled"></a>
-
-### Routes Route Destination CSRF Policy Disabled
+`disabled` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="routes-route-destination-destinations"></a>
 
 ### Routes Route Destination Destinations
 
-`cluster` - (Optional) Cluster. Indicates the upstream cluster to which the request should be sent. If the cluster does not exist ServiceUnavailable response will be sent. See [Cluster](#routes-route-destination-destinations-cluster) below.
+`cluster` - (Optional) Cluster. Indicates the upstream cluster to which the request should be sent. If the cluster does not exist ServiceUnavailable response will be sent (`Block`).
 
-`endpoint_subsets` - (Optional) Endpoint Subsets. Upstream cluster may be configured to divide its endpoints into subsets based on metadata attached to the endpoints. Routes may then specify the metadata that a endpoint must match in order to be selected by the load balancer Labels field of endpoint object's metadata is used for subset matching. For endpoints which are discovered in K8S or Consul cluster, the label of the service is merged with endpoint's labels. In case of Consul, the label is derived from the 'Tag' field. See [Endpoint Subsets](#routes-route-destination-destinations-endpoint-subsets) below.
+`endpoint_subsets` - (Optional) Endpoint Subsets. Upstream cluster may be configured to divide its endpoints into subsets based on metadata attached to the endpoints. Routes may then specify the metadata that a endpoint must match in order to be selected by the load balancer Labels field of endpoint object's metadata is used for subset matching. For endpoints which are discovered in K8S or Consul cluster, the label of the service is merged with endpoint's labels. In case of Consul, the label is derived from the 'Tag' field (`Block`).
 
 `priority` - (Optional) Priority. Priority of this cluster, valid only with multiple destinations are configured. Value of 0 will make the cluster as lowest priority upstream cluster Priority of 1 means highest priority and is considered active. When active cluster is not available, lower priority clusters are made active as per the increasing priority (`Number`).
 
 `weight` - (Optional) Weight. When requests have to distributed among multiple upstream clusters, multiple destinations are configured, each having its own cluster and weight. Traffic is distributed among clusters based on the weight configured. destinations: - cluster: - kind: ves.io.vega.cfg.adc.cluster.Object uid: cluster-1 weight: 20 - cluster: - kind: ves.io.vega.cfg.adc.cluster.Object uid: cluster-2 weight: 30 - cluster: - kind: ves.io.vega.cfg.adc.cluster.Object uid: cluster-3 weight: 10 This indicates that (`Number`).
 
-<a id="routes-route-destination-destinations-cluster"></a>
-
-### Routes Route Destination Destinations Cluster
-
-<a id="routes-route-destination-destinations-endpoint-subsets"></a>
-
-### Routes Route Destination Destinations Endpoint Subsets
-
-<a id="routes-route-destination-do-not-retract-cluster"></a>
-
-### Routes Route Destination Do Not Retract Cluster
-
-<a id="routes-route-destination-endpoint-subsets"></a>
-
-### Routes Route Destination Endpoint Subsets
-
 <a id="routes-route-destination-hash-policy"></a>
 
 ### Routes Route Destination Hash Policy
 
-`cookie` - (Optional) Hashing using Cookie. Two types of cookie affinity: 1. Passive. Takes a cookie that's present in the cookies header and hashes on its value. 2. Generated. Generates and sets a cookie with an expiration (TTL) on the first request from the client in its response to the client, based on the endpoint the request gets sent to. The client then presents this on the next and all subsequent requests. The hash of this is sufficient to ensure these requests get sent to the same endpoint. The cookie is g. See [Cookie](#routes-route-destination-hash-policy-cookie) below.
+`cookie` - (Optional) Hashing using Cookie. Two types of cookie affinity: 1. Passive. Takes a cookie that's present in the cookies header and hashes on its value. 2. Generated. Generates and sets a cookie with an expiration (TTL) on the first request from the client in its response to the client, based on the endpoint the request gets sent to. The client then presents this on the next and all subsequent requests. The hash of this is sufficient to ensure these requests get sent to the same endpoint. The cookie is g (`Block`).
 
 `header_name` - (Optional) Header Name. The name or key of the request header that will be used to obtain the hash key (`String`).
 
@@ -552,43 +416,23 @@ In addition to all arguments above, the following attributes are exported:
 
 `terminal` - (Optional) Terminal. Specify if its a terminal policy (`Bool`).
 
-<a id="routes-route-destination-hash-policy-cookie"></a>
-
-### Routes Route Destination Hash Policy Cookie
-
 <a id="routes-route-destination-mirror-policy"></a>
 
 ### Routes Route Destination Mirror Policy
 
-`cluster` - (Optional) Mirror Destination Cluster. Specifies the cluster to which the requests will be mirrored. The cluster object referred here must be present. See [Cluster](#routes-route-destination-mirror-policy-cluster) below.
+`cluster` - (Optional) Mirror Destination Cluster. Specifies the cluster to which the requests will be mirrored. The cluster object referred here must be present (`Block`).
 
-`percent` - (Optional) Fractional Percent. Fraction used where sampling percentages are needed. example sampled requests. See [Percent](#routes-route-destination-mirror-policy-percent) below.
-
-<a id="routes-route-destination-mirror-policy-cluster"></a>
-
-### Routes Route Destination Mirror Policy Cluster
-
-<a id="routes-route-destination-mirror-policy-percent"></a>
-
-### Routes Route Destination Mirror Policy Percent
+`percent` - (Optional) Fractional Percent. Fraction used where sampling percentages are needed. example sampled requests (`Block`).
 
 <a id="routes-route-destination-query-params"></a>
 
 ### Routes Route Destination Query Params
 
-`remove_all_params` - (Optional) Empty. This can be used for messages where no values are needed. See [Remove All Params](#routes-route-destination-query-params-remove-all-params) below.
+`remove_all_params` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `replace_params` - (Optional) Replace All Parameters (`String`).
 
-`retain_all_params` - (Optional) Empty. This can be used for messages where no values are needed. See [Retain All Params](#routes-route-destination-query-params-retain-all-params) below.
-
-<a id="routes-route-destination-query-params-remove-all-params"></a>
-
-### Routes Route Destination Query Params Remove All Params
-
-<a id="routes-route-destination-query-params-retain-all-params"></a>
-
-### Routes Route Destination Query Params Retain All Params
+`retain_all_params` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="routes-route-destination-regex-rewrite"></a>
 
@@ -598,15 +442,11 @@ In addition to all arguments above, the following attributes are exported:
 
 `substitution` - (Optional) Substitution. The string that should be substituted into matching portions of the subject string during a substitution operation to produce a new string (`String`).
 
-<a id="routes-route-destination-retract-cluster"></a>
-
-### Routes Route Destination Retract Cluster
-
 <a id="routes-route-destination-retry-policy"></a>
 
 ### Routes Route Destination Retry Policy
 
-`back_off` - (Optional) Retry BackOff Interval. Specifies parameters that control retry back off. See [Back Off](#routes-route-destination-retry-policy-back-off) below.
+`back_off` - (Optional) Retry BackOff Interval. Specifies parameters that control retry back off (`Block`).
 
 `num_retries` - (Optional) Number of Retries. Specifies the allowed number of retries. Defaults to 1. Retries can be done any number of times. An exponential back-off algorithm is used between each retry (`Number`).
 
@@ -615,10 +455,6 @@ In addition to all arguments above, the following attributes are exported:
 `retriable_status_codes` - (Optional) Status Code to Retry. HTTP status codes that should trigger a retry in addition to those specified by retry_on (`List`).
 
 `retry_condition` - (Optional) Retry Condition. Specifies the conditions under which retry takes place. Retries can be on different types of condition depending on application requirements. For example, network failure, all 5xx response codes, idempotent 4xx response codes, etc The possible values are '5xx' : Retry will be done if the upstream server responds with any 5xx response code, or does not respond at all (disconnect/reset/read timeout). 'gateway-error' : Retry will be done only if the upstream server responds with (`List`).
-
-<a id="routes-route-destination-retry-policy-back-off"></a>
-
-### Routes Route Destination Retry Policy Back Off
 
 <a id="routes-route-destination-spdy-config"></a>
 
@@ -652,21 +488,13 @@ In addition to all arguments above, the following attributes are exported:
 
 `proto_redirect` - (Optional) Protocol. swap protocol part of incoming URL in redirect URL The protocol can be swapped with either HTTP or HTTPS When incoming-proto option is specified, swapping of protocol is not done (`String`).
 
-`remove_all_params` - (Optional) Empty. This can be used for messages where no values are needed. See [Remove All Params](#routes-route-redirect-remove-all-params) below.
+`remove_all_params` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `replace_params` - (Optional) Replace All Parameters (`String`).
 
 `response_code` - (Optional) Response Code. The HTTP status code to use in the redirect response (`Number`).
 
-`retain_all_params` - (Optional) Empty. This can be used for messages where no values are needed. See [Retain All Params](#routes-route-redirect-retain-all-params) below.
-
-<a id="routes-route-redirect-remove-all-params"></a>
-
-### Routes Route Redirect Remove All Params
-
-<a id="routes-route-redirect-retain-all-params"></a>
-
-### Routes Route Redirect Retain All Params
+`retain_all_params` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="routes-service-policy"></a>
 
@@ -690,27 +518,15 @@ In addition to all arguments above, the following attributes are exported:
 
 `app_firewall` - (Optional) App Firewall Reference. A list of references to the app_firewall configuration objects. See [App Firewall](#routes-waf-type-app-firewall) below.
 
-`disable_waf` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable WAF](#routes-waf-type-disable-waf) below.
+`disable_waf` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`inherit_waf` - (Optional) Empty. This can be used for messages where no values are needed. See [Inherit WAF](#routes-waf-type-inherit-waf) below.
+`inherit_waf` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="routes-waf-type-app-firewall"></a>
 
 ### Routes WAF Type App Firewall
 
-`app_firewall` - (Optional) Application Firewall. References to an Application Firewall configuration object. See [App Firewall](#routes-waf-type-app-firewall-app-firewall) below.
-
-<a id="routes-waf-type-app-firewall-app-firewall"></a>
-
-### Routes WAF Type App Firewall App Firewall
-
-<a id="routes-waf-type-disable-waf"></a>
-
-### Routes WAF Type Disable WAF
-
-<a id="routes-waf-type-inherit-waf"></a>
-
-### Routes WAF Type Inherit WAF
+`app_firewall` - (Optional) Application Firewall. References to an Application Firewall configuration object (`Block`).
 
 <a id="timeouts"></a>
 

--- a/docs/resources/secret_management_access.md
+++ b/docs/resources/secret_management_access.md
@@ -106,33 +106,21 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Access Info REST Auth Info Basic Auth
 
-`password` - (Optional) Secret. SecretType is used in an object to indicate a sensitive/confidential field. See [Password](#access-info-rest-auth-info-basic-auth-password) below.
+`password` - (Optional) Secret. SecretType is used in an object to indicate a sensitive/confidential field (`Block`).
 
 `username` - (Optional) Username. The username to encode in Basic Auth scheme (`String`).
-
-<a id="access-info-rest-auth-info-basic-auth-password"></a>
-
-### Access Info REST Auth Info Basic Auth Password
 
 <a id="access-info-rest-auth-info-headers-auth"></a>
 
 ### Access Info REST Auth Info Headers Auth
 
-`headers` - (Optional) Headers. The set of authentication headers to pass in HTTP request. See [Headers](#access-info-rest-auth-info-headers-auth-headers) below.
-
-<a id="access-info-rest-auth-info-headers-auth-headers"></a>
-
-### Access Info REST Auth Info Headers Auth Headers
+`headers` - (Optional) Headers. The set of authentication headers to pass in HTTP request (`Block`).
 
 <a id="access-info-rest-auth-info-query-params-auth"></a>
 
 ### Access Info REST Auth Info Query Params Auth
 
-`query_params` - (Optional) Query Parameters. The set of authentication parameters to be passed as query parameters. See [Query Params](#access-info-rest-auth-info-query-params-auth-query-params) below.
-
-<a id="access-info-rest-auth-info-query-params-auth-query-params"></a>
-
-### Access Info REST Auth Info Query Params Auth Query Params
+`query_params` - (Optional) Query Parameters. The set of authentication parameters to be passed as query parameters (`Block`).
 
 <a id="access-info-tls-config"></a>
 
@@ -142,23 +130,23 @@ In addition to all arguments above, the following attributes are exported:
 
 `common_params` - (Optional) TLS Parameters. Information of different aspects for TLS authentication related to ciphers, certificates and trust store. See [Common Params](#access-info-tls-config-common-params) below.
 
-`default_session_key_caching` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Session Key Caching](#access-info-tls-config-default-session-key-caching) below.
+`default_session_key_caching` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`disable_session_key_caching` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Session Key Caching](#access-info-tls-config-disable-session-key-caching) below.
+`disable_session_key_caching` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`disable_sni` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Sni](#access-info-tls-config-disable-sni) below.
+`disable_sni` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `max_session_keys` - (Optional) Max Session Keys Cached. x-example:'25' Number of session keys that are cached (`Number`).
 
 `sni` - (Optional) SNI Value. SNI value to be used (`String`).
 
-`use_host_header_as_sni` - (Optional) Empty. This can be used for messages where no values are needed. See [Use Host Header As Sni](#access-info-tls-config-use-host-header-as-sni) below.
+`use_host_header_as_sni` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="access-info-tls-config-cert-params"></a>
 
 ### Access Info TLS Config Cert Params
 
-`certificates` - (Optional) Client Certificate. Client TLS Certificate required for mTLS authentication. See [Certificates](#access-info-tls-config-cert-params-certificates) below.
+`certificates` - (Optional) Client Certificate. Client TLS Certificate required for mTLS authentication (`Block`).
 
 `cipher_suites` - (Optional) Cipher Suites. The following list specifies the supported cipher suite TLS_AES_128_GCM_SHA256 TLS_AES_256_GCM_SHA384 TLS_CHACHA20_POLY1305_SHA256 TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384 TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256 TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256 TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA TLS_ECDHE_RSA_WITH_AES_128_CBC_ (`List`).
 
@@ -166,15 +154,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `minimum_protocol_version` - (Optional) TLS Protocol. TlsProtocol is enumeration of supported TLS versions F5 Distributed Cloud will choose the optimal TLS version. Possible values are `TLS_AUTO`, `TLSv1_0`, `TLSv1_1`, `TLSv1_2`, `TLSv1_3`. Defaults to `TLS_AUTO` (`String`).
 
-`validation_params` - (Optional) TLS Certificate Validation Parameters. This includes URL for a trust store, whether SAN verification is required and list of Subject Alt Names for verification. See [Validation Params](#access-info-tls-config-cert-params-validation-params) below.
-
-<a id="access-info-tls-config-cert-params-certificates"></a>
-
-### Access Info TLS Config Cert Params Certificates
-
-<a id="access-info-tls-config-cert-params-validation-params"></a>
-
-### Access Info TLS Config Cert Params Validation Params
+`validation_params` - (Optional) TLS Certificate Validation Parameters. This includes URL for a trust store, whether SAN verification is required and list of Subject Alt Names for verification (`Block`).
 
 <a id="access-info-tls-config-common-params"></a>
 
@@ -186,33 +166,9 @@ In addition to all arguments above, the following attributes are exported:
 
 `minimum_protocol_version` - (Optional) TLS Protocol. TlsProtocol is enumeration of supported TLS versions F5 Distributed Cloud will choose the optimal TLS version. Possible values are `TLS_AUTO`, `TLSv1_0`, `TLSv1_1`, `TLSv1_2`, `TLSv1_3`. Defaults to `TLS_AUTO` (`String`).
 
-`tls_certificates` - (Optional) TLS Certificates. Set of TLS certificates. See [TLS Certificates](#access-info-tls-config-common-params-tls-certificates) below.
+`tls_certificates` - (Optional) TLS Certificates. Set of TLS certificates (`Block`).
 
-`validation_params` - (Optional) TLS Certificate Validation Parameters. This includes URL for a trust store, whether SAN verification is required and list of Subject Alt Names for verification. See [Validation Params](#access-info-tls-config-common-params-validation-params) below.
-
-<a id="access-info-tls-config-common-params-tls-certificates"></a>
-
-### Access Info TLS Config Common Params TLS Certificates
-
-<a id="access-info-tls-config-common-params-validation-params"></a>
-
-### Access Info TLS Config Common Params Validation Params
-
-<a id="access-info-tls-config-default-session-key-caching"></a>
-
-### Access Info TLS Config Default Session Key Caching
-
-<a id="access-info-tls-config-disable-session-key-caching"></a>
-
-### Access Info TLS Config Disable Session Key Caching
-
-<a id="access-info-tls-config-disable-sni"></a>
-
-### Access Info TLS Config Disable Sni
-
-<a id="access-info-tls-config-use-host-header-as-sni"></a>
-
-### Access Info TLS Config Use Host Header As Sni
+`validation_params` - (Optional) TLS Certificate Validation Parameters. This includes URL for a trust store, whether SAN verification is required and list of Subject Alt Names for verification (`Block`).
 
 <a id="access-info-vault-auth-info"></a>
 
@@ -228,27 +184,15 @@ In addition to all arguments above, the following attributes are exported:
 
 `role_id` - (Optional) Role ID. role-id to be used for authentication (`String`).
 
-`secret_id` - (Optional) Secret. SecretType is used in an object to indicate a sensitive/confidential field. See [Secret Id](#access-info-vault-auth-info-app-role-auth-secret-id) below.
-
-<a id="access-info-vault-auth-info-app-role-auth-secret-id"></a>
-
-### Access Info Vault Auth Info App Role Auth Secret Id
+`secret_id` - (Optional) Secret. SecretType is used in an object to indicate a sensitive/confidential field (`Block`).
 
 <a id="access-info-vault-auth-info-token"></a>
 
 ### Access Info Vault Auth Info Token
 
-`blindfold_secret_info` - (Optional) Blindfold Secret. BlindfoldSecretInfoType specifies information about the Secret managed by F5XC Secret Management. See [Blindfold Secret Info](#access-info-vault-auth-info-token-blindfold-secret-info) below.
+`blindfold_secret_info` - (Optional) Blindfold Secret. BlindfoldSecretInfoType specifies information about the Secret managed by F5XC Secret Management (`Block`).
 
-`clear_secret_info` - (Optional) In-Clear Secret. ClearSecretInfoType specifies information about the Secret that is not encrypted. See [Clear Secret Info](#access-info-vault-auth-info-token-clear-secret-info) below.
-
-<a id="access-info-vault-auth-info-token-blindfold-secret-info"></a>
-
-### Access Info Vault Auth Info Token Blindfold Secret Info
-
-<a id="access-info-vault-auth-info-token-clear-secret-info"></a>
-
-### Access Info Vault Auth Info Token Clear Secret Info
+`clear_secret_info` - (Optional) In-Clear Secret. ClearSecretInfoType specifies information about the Secret that is not encrypted (`Block`).
 
 <a id="timeouts"></a>
 
@@ -276,21 +220,13 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Where Site
 
-`disable_internet_vip` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Internet VIP](#where-site-disable-internet-vip) below.
+`disable_internet_vip` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`enable_internet_vip` - (Optional) Empty. This can be used for messages where no values are needed. See [Enable Internet VIP](#where-site-enable-internet-vip) below.
+`enable_internet_vip` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `network_type` - (Optional) Virtual Network Type. Different types of virtual networks understood by the system Virtual-network of type VIRTUAL_NETWORK_SITE_LOCAL provides connectivity to public (outside) network. This is an insecure network and is connected to public internet via NAT Gateways/firwalls Virtual-network of this type is local to every site. Two virtual networks of this type on different sites are neither related nor connected. Constraints: There can be atmost one virtual network of this type in a given site... Possible values include `VIRTUAL_NETWORK_SITE_LOCAL`, `VIRTUAL_NETWORK_SITE_LOCAL_INSIDE`, `VIRTUAL_NETWORK_PER_SITE`, `VIRTUAL_NETWORK_PUBLIC`, `VIRTUAL_NETWORK_GLOBAL`, `VIRTUAL_NETWORK_SITE_SERVICE`, `VIRTUAL_NETWORK_VER_INTERNAL`, `VIRTUAL_NETWORK_SITE_LOCAL_INSIDE_OUTSIDE`, `VIRTUAL_NETWORK_IP_AUTO`, `VIRTUAL_NETWORK_VOLTADN_PRIVATE_NETWORK`, and others. Defaults to `VIRTUAL_NETWORK_SITE_LOCAL` (`String`).
 
 `ref` - (Optional) Reference. A site direct reference. See [Ref](#where-site-ref) below.
-
-<a id="where-site-disable-internet-vip"></a>
-
-### Where Site Disable Internet VIP
-
-<a id="where-site-enable-internet-vip"></a>
-
-### Where Site Enable Internet VIP
 
 <a id="where-site-ref"></a>
 
@@ -330,21 +266,13 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Where Virtual Site
 
-`disable_internet_vip` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Internet VIP](#where-virtual-site-disable-internet-vip) below.
+`disable_internet_vip` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`enable_internet_vip` - (Optional) Empty. This can be used for messages where no values are needed. See [Enable Internet VIP](#where-virtual-site-enable-internet-vip) below.
+`enable_internet_vip` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `network_type` - (Optional) Virtual Network Type. Different types of virtual networks understood by the system Virtual-network of type VIRTUAL_NETWORK_SITE_LOCAL provides connectivity to public (outside) network. This is an insecure network and is connected to public internet via NAT Gateways/firwalls Virtual-network of this type is local to every site. Two virtual networks of this type on different sites are neither related nor connected. Constraints: There can be atmost one virtual network of this type in a given site... Possible values include `VIRTUAL_NETWORK_SITE_LOCAL`, `VIRTUAL_NETWORK_SITE_LOCAL_INSIDE`, `VIRTUAL_NETWORK_PER_SITE`, `VIRTUAL_NETWORK_PUBLIC`, `VIRTUAL_NETWORK_GLOBAL`, `VIRTUAL_NETWORK_SITE_SERVICE`, `VIRTUAL_NETWORK_VER_INTERNAL`, `VIRTUAL_NETWORK_SITE_LOCAL_INSIDE_OUTSIDE`, `VIRTUAL_NETWORK_IP_AUTO`, `VIRTUAL_NETWORK_VOLTADN_PRIVATE_NETWORK`, and others. Defaults to `VIRTUAL_NETWORK_SITE_LOCAL` (`String`).
 
 `ref` - (Optional) Reference. A virtual_site direct reference. See [Ref](#where-virtual-site-ref) below.
-
-<a id="where-virtual-site-disable-internet-vip"></a>
-
-### Where Virtual Site Disable Internet VIP
-
-<a id="where-virtual-site-enable-internet-vip"></a>
-
-### Where Virtual Site Enable Internet VIP
 
 <a id="where-virtual-site-ref"></a>
 

--- a/docs/resources/secret_policy.md
+++ b/docs/resources/secret_policy.md
@@ -111,17 +111,9 @@ In addition to all arguments above, the following attributes are exported:
 
 `client_name` - (Optional) Client Name. The name of the client trying to access the secret. Name of the client will be extracted from client TLS certificate. This predicate evaluates to true if client name matches the configured name (`String`).
 
-`client_name_matcher` - (Optional) Matcher. A matcher specifies multiple criteria for matching an input string. The match is considered successful if any of the criteria are satisfied. The set of supported match criteria includes a list of exact values and a list of regular expressions. See [Client Name Matcher](#rule-list-rules-spec-client-name-matcher) below.
+`client_name_matcher` - (Optional) Matcher. A matcher specifies multiple criteria for matching an input string. The match is considered successful if any of the criteria are satisfied. The set of supported match criteria includes a list of exact values and a list of regular expressions (`Block`).
 
-`client_selector` - (Optional) Label Selector. This type can be used to establish a 'selector reference' from one object(called selector) to a set of other objects(called selectees) based on the value of expresssions. A label selector is a label query over a set of resources. An empty label selector matches all objects. A null label selector matches no objects. Label selector is immutable. expressions is a list of strings of label selection expression. Each string has ',' separated values which are 'AND' and all strings ar. See [Client Selector](#rule-list-rules-spec-client-selector) below.
-
-<a id="rule-list-rules-spec-client-name-matcher"></a>
-
-### Rule List Rules Spec Client Name Matcher
-
-<a id="rule-list-rules-spec-client-selector"></a>
-
-### Rule List Rules Spec Client Selector
+`client_selector` - (Optional) Label Selector. This type can be used to establish a 'selector reference' from one object(called selector) to a set of other objects(called selectees) based on the value of expresssions. A label selector is a label query over a set of resources. An empty label selector matches all objects. A null label selector matches no objects. Label selector is immutable. expressions is a list of strings of label selection expression. Each string has ',' separated values which are 'AND' and all strings ar (`Block`).
 
 <a id="timeouts"></a>
 

--- a/docs/resources/securemesh_site.md
+++ b/docs/resources/securemesh_site.md
@@ -75,13 +75,13 @@ resource "f5xc_securemesh_site" "example" {
 
 `blocked_services` - (Optional) Disable Node Local Services. Disable node local services on this site. Note: The chosen services will get disabled on all nodes in the site. See [Blocked Services](#blocked-services) below for details.
 
-`default_blocked_services` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Blocked Services](#default-blocked-services) below for details.
+`default_blocked_services` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 > **Note:** One of the arguments from this list "bond_device_list, no_bond_devices" must be set.
 
 `bond_device_list` - (Optional) Bond Devices List. List of bond devices for this fleet. See [Bond Device List](#bond-device-list) below for details.
 
-`no_bond_devices` - (Optional) Empty. This can be used for messages where no values are needed. See [No Bond Devices](#no-bond-devices) below for details.
+`no_bond_devices` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `coordinates` - (Optional) Site Coordinates. Coordinates of the site which provides the site physical location. See [Coordinates](#coordinates) below for details.
 
@@ -89,7 +89,7 @@ resource "f5xc_securemesh_site" "example" {
 
 `custom_network_config` - (Optional) SmsNetworkConfiguration. See [Custom Network Config](#custom-network-config) below for details.
 
-`default_network_config` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Network Config](#default-network-config) below for details.
+`default_network_config` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `kubernetes_upgrade_drain` - (Optional) Node by Node Upgrade. Specify how worker nodes within a site will be upgraded. See [Kubernetes Upgrade Drain](#kubernetes-upgrade-drain) below for details.
 
@@ -97,7 +97,7 @@ resource "f5xc_securemesh_site" "example" {
 
 `log_receiver` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Log Receiver](#log-receiver) below for details.
 
-`logs_streaming_disabled` - (Optional) Empty. This can be used for messages where no values are needed. See [Logs Streaming Disabled](#logs-streaming-disabled) below for details.
+`logs_streaming_disabled` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `master_node_configuration` - (Optional) Master Nodes. Configuration of master nodes. See [Master Node Configuration](#master-node-configuration) below for details.
 
@@ -133,25 +133,13 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Blocked Services Blocked Sevice
 
-`dns` - (Optional) Empty. This can be used for messages where no values are needed. See [DNS](#blocked-services-blocked-sevice-dns) below.
+`dns` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `network_type` - (Optional) Virtual Network Type. Different types of virtual networks understood by the system Virtual-network of type VIRTUAL_NETWORK_SITE_LOCAL provides connectivity to public (outside) network. This is an insecure network and is connected to public internet via NAT Gateways/firwalls Virtual-network of this type is local to every site. Two virtual networks of this type on different sites are neither related nor connected. Constraints: There can be atmost one virtual network of this type in a given site... Possible values include `VIRTUAL_NETWORK_SITE_LOCAL`, `VIRTUAL_NETWORK_SITE_LOCAL_INSIDE`, `VIRTUAL_NETWORK_PER_SITE`, `VIRTUAL_NETWORK_PUBLIC`, `VIRTUAL_NETWORK_GLOBAL`, `VIRTUAL_NETWORK_SITE_SERVICE`, `VIRTUAL_NETWORK_VER_INTERNAL`, `VIRTUAL_NETWORK_SITE_LOCAL_INSIDE_OUTSIDE`, `VIRTUAL_NETWORK_IP_AUTO`, `VIRTUAL_NETWORK_VOLTADN_PRIVATE_NETWORK`, and others. Defaults to `VIRTUAL_NETWORK_SITE_LOCAL` (`String`).
 
-`ssh` - (Optional) Empty. This can be used for messages where no values are needed. See [SSH](#blocked-services-blocked-sevice-ssh) below.
+`ssh` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`web_user_interface` - (Optional) Empty. This can be used for messages where no values are needed. See [Web User Interface](#blocked-services-blocked-sevice-web-user-interface) below.
-
-<a id="blocked-services-blocked-sevice-dns"></a>
-
-### Blocked Services Blocked Sevice DNS
-
-<a id="blocked-services-blocked-sevice-ssh"></a>
-
-### Blocked Services Blocked Sevice SSH
-
-<a id="blocked-services-blocked-sevice-web-user-interface"></a>
-
-### Blocked Services Blocked Sevice Web User Interface
+`web_user_interface` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="bond-device-list"></a>
 
@@ -163,7 +151,7 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Bond Device List Bond Devices
 
-`active_backup` - (Optional) Empty. This can be used for messages where no values are needed. See [Active Backup](#bond-device-list-bond-devices-active-backup) below.
+`active_backup` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `devices` - (Optional) Member Ethernet Devices. Ethernet devices that will make up this bond (`List`).
 
@@ -174,10 +162,6 @@ In addition to all arguments above, the following attributes are exported:
 `link_up_delay` - (Optional) Link Up Delay. Milliseconds wait before link is declared up (`Number`).
 
 `name` - (Optional) Bond Device Name. Name for the Bond. Ex 'bond0' (`String`).
-
-<a id="bond-device-list-bond-devices-active-backup"></a>
-
-### Bond Device List Bond Devices Active Backup
 
 <a id="bond-device-list-bond-devices-lacp"></a>
 
@@ -203,31 +187,31 @@ In addition to all arguments above, the following attributes are exported:
 
 `active_network_policies` - (Optional) Active Firewall Policies Type. List of firewall policy views. See [Active Network Policies](#custom-network-config-active-network-policies) below.
 
-`default_config` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Config](#custom-network-config-default-config) below.
+`default_config` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`default_interface_config` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Interface Config](#custom-network-config-default-interface-config) below.
+`default_interface_config` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`default_sli_config` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Sli Config](#custom-network-config-default-sli-config) below.
+`default_sli_config` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`forward_proxy_allow_all` - (Optional) Empty. This can be used for messages where no values are needed. See [Forward Proxy Allow All](#custom-network-config-forward-proxy-allow-all) below.
+`forward_proxy_allow_all` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `global_network_list` - (Optional) Global Network Connection List. List of global network connections. See [Global Network List](#custom-network-config-global-network-list) below.
 
 `interface_list` - (Optional) List of Interface. Configure network interfaces for this Secure Mesh site. See [Interface List](#custom-network-config-interface-list) below.
 
-`no_forward_proxy` - (Optional) Empty. This can be used for messages where no values are needed. See [No Forward Proxy](#custom-network-config-no-forward-proxy) below.
+`no_forward_proxy` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_global_network` - (Optional) Empty. This can be used for messages where no values are needed. See [No Global Network](#custom-network-config-no-global-network) below.
+`no_global_network` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_network_policy` - (Optional) Empty. This can be used for messages where no values are needed. See [No Network Policy](#custom-network-config-no-network-policy) below.
+`no_network_policy` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `sli_config` - (Optional) Site Local Network Configuration. Site local network configuration. See [Sli Config](#custom-network-config-sli-config) below.
 
 `slo_config` - (Optional) Site Local Network Configuration. Site local network configuration. See [Slo Config](#custom-network-config-slo-config) below.
 
-`sm_connection_public_ip` - (Optional) Empty. This can be used for messages where no values are needed. See [Sm Connection Public IP](#custom-network-config-sm-connection-public-ip) below.
+`sm_connection_public_ip` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`sm_connection_pvt_ip` - (Optional) Empty. This can be used for messages where no values are needed. See [Sm Connection Pvt IP](#custom-network-config-sm-connection-pvt-ip) below.
+`sm_connection_pvt_ip` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `tunnel_dead_timeout` - (Optional) Tunnel Dead Timeout (msec). Time interval, in millisec, within which any ipsec / SSL connection from the site going down is detected. When not set (== 0), a default value of 10000 msec will be used (`Number`).
 
@@ -281,22 +265,6 @@ In addition to all arguments above, the following attributes are exported:
 
 `tenant` - (Optional) Tenant. When a configuration object(e.g. virtual_host) refers to another(e.g route) then tenant will hold the referred object's(e.g. route's) tenant (`String`).
 
-<a id="custom-network-config-default-config"></a>
-
-### Custom Network Config Default Config
-
-<a id="custom-network-config-default-interface-config"></a>
-
-### Custom Network Config Default Interface Config
-
-<a id="custom-network-config-default-sli-config"></a>
-
-### Custom Network Config Default Sli Config
-
-<a id="custom-network-config-forward-proxy-allow-all"></a>
-
-### Custom Network Config Forward Proxy Allow All
-
 <a id="custom-network-config-global-network-list"></a>
 
 ### Custom Network Config Global Network List
@@ -307,17 +275,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Custom Network Config Global Network List Global Network Connections
 
-`sli_to_global_dr` - (Optional) Global Network. Global network reference for direct connection. See [Sli To Global DR](#custom-network-config-global-network-list-global-network-connections-sli-to-global-dr) below.
+`sli_to_global_dr` - (Optional) Global Network. Global network reference for direct connection (`Block`).
 
-`slo_to_global_dr` - (Optional) Global Network. Global network reference for direct connection. See [Slo To Global DR](#custom-network-config-global-network-list-global-network-connections-slo-to-global-dr) below.
-
-<a id="custom-network-config-global-network-list-global-network-connections-sli-to-global-dr"></a>
-
-### Custom Network Config Global Network List Global Network Connections Sli To Global DR
-
-<a id="custom-network-config-global-network-list-global-network-connections-slo-to-global-dr"></a>
-
-### Custom Network Config Global Network List Global Network Connections Slo To Global DR
+`slo_to_global_dr` - (Optional) Global Network. Global network reference for direct connection (`Block`).
 
 <a id="custom-network-config-interface-list"></a>
 
@@ -329,55 +289,19 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Custom Network Config Interface List Interfaces
 
-`dc_cluster_group_connectivity_interface_disabled` - (Optional) Empty. This can be used for messages where no values are needed. See [Dc Cluster Group Connectivity Interface Disabled](#custom-network-config-interface-list-interfaces-dc-cluster-group-connectivity-interface-disabled) below.
+`dc_cluster_group_connectivity_interface_disabled` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`dc_cluster_group_connectivity_interface_enabled` - (Optional) Empty. This can be used for messages where no values are needed. See [Dc Cluster Group Connectivity Interface Enabled](#custom-network-config-interface-list-interfaces-dc-cluster-group-connectivity-interface-enabled) below.
+`dc_cluster_group_connectivity_interface_enabled` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`dedicated_interface` - (Optional) Dedicated Interface. Dedicated Interface Configuration. See [Dedicated Interface](#custom-network-config-interface-list-interfaces-dedicated-interface) below.
+`dedicated_interface` - (Optional) Dedicated Interface. Dedicated Interface Configuration (`Block`).
 
-`dedicated_management_interface` - (Optional) Dedicated Management Interface. Dedicated Interface Configuration. See [Dedicated Management Interface](#custom-network-config-interface-list-interfaces-dedicated-management-interface) below.
+`dedicated_management_interface` - (Optional) Dedicated Management Interface. Dedicated Interface Configuration (`Block`).
 
 `description` - (Optional) Interface Description. Description for this Interface (`String`).
 
-`ethernet_interface` - (Optional) Ethernet Interface. Ethernet Interface Configuration. See [Ethernet Interface](#custom-network-config-interface-list-interfaces-ethernet-interface) below.
+`ethernet_interface` - (Optional) Ethernet Interface. Ethernet Interface Configuration (`Block`).
 
-`labels` - (Optional) Interface Labels. Add Labels for this Interface, these labels can be used in firewall policy. See [Labels](#custom-network-config-interface-list-interfaces-labels) below.
-
-<a id="custom-network-config-interface-list-interfaces-dc-cluster-group-connectivity-interface-disabled"></a>
-
-### Custom Network Config Interface List Interfaces Dc Cluster Group Connectivity Interface Disabled
-
-<a id="custom-network-config-interface-list-interfaces-dc-cluster-group-connectivity-interface-enabled"></a>
-
-### Custom Network Config Interface List Interfaces Dc Cluster Group Connectivity Interface Enabled
-
-<a id="custom-network-config-interface-list-interfaces-dedicated-interface"></a>
-
-### Custom Network Config Interface List Interfaces Dedicated Interface
-
-<a id="custom-network-config-interface-list-interfaces-dedicated-management-interface"></a>
-
-### Custom Network Config Interface List Interfaces Dedicated Management Interface
-
-<a id="custom-network-config-interface-list-interfaces-ethernet-interface"></a>
-
-### Custom Network Config Interface List Interfaces Ethernet Interface
-
-<a id="custom-network-config-interface-list-interfaces-labels"></a>
-
-### Custom Network Config Interface List Interfaces Labels
-
-<a id="custom-network-config-no-forward-proxy"></a>
-
-### Custom Network Config No Forward Proxy
-
-<a id="custom-network-config-no-global-network"></a>
-
-### Custom Network Config No Global Network
-
-<a id="custom-network-config-no-network-policy"></a>
-
-### Custom Network Config No Network Policy
+`labels` - (Optional) Interface Labels. Add Labels for this Interface, these labels can be used in firewall policy (`Block`).
 
 <a id="custom-network-config-sli-config"></a>
 
@@ -385,15 +309,15 @@ In addition to all arguments above, the following attributes are exported:
 
 `dc_cluster_group` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Dc Cluster Group](#custom-network-config-sli-config-dc-cluster-group) below.
 
-`labels` - (Optional) Network Labels. Add Labels for this network, these labels can be used in firewall policy. See [Labels](#custom-network-config-sli-config-labels) below.
+`labels` - (Optional) Network Labels. Add Labels for this network, these labels can be used in firewall policy (`Block`).
 
 `nameserver` - (Optional) DNS V4 Server. Optional DNS V4 server IP to be used for name resolution (`String`).
 
-`no_dc_cluster_group` - (Optional) Empty. This can be used for messages where no values are needed. See [No Dc Cluster Group](#custom-network-config-sli-config-no-dc-cluster-group) below.
+`no_dc_cluster_group` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_static_routes` - (Optional) Empty. This can be used for messages where no values are needed. See [No Static Routes](#custom-network-config-sli-config-no-static-routes) below.
+`no_static_routes` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_v6_static_routes` - (Optional) Empty. This can be used for messages where no values are needed. See [No V6 Static Routes](#custom-network-config-sli-config-no-v6-static-routes) below.
+`no_v6_static_routes` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `static_routes` - (Optional) Static Routes List. List of static routes. See [Static Routes](#custom-network-config-sli-config-static-routes) below.
 
@@ -411,41 +335,17 @@ In addition to all arguments above, the following attributes are exported:
 
 `tenant` - (Optional) Tenant. When a configuration object(e.g. virtual_host) refers to another(e.g route) then tenant will hold the referred object's(e.g. route's) tenant (`String`).
 
-<a id="custom-network-config-sli-config-labels"></a>
-
-### Custom Network Config Sli Config Labels
-
-<a id="custom-network-config-sli-config-no-dc-cluster-group"></a>
-
-### Custom Network Config Sli Config No Dc Cluster Group
-
-<a id="custom-network-config-sli-config-no-static-routes"></a>
-
-### Custom Network Config Sli Config No Static Routes
-
-<a id="custom-network-config-sli-config-no-v6-static-routes"></a>
-
-### Custom Network Config Sli Config No V6 Static Routes
-
 <a id="custom-network-config-sli-config-static-routes"></a>
 
 ### Custom Network Config Sli Config Static Routes
 
-`static_routes` - (Optional) Static Routes. List of static routes. See [Static Routes](#custom-network-config-sli-config-static-routes-static-routes) below.
-
-<a id="custom-network-config-sli-config-static-routes-static-routes"></a>
-
-### Custom Network Config Sli Config Static Routes Static Routes
+`static_routes` - (Optional) Static Routes. List of static routes (`Block`).
 
 <a id="custom-network-config-sli-config-static-v6-routes"></a>
 
 ### Custom Network Config Sli Config Static V6 Routes
 
-`static_routes` - (Optional) Static IPv6 Routes. List of IPv6 static routes. See [Static Routes](#custom-network-config-sli-config-static-v6-routes-static-routes) below.
-
-<a id="custom-network-config-sli-config-static-v6-routes-static-routes"></a>
-
-### Custom Network Config Sli Config Static V6 Routes Static Routes
+`static_routes` - (Optional) Static IPv6 Routes. List of IPv6 static routes (`Block`).
 
 <a id="custom-network-config-slo-config"></a>
 
@@ -453,15 +353,15 @@ In addition to all arguments above, the following attributes are exported:
 
 `dc_cluster_group` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Dc Cluster Group](#custom-network-config-slo-config-dc-cluster-group) below.
 
-`labels` - (Optional) Network Labels. Add Labels for this network, these labels can be used in firewall policy. See [Labels](#custom-network-config-slo-config-labels) below.
+`labels` - (Optional) Network Labels. Add Labels for this network, these labels can be used in firewall policy (`Block`).
 
 `nameserver` - (Optional) DNS V4 Server. Optional DNS V4 server IP to be used for name resolution (`String`).
 
-`no_dc_cluster_group` - (Optional) Empty. This can be used for messages where no values are needed. See [No Dc Cluster Group](#custom-network-config-slo-config-no-dc-cluster-group) below.
+`no_dc_cluster_group` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_static_routes` - (Optional) Empty. This can be used for messages where no values are needed. See [No Static Routes](#custom-network-config-slo-config-no-static-routes) below.
+`no_static_routes` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_v6_static_routes` - (Optional) Empty. This can be used for messages where no values are needed. See [No V6 Static Routes](#custom-network-config-slo-config-no-v6-static-routes) below.
+`no_v6_static_routes` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `static_routes` - (Optional) Static Routes List. List of static routes. See [Static Routes](#custom-network-config-slo-config-static-routes) below.
 
@@ -479,89 +379,37 @@ In addition to all arguments above, the following attributes are exported:
 
 `tenant` - (Optional) Tenant. When a configuration object(e.g. virtual_host) refers to another(e.g route) then tenant will hold the referred object's(e.g. route's) tenant (`String`).
 
-<a id="custom-network-config-slo-config-labels"></a>
-
-### Custom Network Config Slo Config Labels
-
-<a id="custom-network-config-slo-config-no-dc-cluster-group"></a>
-
-### Custom Network Config Slo Config No Dc Cluster Group
-
-<a id="custom-network-config-slo-config-no-static-routes"></a>
-
-### Custom Network Config Slo Config No Static Routes
-
-<a id="custom-network-config-slo-config-no-v6-static-routes"></a>
-
-### Custom Network Config Slo Config No V6 Static Routes
-
 <a id="custom-network-config-slo-config-static-routes"></a>
 
 ### Custom Network Config Slo Config Static Routes
 
-`static_routes` - (Optional) Static Routes. List of static routes. See [Static Routes](#custom-network-config-slo-config-static-routes-static-routes) below.
-
-<a id="custom-network-config-slo-config-static-routes-static-routes"></a>
-
-### Custom Network Config Slo Config Static Routes Static Routes
+`static_routes` - (Optional) Static Routes. List of static routes (`Block`).
 
 <a id="custom-network-config-slo-config-static-v6-routes"></a>
 
 ### Custom Network Config Slo Config Static V6 Routes
 
-`static_routes` - (Optional) Static IPv6 Routes. List of IPv6 static routes. See [Static Routes](#custom-network-config-slo-config-static-v6-routes-static-routes) below.
-
-<a id="custom-network-config-slo-config-static-v6-routes-static-routes"></a>
-
-### Custom Network Config Slo Config Static V6 Routes Static Routes
-
-<a id="custom-network-config-sm-connection-public-ip"></a>
-
-### Custom Network Config Sm Connection Public IP
-
-<a id="custom-network-config-sm-connection-pvt-ip"></a>
-
-### Custom Network Config Sm Connection Pvt IP
-
-<a id="default-blocked-services"></a>
-
-### Default Blocked Services
-
-<a id="default-network-config"></a>
-
-### Default Network Config
+`static_routes` - (Optional) Static IPv6 Routes. List of IPv6 static routes (`Block`).
 
 <a id="kubernetes-upgrade-drain"></a>
 
 ### Kubernetes Upgrade Drain
 
-`disable_upgrade_drain` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Upgrade Drain](#kubernetes-upgrade-drain-disable-upgrade-drain) below.
+`disable_upgrade_drain` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `enable_upgrade_drain` - (Optional) Enable Node by Node Upgrade. Specify batch upgrade settings for worker nodes within a site. See [Enable Upgrade Drain](#kubernetes-upgrade-drain-enable-upgrade-drain) below.
-
-<a id="kubernetes-upgrade-drain-disable-upgrade-drain"></a>
-
-### Kubernetes Upgrade Drain Disable Upgrade Drain
 
 <a id="kubernetes-upgrade-drain-enable-upgrade-drain"></a>
 
 ### Kubernetes Upgrade Drain Enable Upgrade Drain
 
-`disable_vega_upgrade_mode` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Vega Upgrade Mode](#kubernetes-upgrade-drain-enable-upgrade-drain-disable-vega-upgrade-mode) below.
+`disable_vega_upgrade_mode` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `drain_max_unavailable_node_count` - (Optional) Node Batch Size Count (`Number`).
 
 `drain_node_timeout` - (Optional) Upgrade Wait Time. Seconds to wait before initiating upgrade on the next set of nodes. Setting it to 0 will wait indefinitely for all services on nodes to be upgraded gracefully before proceeding to the next set of nodes. (Warning: It may block upgrade if services on a node cannot be gracefully upgraded. It is recommended to use the default value) (`Number`).
 
-`enable_vega_upgrade_mode` - (Optional) Empty. This can be used for messages where no values are needed. See [Enable Vega Upgrade Mode](#kubernetes-upgrade-drain-enable-upgrade-drain-enable-vega-upgrade-mode) below.
-
-<a id="kubernetes-upgrade-drain-enable-upgrade-drain-disable-vega-upgrade-mode"></a>
-
-### Kubernetes Upgrade Drain Enable Upgrade Drain Disable Vega Upgrade Mode
-
-<a id="kubernetes-upgrade-drain-enable-upgrade-drain-enable-vega-upgrade-mode"></a>
-
-### Kubernetes Upgrade Drain Enable Upgrade Drain Enable Vega Upgrade Mode
+`enable_vega_upgrade_mode` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="log-receiver"></a>
 
@@ -573,10 +421,6 @@ In addition to all arguments above, the following attributes are exported:
 
 `tenant` - (Optional) Tenant. When a configuration object(e.g. virtual_host) refers to another(e.g route) then tenant will hold the referred object's(e.g. route's) tenant (`String`).
 
-<a id="logs-streaming-disabled"></a>
-
-### Logs Streaming Disabled
-
 <a id="master-node-configuration"></a>
 
 ### Master Node Configuration
@@ -585,37 +429,21 @@ In addition to all arguments above, the following attributes are exported:
 
 `public_ip` - (Optional) Public IP. IP Address of the master node. This IP will be used when other sites connect via Site Mesh Group (`String`).
 
-<a id="no-bond-devices"></a>
-
-### No Bond Devices
-
 <a id="offline-survivability-mode"></a>
 
 ### Offline Survivability Mode
 
-`enable_offline_survivability_mode` - (Optional) Empty. This can be used for messages where no values are needed. See [Enable Offline Survivability Mode](#offline-survivability-mode-enable-offline-survivability-mode) below.
+`enable_offline_survivability_mode` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_offline_survivability_mode` - (Optional) Empty. This can be used for messages where no values are needed. See [No Offline Survivability Mode](#offline-survivability-mode-no-offline-survivability-mode) below.
-
-<a id="offline-survivability-mode-enable-offline-survivability-mode"></a>
-
-### Offline Survivability Mode Enable Offline Survivability Mode
-
-<a id="offline-survivability-mode-no-offline-survivability-mode"></a>
-
-### Offline Survivability Mode No Offline Survivability Mode
+`no_offline_survivability_mode` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="os"></a>
 
 ### OS
 
-`default_os_version` - (Optional) Empty. This can be used for messages where no values are needed. See [Default OS Version](#os-default-os-version) below.
+`default_os_version` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `operating_system_version` - (Optional) Operating System Version. Specify a OS version to be used e.g. 9.2024.6 (`String`).
-
-<a id="os-default-os-version"></a>
-
-### OS Default OS Version
 
 <a id="performance-enhancement-mode"></a>
 
@@ -623,39 +451,23 @@ In addition to all arguments above, the following attributes are exported:
 
 `perf_mode_l3_enhanced` - (Optional) L3 Mode Enhanced Performance. x-required L3 enhanced performance mode options. See [Perf Mode L3 Enhanced](#performance-enhancement-mode-perf-mode-l3-enhanced) below.
 
-`perf_mode_l7_enhanced` - (Optional) Empty. This can be used for messages where no values are needed. See [Perf Mode L7 Enhanced](#performance-enhancement-mode-perf-mode-l7-enhanced) below.
+`perf_mode_l7_enhanced` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="performance-enhancement-mode-perf-mode-l3-enhanced"></a>
 
 ### Performance Enhancement Mode Perf Mode L3 Enhanced
 
-`jumbo` - (Optional) Empty. This can be used for messages where no values are needed. See [Jumbo](#performance-enhancement-mode-perf-mode-l3-enhanced-jumbo) below.
+`jumbo` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_jumbo` - (Optional) Empty. This can be used for messages where no values are needed. See [No Jumbo](#performance-enhancement-mode-perf-mode-l3-enhanced-no-jumbo) below.
-
-<a id="performance-enhancement-mode-perf-mode-l3-enhanced-jumbo"></a>
-
-### Performance Enhancement Mode Perf Mode L3 Enhanced Jumbo
-
-<a id="performance-enhancement-mode-perf-mode-l3-enhanced-no-jumbo"></a>
-
-### Performance Enhancement Mode Perf Mode L3 Enhanced No Jumbo
-
-<a id="performance-enhancement-mode-perf-mode-l7-enhanced"></a>
-
-### Performance Enhancement Mode Perf Mode L7 Enhanced
+`no_jumbo` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="sw"></a>
 
 ### Sw
 
-`default_sw_version` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Sw Version](#sw-default-sw-version) below.
+`default_sw_version` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `volterra_software_version` - (Optional) F5XC Software Version. Specify a F5XC Software Version to be used e.g. crt-20210329-1002 (`String`).
-
-<a id="sw-default-sw-version"></a>
-
-### Sw Default Sw Version
 
 <a id="timeouts"></a>
 

--- a/docs/resources/securemesh_site_v2.md
+++ b/docs/resources/securemesh_site_v2.md
@@ -66,13 +66,13 @@ resource "f5xc_securemesh_site_v2" "example" {
 
 `active_enhanced_firewall_policies` - (Optional) Active Enhanced Network Policies Type. List of Enhanced Firewall Policies These policies use session-based rules and provide all options available under firewall policies with an additional option for service insertion. See [Active Enhanced Firewall Policies](#active-enhanced-firewall-policies) below for details.
 
-`no_network_policy` - (Optional) Empty. This can be used for messages where no values are needed. See [No Network Policy](#no-network-policy) below for details.
+`no_network_policy` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 > **Note:** One of the arguments from this list "active_forward_proxy_policies, no_forward_proxy" must be set.
 
 `active_forward_proxy_policies` - (Optional) Active Forward Proxy Policies Type. Ordered List of Forward Proxy Policies active. See [Active Forward Proxy Policies](#active-forward-proxy-policies) below for details.
 
-`no_forward_proxy` - (Optional) Empty. This can be used for messages where no values are needed. See [No Forward Proxy](#no-forward-proxy) below for details.
+`no_forward_proxy` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `admin_user_credentials` - (Optional) Admin User Credentials. Setup user credentials to manage access to nodes belonging to the site. When configured, 'admin' user will be setup and customers can access these nodes via either the node local WebUI or via SSH to access shell/CLI Ensure 'Node Local Services' are enabled to allow for required access. See [Admin User Credentials](#admin-user-credentials) below for details.
 
@@ -100,7 +100,7 @@ resource "f5xc_securemesh_site_v2" "example" {
 
 > **Note:** One of the arguments from this list "block_all_services, blocked_services" must be set.
 
-`block_all_services` - (Optional) Empty. This can be used for messages where no values are needed. See [Block All Services](#block-all-services) below for details.
+`block_all_services` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `blocked_services` - (Optional) Disable Node Local Services. Disable node local services on this site. Note: The chosen services will get disabled on all nodes in the site. See [Blocked Services](#blocked-services) below for details.
 
@@ -108,39 +108,39 @@ resource "f5xc_securemesh_site_v2" "example" {
 
 `custom_proxy` - (Optional) Custom Enterprise Proxy. Custom Enterprise Proxy. See [Custom Proxy](#custom-proxy) below for details.
 
-`f5_proxy` - (Optional) Empty. This can be used for messages where no values are needed. See [F5 Proxy](#f5-proxy) below for details.
+`f5_proxy` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 > **Note:** One of the arguments from this list "custom_proxy_bypass, no_proxy_bypass" must be set.
 
 `custom_proxy_bypass` - (Optional) Proxy Bypass. List of domains to bypass the proxy. See [Custom Proxy Bypass](#custom-proxy-bypass) below for details.
 
-`no_proxy_bypass` - (Optional) Empty. This can be used for messages where no values are needed. See [No Proxy Bypass](#no-proxy-bypass) below for details.
+`no_proxy_bypass` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 > **Note:** One of the arguments from this list "dc_cluster_group_sli, no_s2s_connectivity_sli" must be set.
 
 `dc_cluster_group_sli` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Dc Cluster Group Sli](#dc-cluster-group-sli) below for details.
 
-`no_s2s_connectivity_sli` - (Optional) Empty. This can be used for messages where no values are needed. See [No S2s Connectivity Sli](#no-s2s-connectivity-sli) below for details.
+`no_s2s_connectivity_sli` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 > **Note:** One of the arguments from this list "dc_cluster_group_slo, no_s2s_connectivity_slo, site_mesh_group_on_slo" must be set.
 
 `dc_cluster_group_slo` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Dc Cluster Group Slo](#dc-cluster-group-slo) below for details.
 
-`no_s2s_connectivity_slo` - (Optional) Empty. This can be used for messages where no values are needed. See [No S2s Connectivity Slo](#no-s2s-connectivity-slo) below for details.
+`no_s2s_connectivity_slo` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `site_mesh_group_on_slo` - (Optional) Site Mesh Group Type. Select how the site mesh group will be connected. By default, public IPs of the control nodes of the site will be used. See [Site Mesh Group On Slo](#site-mesh-group-on-slo) below for details.
 
 > **Note:** One of the arguments from this list "disable_ha, enable_ha" must be set.
 
-`disable_ha` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable HA](#disable-ha) below for details.
+`disable_ha` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`enable_ha` - (Optional) Empty. This can be used for messages where no values are needed. See [Enable HA](#enable-ha) below for details.
+`enable_ha` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 > **Note:** One of the arguments from this list "disable_url_categorization, enable_url_categorization" must be set.
 
-`disable_url_categorization` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable URL Categorization](#disable-url-categorization) below for details.
+`disable_url_categorization` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`enable_url_categorization` - (Optional) Empty. This can be used for messages where no values are needed. See [Enable URL Categorization](#enable-url-categorization) below for details.
+`enable_url_categorization` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `dns_ntp_config` - (Optional) DNS & NTP Servers Settings. Specify DNS and NTP servers that will be used by the nodes in this Customer Edge site. See [DNS NTP Config](#dns-ntp-config) below for details.
 
@@ -152,7 +152,7 @@ resource "f5xc_securemesh_site_v2" "example" {
 
 `log_receiver` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Log Receiver](#log-receiver) below for details.
 
-`logs_streaming_disabled` - (Optional) Empty. This can be used for messages where no values are needed. See [Logs Streaming Disabled](#logs-streaming-disabled) below for details.
+`logs_streaming_disabled` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `offline_survivability_mode` - (Optional) Offline Survivability Mode. Offline Survivability allows the Site to continue functioning normally without traffic loss during periods of connectivity loss to the Regional Edge (RE) or the Global Controller (GC). When this feature is enabled, a site can continue to function as is with existing configuration for upto 7 days, even when the site is offline. The certificates needed to keep the services running on this site are signed using a local CA. Secrets would also be cached locally to handl. See [Offline Survivability Mode](#offline-survivability-mode) below for details.
 
@@ -262,15 +262,11 @@ In addition to all arguments above, the following attributes are exported:
 
 `hostname` - (Optional) Hostname. Hostname for this Node (`String`).
 
-`interface_list` - (Optional) Interfaces. Manage interfaces belonging to this node. See [Interface List](#aws-not-managed-node-list-interface-list) below.
+`interface_list` - (Optional) Interfaces. Manage interfaces belonging to this node (`Block`).
 
 `public_ip` - (Optional) Public IP. Public IP for this Node (`String`).
 
 `type` - (Optional) Type. Type for this Node, can be Control or Worker (`String`).
-
-<a id="aws-not-managed-node-list-interface-list"></a>
-
-### AWS Not Managed Node List Interface List
 
 <a id="azure"></a>
 
@@ -290,15 +286,11 @@ In addition to all arguments above, the following attributes are exported:
 
 `hostname` - (Optional) Hostname. Hostname for this Node (`String`).
 
-`interface_list` - (Optional) Interfaces. Manage interfaces belonging to this node. See [Interface List](#azure-not-managed-node-list-interface-list) below.
+`interface_list` - (Optional) Interfaces. Manage interfaces belonging to this node (`Block`).
 
 `public_ip` - (Optional) Public IP. Public IP for this Node (`String`).
 
 `type` - (Optional) Type. Type for this Node, can be Control or Worker (`String`).
-
-<a id="azure-not-managed-node-list-interface-list"></a>
-
-### Azure Not Managed Node List Interface List
 
 <a id="baremetal"></a>
 
@@ -318,19 +310,11 @@ In addition to all arguments above, the following attributes are exported:
 
 `hostname` - (Optional) Hostname. Hostname for this Node (`String`).
 
-`interface_list` - (Optional) Interfaces. Manage interfaces belonging to this node. See [Interface List](#baremetal-not-managed-node-list-interface-list) below.
+`interface_list` - (Optional) Interfaces. Manage interfaces belonging to this node (`Block`).
 
 `public_ip` - (Optional) Public IP. Public IP for this Node (`String`).
 
 `type` - (Optional) Type. Type for this Node, can be Control or Worker (`String`).
-
-<a id="baremetal-not-managed-node-list-interface-list"></a>
-
-### Baremetal Not Managed Node List Interface List
-
-<a id="block-all-services"></a>
-
-### Block All Services
 
 <a id="blocked-services"></a>
 
@@ -342,33 +326,21 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Blocked Services Blocked Sevice
 
-`dns` - (Optional) Empty. This can be used for messages where no values are needed. See [DNS](#blocked-services-blocked-sevice-dns) below.
+`dns` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `network_type` - (Optional) Virtual Network Type. Different types of virtual networks understood by the system Virtual-network of type VIRTUAL_NETWORK_SITE_LOCAL provides connectivity to public (outside) network. This is an insecure network and is connected to public internet via NAT Gateways/firwalls Virtual-network of this type is local to every site. Two virtual networks of this type on different sites are neither related nor connected. Constraints: There can be atmost one virtual network of this type in a given site... Possible values include `VIRTUAL_NETWORK_SITE_LOCAL`, `VIRTUAL_NETWORK_SITE_LOCAL_INSIDE`, `VIRTUAL_NETWORK_PER_SITE`, `VIRTUAL_NETWORK_PUBLIC`, `VIRTUAL_NETWORK_GLOBAL`, `VIRTUAL_NETWORK_SITE_SERVICE`, `VIRTUAL_NETWORK_VER_INTERNAL`, `VIRTUAL_NETWORK_SITE_LOCAL_INSIDE_OUTSIDE`, `VIRTUAL_NETWORK_IP_AUTO`, `VIRTUAL_NETWORK_VOLTADN_PRIVATE_NETWORK`, and others. Defaults to `VIRTUAL_NETWORK_SITE_LOCAL` (`String`).
 
-`ssh` - (Optional) Empty. This can be used for messages where no values are needed. See [SSH](#blocked-services-blocked-sevice-ssh) below.
+`ssh` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`web_user_interface` - (Optional) Empty. This can be used for messages where no values are needed. See [Web User Interface](#blocked-services-blocked-sevice-web-user-interface) below.
-
-<a id="blocked-services-blocked-sevice-dns"></a>
-
-### Blocked Services Blocked Sevice DNS
-
-<a id="blocked-services-blocked-sevice-ssh"></a>
-
-### Blocked Services Blocked Sevice SSH
-
-<a id="blocked-services-blocked-sevice-web-user-interface"></a>
-
-### Blocked Services Blocked Sevice Web User Interface
+`web_user_interface` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="custom-proxy"></a>
 
 ### Custom Proxy
 
-`disable_re_tunnel` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable RE Tunnel](#custom-proxy-disable-re-tunnel) below.
+`disable_re_tunnel` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`enable_re_tunnel` - (Optional) Empty. This can be used for messages where no values are needed. See [Enable RE Tunnel](#custom-proxy-enable-re-tunnel) below.
+`enable_re_tunnel` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `password` - (Optional) Secret. SecretType is used in an object to indicate a sensitive/confidential field. See [Password](#custom-proxy-password) below.
 
@@ -377,14 +349,6 @@ In addition to all arguments above, the following attributes are exported:
 `proxy_port` - (Optional) Proxy Port. Specify the Port of the internal Enterprise Proxy (`Number`).
 
 `username` - (Optional) Username. If the internal Enterprise Proxy is using basic authentication, specify the username. This is an optional field (`String`).
-
-<a id="custom-proxy-disable-re-tunnel"></a>
-
-### Custom Proxy Disable RE Tunnel
-
-<a id="custom-proxy-enable-re-tunnel"></a>
-
-### Custom Proxy Enable RE Tunnel
 
 <a id="custom-proxy-password"></a>
 
@@ -438,14 +402,6 @@ In addition to all arguments above, the following attributes are exported:
 
 `tenant` - (Optional) Tenant. When a configuration object(e.g. virtual_host) refers to another(e.g route) then tenant will hold the referred object's(e.g. route's) tenant (`String`).
 
-<a id="disable-ha"></a>
-
-### Disable HA
-
-<a id="disable-url-categorization"></a>
-
-### Disable URL Categorization
-
 <a id="dns-ntp-config"></a>
 
 ### DNS NTP Config
@@ -454,9 +410,9 @@ In addition to all arguments above, the following attributes are exported:
 
 `custom_ntp` - (Optional) NTP Servers. NTP Servers. See [Custom NTP](#dns-ntp-config-custom-ntp) below.
 
-`f5_dns_default` - (Optional) Empty. This can be used for messages where no values are needed. See [F5 DNS Default](#dns-ntp-config-f5-dns-default) below.
+`f5_dns_default` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`f5_ntp_default` - (Optional) Empty. This can be used for messages where no values are needed. See [F5 NTP Default](#dns-ntp-config-f5-ntp-default) below.
+`f5_ntp_default` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="dns-ntp-config-custom-dns"></a>
 
@@ -469,22 +425,6 @@ In addition to all arguments above, the following attributes are exported:
 ### DNS NTP Config Custom NTP
 
 `ntp_servers` - (Optional) NTP Servers. NTP Servers (`List`).
-
-<a id="dns-ntp-config-f5-dns-default"></a>
-
-### DNS NTP Config F5 DNS Default
-
-<a id="dns-ntp-config-f5-ntp-default"></a>
-
-### DNS NTP Config F5 NTP Default
-
-<a id="enable-ha"></a>
-
-### Enable HA
-
-<a id="enable-url-categorization"></a>
-
-### Enable URL Categorization
 
 <a id="equinix"></a>
 
@@ -504,19 +444,11 @@ In addition to all arguments above, the following attributes are exported:
 
 `hostname` - (Optional) Hostname. Hostname for this Node (`String`).
 
-`interface_list` - (Optional) Interfaces. Manage interfaces belonging to this node. See [Interface List](#equinix-not-managed-node-list-interface-list) below.
+`interface_list` - (Optional) Interfaces. Manage interfaces belonging to this node (`Block`).
 
 `public_ip` - (Optional) Public IP. Public IP for this Node (`String`).
 
 `type` - (Optional) Type. Type for this Node, can be Control or Worker (`String`).
-
-<a id="equinix-not-managed-node-list-interface-list"></a>
-
-### Equinix Not Managed Node List Interface List
-
-<a id="f5-proxy"></a>
-
-### F5 Proxy
 
 <a id="gcp"></a>
 
@@ -536,15 +468,11 @@ In addition to all arguments above, the following attributes are exported:
 
 `hostname` - (Optional) Hostname. Hostname for this Node (`String`).
 
-`interface_list` - (Optional) Interfaces. Manage interfaces belonging to this node. See [Interface List](#gcp-not-managed-node-list-interface-list) below.
+`interface_list` - (Optional) Interfaces. Manage interfaces belonging to this node (`Block`).
 
 `public_ip` - (Optional) Public IP. Public IP for this Node (`String`).
 
 `type` - (Optional) Type. Type for this Node, can be Control or Worker (`String`).
-
-<a id="gcp-not-managed-node-list-interface-list"></a>
-
-### GCP Not Managed Node List Interface List
 
 <a id="kvm"></a>
 
@@ -564,15 +492,11 @@ In addition to all arguments above, the following attributes are exported:
 
 `hostname` - (Optional) Hostname. Hostname for this Node (`String`).
 
-`interface_list` - (Optional) Interfaces. Manage interfaces belonging to this node. See [Interface List](#kvm-not-managed-node-list-interface-list) below.
+`interface_list` - (Optional) Interfaces. Manage interfaces belonging to this node (`Block`).
 
 `public_ip` - (Optional) Public IP. Public IP for this Node (`String`).
 
 `type` - (Optional) Type. Type for this Node, can be Control or Worker (`String`).
-
-<a id="kvm-not-managed-node-list-interface-list"></a>
-
-### Kvm Not Managed Node List Interface List
 
 <a id="load-balancing"></a>
 
@@ -584,33 +508,25 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Local Vrf
 
-`default_config` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Config](#local-vrf-default-config) below.
+`default_config` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`default_sli_config` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Sli Config](#local-vrf-default-sli-config) below.
+`default_sli_config` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `sli_config` - (Optional) Site Local Network Configuration. Site local network configuration. See [Sli Config](#local-vrf-sli-config) below.
 
 `slo_config` - (Optional) Site Local Network Configuration. Site local network configuration. See [Slo Config](#local-vrf-slo-config) below.
 
-<a id="local-vrf-default-config"></a>
-
-### Local Vrf Default Config
-
-<a id="local-vrf-default-sli-config"></a>
-
-### Local Vrf Default Sli Config
-
 <a id="local-vrf-sli-config"></a>
 
 ### Local Vrf Sli Config
 
-`labels` - (Optional) Network Labels. Add Labels for this network, these labels can be used in firewall policy. See [Labels](#local-vrf-sli-config-labels) below.
+`labels` - (Optional) Network Labels. Add Labels for this network, these labels can be used in firewall policy (`Block`).
 
 `nameserver` - (Optional) DNS V4 Server. Optional DNS V4 server IP to be used for name resolution (`String`).
 
-`no_static_routes` - (Optional) Empty. This can be used for messages where no values are needed. See [No Static Routes](#local-vrf-sli-config-no-static-routes) below.
+`no_static_routes` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_v6_static_routes` - (Optional) Empty. This can be used for messages where no values are needed. See [No V6 Static Routes](#local-vrf-sli-config-no-v6-static-routes) below.
+`no_v6_static_routes` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `static_routes` - (Optional) Static Routes List. See [Static Routes](#local-vrf-sli-config-static-routes) below.
 
@@ -618,49 +534,29 @@ In addition to all arguments above, the following attributes are exported:
 
 `vip` - (Optional) Common V4 VIP. Optional common virtual V4 IP across all nodes to be used as automatic VIP (`String`).
 
-<a id="local-vrf-sli-config-labels"></a>
-
-### Local Vrf Sli Config Labels
-
-<a id="local-vrf-sli-config-no-static-routes"></a>
-
-### Local Vrf Sli Config No Static Routes
-
-<a id="local-vrf-sli-config-no-v6-static-routes"></a>
-
-### Local Vrf Sli Config No V6 Static Routes
-
 <a id="local-vrf-sli-config-static-routes"></a>
 
 ### Local Vrf Sli Config Static Routes
 
-`static_routes` - (Optional) Static Routes. See [Static Routes](#local-vrf-sli-config-static-routes-static-routes) below.
-
-<a id="local-vrf-sli-config-static-routes-static-routes"></a>
-
-### Local Vrf Sli Config Static Routes Static Routes
+`static_routes` - (Optional) Static Routes (`Block`).
 
 <a id="local-vrf-sli-config-static-v6-routes"></a>
 
 ### Local Vrf Sli Config Static V6 Routes
 
-`static_routes` - (Optional) Static IPv6 Routes. List of IPv6 static routes. See [Static Routes](#local-vrf-sli-config-static-v6-routes-static-routes) below.
-
-<a id="local-vrf-sli-config-static-v6-routes-static-routes"></a>
-
-### Local Vrf Sli Config Static V6 Routes Static Routes
+`static_routes` - (Optional) Static IPv6 Routes. List of IPv6 static routes (`Block`).
 
 <a id="local-vrf-slo-config"></a>
 
 ### Local Vrf Slo Config
 
-`labels` - (Optional) Network Labels. Add Labels for this network, these labels can be used in firewall policy. See [Labels](#local-vrf-slo-config-labels) below.
+`labels` - (Optional) Network Labels. Add Labels for this network, these labels can be used in firewall policy (`Block`).
 
 `nameserver` - (Optional) DNS V4 Server. Optional DNS V4 server IP to be used for name resolution (`String`).
 
-`no_static_routes` - (Optional) Empty. This can be used for messages where no values are needed. See [No Static Routes](#local-vrf-slo-config-no-static-routes) below.
+`no_static_routes` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_v6_static_routes` - (Optional) Empty. This can be used for messages where no values are needed. See [No V6 Static Routes](#local-vrf-slo-config-no-v6-static-routes) below.
+`no_v6_static_routes` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `static_routes` - (Optional) Static Routes List. See [Static Routes](#local-vrf-slo-config-static-routes) below.
 
@@ -668,37 +564,17 @@ In addition to all arguments above, the following attributes are exported:
 
 `vip` - (Optional) Common V4 VIP. Optional common virtual V4 IP across all nodes to be used as automatic VIP (`String`).
 
-<a id="local-vrf-slo-config-labels"></a>
-
-### Local Vrf Slo Config Labels
-
-<a id="local-vrf-slo-config-no-static-routes"></a>
-
-### Local Vrf Slo Config No Static Routes
-
-<a id="local-vrf-slo-config-no-v6-static-routes"></a>
-
-### Local Vrf Slo Config No V6 Static Routes
-
 <a id="local-vrf-slo-config-static-routes"></a>
 
 ### Local Vrf Slo Config Static Routes
 
-`static_routes` - (Optional) Static Routes. See [Static Routes](#local-vrf-slo-config-static-routes-static-routes) below.
-
-<a id="local-vrf-slo-config-static-routes-static-routes"></a>
-
-### Local Vrf Slo Config Static Routes Static Routes
+`static_routes` - (Optional) Static Routes (`Block`).
 
 <a id="local-vrf-slo-config-static-v6-routes"></a>
 
 ### Local Vrf Slo Config Static V6 Routes
 
-`static_routes` - (Optional) Static IPv6 Routes. List of IPv6 static routes. See [Static Routes](#local-vrf-slo-config-static-v6-routes-static-routes) below.
-
-<a id="local-vrf-slo-config-static-v6-routes-static-routes"></a>
-
-### Local Vrf Slo Config Static V6 Routes Static Routes
+`static_routes` - (Optional) Static IPv6 Routes. List of IPv6 static routes (`Block`).
 
 <a id="log-receiver"></a>
 
@@ -709,30 +585,6 @@ In addition to all arguments above, the following attributes are exported:
 `namespace` - (Optional) Namespace. When a configuration object(e.g. virtual_host) refers to another(e.g route) then namespace will hold the referred object's(e.g. route's) namespace (`String`).
 
 `tenant` - (Optional) Tenant. When a configuration object(e.g. virtual_host) refers to another(e.g route) then tenant will hold the referred object's(e.g. route's) tenant (`String`).
-
-<a id="logs-streaming-disabled"></a>
-
-### Logs Streaming Disabled
-
-<a id="no-forward-proxy"></a>
-
-### No Forward Proxy
-
-<a id="no-network-policy"></a>
-
-### No Network Policy
-
-<a id="no-proxy-bypass"></a>
-
-### No Proxy Bypass
-
-<a id="no-s2s-connectivity-sli"></a>
-
-### No S2s Connectivity Sli
-
-<a id="no-s2s-connectivity-slo"></a>
-
-### No S2s Connectivity Slo
 
 <a id="nutanix"></a>
 
@@ -752,15 +604,11 @@ In addition to all arguments above, the following attributes are exported:
 
 `hostname` - (Optional) Hostname. Hostname for this Node (`String`).
 
-`interface_list` - (Optional) Interfaces. Manage interfaces belonging to this node. See [Interface List](#nutanix-not-managed-node-list-interface-list) below.
+`interface_list` - (Optional) Interfaces. Manage interfaces belonging to this node (`Block`).
 
 `public_ip` - (Optional) Public IP. Public IP for this Node (`String`).
 
 `type` - (Optional) Type. Type for this Node, can be Control or Worker (`String`).
-
-<a id="nutanix-not-managed-node-list-interface-list"></a>
-
-### Nutanix Not Managed Node List Interface List
 
 <a id="oci"></a>
 
@@ -780,31 +628,19 @@ In addition to all arguments above, the following attributes are exported:
 
 `hostname` - (Optional) Hostname. Hostname for this Node (`String`).
 
-`interface_list` - (Optional) Interfaces. Manage interfaces belonging to this node. See [Interface List](#oci-not-managed-node-list-interface-list) below.
+`interface_list` - (Optional) Interfaces. Manage interfaces belonging to this node (`Block`).
 
 `public_ip` - (Optional) Public IP. Public IP for this Node (`String`).
 
 `type` - (Optional) Type. Type for this Node, can be Control or Worker (`String`).
 
-<a id="oci-not-managed-node-list-interface-list"></a>
-
-### Oci Not Managed Node List Interface List
-
 <a id="offline-survivability-mode"></a>
 
 ### Offline Survivability Mode
 
-`enable_offline_survivability_mode` - (Optional) Empty. This can be used for messages where no values are needed. See [Enable Offline Survivability Mode](#offline-survivability-mode-enable-offline-survivability-mode) below.
+`enable_offline_survivability_mode` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_offline_survivability_mode` - (Optional) Empty. This can be used for messages where no values are needed. See [No Offline Survivability Mode](#offline-survivability-mode-no-offline-survivability-mode) below.
-
-<a id="offline-survivability-mode-enable-offline-survivability-mode"></a>
-
-### Offline Survivability Mode Enable Offline Survivability Mode
-
-<a id="offline-survivability-mode-no-offline-survivability-mode"></a>
-
-### Offline Survivability Mode No Offline Survivability Mode
+`no_offline_survivability_mode` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="openstack"></a>
 
@@ -824,15 +660,11 @@ In addition to all arguments above, the following attributes are exported:
 
 `hostname` - (Optional) Hostname. Hostname for this Node (`String`).
 
-`interface_list` - (Optional) Interfaces. Manage interfaces belonging to this node. See [Interface List](#openstack-not-managed-node-list-interface-list) below.
+`interface_list` - (Optional) Interfaces. Manage interfaces belonging to this node (`Block`).
 
 `public_ip` - (Optional) Public IP. Public IP for this Node (`String`).
 
 `type` - (Optional) Type. Type for this Node, can be Control or Worker (`String`).
-
-<a id="openstack-not-managed-node-list-interface-list"></a>
-
-### Openstack Not Managed Node List Interface List
 
 <a id="performance-enhancement-mode"></a>
 
@@ -840,39 +672,23 @@ In addition to all arguments above, the following attributes are exported:
 
 `perf_mode_l3_enhanced` - (Optional) L3 Mode Enhanced Performance. x-required L3 enhanced performance mode options. See [Perf Mode L3 Enhanced](#performance-enhancement-mode-perf-mode-l3-enhanced) below.
 
-`perf_mode_l7_enhanced` - (Optional) Empty. This can be used for messages where no values are needed. See [Perf Mode L7 Enhanced](#performance-enhancement-mode-perf-mode-l7-enhanced) below.
+`perf_mode_l7_enhanced` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="performance-enhancement-mode-perf-mode-l3-enhanced"></a>
 
 ### Performance Enhancement Mode Perf Mode L3 Enhanced
 
-`jumbo` - (Optional) Empty. This can be used for messages where no values are needed. See [Jumbo](#performance-enhancement-mode-perf-mode-l3-enhanced-jumbo) below.
+`jumbo` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_jumbo` - (Optional) Empty. This can be used for messages where no values are needed. See [No Jumbo](#performance-enhancement-mode-perf-mode-l3-enhanced-no-jumbo) below.
-
-<a id="performance-enhancement-mode-perf-mode-l3-enhanced-jumbo"></a>
-
-### Performance Enhancement Mode Perf Mode L3 Enhanced Jumbo
-
-<a id="performance-enhancement-mode-perf-mode-l3-enhanced-no-jumbo"></a>
-
-### Performance Enhancement Mode Perf Mode L3 Enhanced No Jumbo
-
-<a id="performance-enhancement-mode-perf-mode-l7-enhanced"></a>
-
-### Performance Enhancement Mode Perf Mode L7 Enhanced
+`no_jumbo` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="re-select"></a>
 
 ### RE Select
 
-`geo_proximity` - (Optional) Empty. This can be used for messages where no values are needed. See [Geo Proximity](#re-select-geo-proximity) below.
+`geo_proximity` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `specific_re` - (Optional) Specific RE. Select specific REs. This is useful when a site needs to deterministically connect to a set of REs. A site will always be connected to 2 REs. See [Specific RE](#re-select-specific-re) below.
-
-<a id="re-select-geo-proximity"></a>
-
-### RE Select Geo Proximity
 
 <a id="re-select-specific-re"></a>
 
@@ -884,17 +700,13 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Site Mesh Group On Slo
 
-`no_site_mesh_group` - (Optional) Empty. This can be used for messages where no values are needed. See [No Site Mesh Group](#site-mesh-group-on-slo-no-site-mesh-group) below.
+`no_site_mesh_group` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `site_mesh_group` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Site Mesh Group](#site-mesh-group-on-slo-site-mesh-group) below.
 
-`sm_connection_public_ip` - (Optional) Empty. This can be used for messages where no values are needed. See [Sm Connection Public IP](#site-mesh-group-on-slo-sm-connection-public-ip) below.
+`sm_connection_public_ip` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`sm_connection_pvt_ip` - (Optional) Empty. This can be used for messages where no values are needed. See [Sm Connection Pvt IP](#site-mesh-group-on-slo-sm-connection-pvt-ip) below.
-
-<a id="site-mesh-group-on-slo-no-site-mesh-group"></a>
-
-### Site Mesh Group On Slo No Site Mesh Group
+`sm_connection_pvt_ip` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="site-mesh-group-on-slo-site-mesh-group"></a>
 
@@ -905,14 +717,6 @@ In addition to all arguments above, the following attributes are exported:
 `namespace` - (Optional) Namespace. When a configuration object(e.g. virtual_host) refers to another(e.g route) then namespace will hold the referred object's(e.g. route's) namespace (`String`).
 
 `tenant` - (Optional) Tenant. When a configuration object(e.g. virtual_host) refers to another(e.g route) then tenant will hold the referred object's(e.g. route's) tenant (`String`).
-
-<a id="site-mesh-group-on-slo-sm-connection-public-ip"></a>
-
-### Site Mesh Group On Slo Sm Connection Public IP
-
-<a id="site-mesh-group-on-slo-sm-connection-pvt-ip"></a>
-
-### Site Mesh Group On Slo Sm Connection Pvt IP
 
 <a id="software-settings"></a>
 
@@ -926,25 +730,17 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Software Settings OS
 
-`default_os_version` - (Optional) Empty. This can be used for messages where no values are needed. See [Default OS Version](#software-settings-os-default-os-version) below.
+`default_os_version` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `operating_system_version` - (Optional) Operating System Version. Specify a OS version to be used e.g. 9.2024.6 (`String`).
-
-<a id="software-settings-os-default-os-version"></a>
-
-### Software Settings OS Default OS Version
 
 <a id="software-settings-sw"></a>
 
 ### Software Settings Sw
 
-`default_sw_version` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Sw Version](#software-settings-sw-default-sw-version) below.
+`default_sw_version` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `volterra_software_version` - (Optional) F5XC Software Version. Specify a F5XC Software Version to be used e.g. crt-20210329-1002 (`String`).
-
-<a id="software-settings-sw-default-sw-version"></a>
-
-### Software Settings Sw Default Sw Version
 
 <a id="timeouts"></a>
 
@@ -968,33 +764,21 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Upgrade Settings Kubernetes Upgrade Drain
 
-`disable_upgrade_drain` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Upgrade Drain](#upgrade-settings-kubernetes-upgrade-drain-disable-upgrade-drain) below.
+`disable_upgrade_drain` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `enable_upgrade_drain` - (Optional) Enable Node by Node Upgrade. Specify batch upgrade settings for worker nodes within a site. See [Enable Upgrade Drain](#upgrade-settings-kubernetes-upgrade-drain-enable-upgrade-drain) below.
-
-<a id="upgrade-settings-kubernetes-upgrade-drain-disable-upgrade-drain"></a>
-
-### Upgrade Settings Kubernetes Upgrade Drain Disable Upgrade Drain
 
 <a id="upgrade-settings-kubernetes-upgrade-drain-enable-upgrade-drain"></a>
 
 ### Upgrade Settings Kubernetes Upgrade Drain Enable Upgrade Drain
 
-`disable_vega_upgrade_mode` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Vega Upgrade Mode](#upgrade-settings-kubernetes-upgrade-drain-enable-upgrade-drain-disable-vega-upgrade-mode) below.
+`disable_vega_upgrade_mode` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `drain_max_unavailable_node_count` - (Optional) Node Batch Size Count (`Number`).
 
 `drain_node_timeout` - (Optional) Upgrade Wait Time. Seconds to wait before initiating upgrade on the next set of nodes. Setting it to 0 will wait indefinitely for all services on nodes to be upgraded gracefully before proceeding to the next set of nodes. (Warning: It may block upgrade if services on a node cannot be gracefully upgraded. It is recommended to use the default value) (`Number`).
 
-`enable_vega_upgrade_mode` - (Optional) Empty. This can be used for messages where no values are needed. See [Enable Vega Upgrade Mode](#upgrade-settings-kubernetes-upgrade-drain-enable-upgrade-drain-enable-vega-upgrade-mode) below.
-
-<a id="upgrade-settings-kubernetes-upgrade-drain-enable-upgrade-drain-disable-vega-upgrade-mode"></a>
-
-### Upgrade Settings Kubernetes Upgrade Drain Enable Upgrade Drain Disable Vega Upgrade Mode
-
-<a id="upgrade-settings-kubernetes-upgrade-drain-enable-upgrade-drain-enable-vega-upgrade-mode"></a>
-
-### Upgrade Settings Kubernetes Upgrade Drain Enable Upgrade Drain Enable Vega Upgrade Mode
+`enable_vega_upgrade_mode` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="vmware"></a>
 
@@ -1014,15 +798,11 @@ In addition to all arguments above, the following attributes are exported:
 
 `hostname` - (Optional) Hostname. Hostname for this Node (`String`).
 
-`interface_list` - (Optional) Interfaces. Manage interfaces belonging to this node. See [Interface List](#vmware-not-managed-node-list-interface-list) below.
+`interface_list` - (Optional) Interfaces. Manage interfaces belonging to this node (`Block`).
 
 `public_ip` - (Optional) Public IP. Public IP for this Node (`String`).
 
 `type` - (Optional) Type. Type for this Node, can be Control or Worker (`String`).
-
-<a id="vmware-not-managed-node-list-interface-list"></a>
-
-### Vmware Not Managed Node List Interface List
 
 ## Import
 

--- a/docs/resources/segment.md
+++ b/docs/resources/segment.md
@@ -56,13 +56,13 @@ resource "f5xc_segment" "example" {
 
 > **Note:** One of the arguments from this list "disable, enable" must be set.
 
-`disable` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable](#disable) below for details.
+`disable` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `labels` - (Optional) Labels to apply to this resource (`Map`).
 
 ### Spec Argument Reference
 
-`enable` - (Optional) Empty. This can be used for messages where no values are needed. See [Enable](#enable) below for details.
+`enable` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `timeouts` - (Optional) See [Timeouts](#timeouts) below for details.
 
@@ -73,14 +73,6 @@ In addition to all arguments above, the following attributes are exported:
 `id` - (Optional) Unique identifier for the resource (`String`).
 
 ---
-
-<a id="disable"></a>
-
-### Disable
-
-<a id="enable"></a>
-
-### Enable
 
 <a id="timeouts"></a>
 

--- a/docs/resources/service_policy.md
+++ b/docs/resources/service_policy.md
@@ -66,11 +66,11 @@ resource "f5xc_service_policy" "example" {
 
 > **Note:** One of the arguments from this list "allow_all_requests, allow_list, deny_all_requests, deny_list, rule_list" must be set.
 
-`allow_all_requests` - (Optional) Empty. This can be used for messages where no values are needed. See [Allow All Requests](#allow-all-requests) below for details.
+`allow_all_requests` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `allow_list` - (Optional) Source List. List of sources. A request belongs to this list if it satisfies any of the match criteria. See [Allow List](#allow-list) below for details.
 
-`deny_all_requests` - (Optional) Empty. This can be used for messages where no values are needed. See [Deny All Requests](#deny-all-requests) below for details.
+`deny_all_requests` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `deny_list` - (Optional) Source List. List of sources. A request belongs to this list if it satisfies any of the match criteria. See [Deny List](#deny-list) below for details.
 
@@ -78,7 +78,7 @@ resource "f5xc_service_policy" "example" {
 
 > **Note:** One of the arguments from this list "any_server, server_name, server_name_matcher, server_selector" must be set.
 
-`any_server` - (Optional) Empty. This can be used for messages where no values are needed. See [Any Server](#any-server) below for details.
+`any_server` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `server_name` - (Optional) Server Name. The expected name of the server to which the request API is directed. The actual names for the server are extracted from the HTTP Host header and the name of the virtual_host to which the request is directed. If the request is directed to a virtual K8s service, the actual names also contain the name of that service. The predicate evaluates to true if any of the actual names is the same as the expected server name (`String`).
 
@@ -96,10 +96,6 @@ In addition to all arguments above, the following attributes are exported:
 
 ---
 
-<a id="allow-all-requests"></a>
-
-### Allow All Requests
-
 <a id="allow-list"></a>
 
 ### Allow List
@@ -110,11 +106,11 @@ In addition to all arguments above, the following attributes are exported:
 
 `country_list` - (Optional) Country List. Addresses that belong to one of the countries in the given list The country is obtained by performing a lookup for the source IPv4 Address in a GeoIP DB (`List`).
 
-`default_action_allow` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Action Allow](#allow-list-default-action-allow) below.
+`default_action_allow` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`default_action_deny` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Action Deny](#allow-list-default-action-deny) below.
+`default_action_deny` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`default_action_next_policy` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Action Next Policy](#allow-list-default-action-next-policy) below.
+`default_action_next_policy` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `ip_prefix_set` - (Optional) IP Prefix Set. Addresses that are covered by the prefixes in the given ip_prefix_set. See [IP Prefix Set](#allow-list-ip-prefix-set) below.
 
@@ -140,18 +136,6 @@ In addition to all arguments above, the following attributes are exported:
 
 `tenant` - (Optional) Tenant. When a configuration object(e.g. virtual_host) refers to another(e.g route) then tenant will hold the referred object's(e.g. route's) tenant (`String`).
 
-<a id="allow-list-default-action-allow"></a>
-
-### Allow List Default Action Allow
-
-<a id="allow-list-default-action-deny"></a>
-
-### Allow List Default Action Deny
-
-<a id="allow-list-default-action-next-policy"></a>
-
-### Allow List Default Action Next Policy
-
 <a id="allow-list-ip-prefix-set"></a>
 
 ### Allow List IP Prefix Set
@@ -168,14 +152,6 @@ In addition to all arguments above, the following attributes are exported:
 
 `prefixes` - (Optional) IPv4 Prefix List. List of IPv4 prefixes that represent an endpoint (`List`).
 
-<a id="any-server"></a>
-
-### Any Server
-
-<a id="deny-all-requests"></a>
-
-### Deny All Requests
-
 <a id="deny-list"></a>
 
 ### Deny List
@@ -186,11 +162,11 @@ In addition to all arguments above, the following attributes are exported:
 
 `country_list` - (Optional) Country List. Addresses that belong to one of the countries in the given list The country is obtained by performing a lookup for the source IPv4 Address in a GeoIP DB (`List`).
 
-`default_action_allow` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Action Allow](#deny-list-default-action-allow) below.
+`default_action_allow` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`default_action_deny` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Action Deny](#deny-list-default-action-deny) below.
+`default_action_deny` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`default_action_next_policy` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Action Next Policy](#deny-list-default-action-next-policy) below.
+`default_action_next_policy` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `ip_prefix_set` - (Optional) IP Prefix Set. Addresses that are covered by the prefixes in the given ip_prefix_set. See [IP Prefix Set](#deny-list-ip-prefix-set) below.
 
@@ -215,18 +191,6 @@ In addition to all arguments above, the following attributes are exported:
 `namespace` - (Optional) Namespace. When a configuration object(e.g. virtual_host) refers to another(e.g route) then namespace will hold the referred object's(e.g. route's) namespace (`String`).
 
 `tenant` - (Optional) Tenant. When a configuration object(e.g. virtual_host) refers to another(e.g route) then tenant will hold the referred object's(e.g. route's) tenant (`String`).
-
-<a id="deny-list-default-action-allow"></a>
-
-### Deny List Default Action Allow
-
-<a id="deny-list-default-action-deny"></a>
-
-### Deny List Default Action Deny
-
-<a id="deny-list-default-action-next-policy"></a>
-
-### Deny List Default Action Next Policy
 
 <a id="deny-list-ip-prefix-set"></a>
 
@@ -272,189 +236,69 @@ In addition to all arguments above, the following attributes are exported:
 
 `action` - (Optional) Rule Action. The rule action determines the disposition of the input request API. If a policy matches a rule with an ALLOW action, the processing of the request proceeds forward. If it matches a rule with a DENY action, the processing of the request is terminated and an appropriate message/code returned to the originator. If it matches a rule with a NEXT_POLICY_SET action, evaluation of the current policy set terminates and evaluation of the next policy set in the chain begins. - DENY: DENY D... Possible values are `DENY`, `ALLOW`, `NEXT_POLICY`. Defaults to `DENY` (`String`).
 
-`any_asn` - (Optional) Empty. This can be used for messages where no values are needed. See [Any Asn](#rule-list-rules-spec-any-asn) below.
+`any_asn` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`any_client` - (Optional) Empty. This can be used for messages where no values are needed. See [Any Client](#rule-list-rules-spec-any-client) below.
+`any_client` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`any_ip` - (Optional) Empty. This can be used for messages where no values are needed. See [Any IP](#rule-list-rules-spec-any-ip) below.
+`any_ip` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`api_group_matcher` - (Optional) String Matcher. A matcher specifies a list of values for matching an input string. The match is considered successful if the input value is present in the list. The result of the match is inverted if invert_matcher is true. See [API Group Matcher](#rule-list-rules-spec-api-group-matcher) below.
+`api_group_matcher` - (Optional) String Matcher. A matcher specifies a list of values for matching an input string. The match is considered successful if the input value is present in the list. The result of the match is inverted if invert_matcher is true (`Block`).
 
-`arg_matchers` - (Optional) Argument Matchers. A list of predicates for all POST args that need to be matched. The criteria for matching each arg are described in individual instances of ArgMatcherType. The actual arg values are extracted from the request API as a list of strings for each arg selector name. Note that all specified arg matcher predicates must evaluate to true. See [Arg Matchers](#rule-list-rules-spec-arg-matchers) below.
+`arg_matchers` - (Optional) Argument Matchers. A list of predicates for all POST args that need to be matched. The criteria for matching each arg are described in individual instances of ArgMatcherType. The actual arg values are extracted from the request API as a list of strings for each arg selector name. Note that all specified arg matcher predicates must evaluate to true (`Block`).
 
-`asn_list` - (Optional) ASN Match List. An unordered set of RFC 6793 defined 4-byte AS numbers that can be used to create allow or deny lists for use in network policy or service policy. It can be used to create the allow list only for DNS Load Balancer. See [Asn List](#rule-list-rules-spec-asn-list) below.
+`asn_list` - (Optional) ASN Match List. An unordered set of RFC 6793 defined 4-byte AS numbers that can be used to create allow or deny lists for use in network policy or service policy. It can be used to create the allow list only for DNS Load Balancer (`Block`).
 
-`asn_matcher` - (Optional) ASN Matcher. Match any AS number contained in the list of bgp_asn_sets. See [Asn Matcher](#rule-list-rules-spec-asn-matcher) below.
+`asn_matcher` - (Optional) ASN Matcher. Match any AS number contained in the list of bgp_asn_sets (`Block`).
 
-`body_matcher` - (Optional) Matcher. A matcher specifies multiple criteria for matching an input string. The match is considered successful if any of the criteria are satisfied. The set of supported match criteria includes a list of exact values and a list of regular expressions. See [Body Matcher](#rule-list-rules-spec-body-matcher) below.
+`body_matcher` - (Optional) Matcher. A matcher specifies multiple criteria for matching an input string. The match is considered successful if any of the criteria are satisfied. The set of supported match criteria includes a list of exact values and a list of regular expressions (`Block`).
 
-`bot_action` - (Optional) Bot Action. Modify Bot protection behavior for a matching request. The modification could be to entirely skip Bot processing. See [Bot Action](#rule-list-rules-spec-bot-action) below.
+`bot_action` - (Optional) Bot Action. Modify Bot protection behavior for a matching request. The modification could be to entirely skip Bot processing (`Block`).
 
 `client_name` - (Optional) Client Name. The expected name of the client invoking the request API. The predicate evaluates to true if any of the actual names is the same as the expected client name (`String`).
 
-`client_name_matcher` - (Optional) Matcher. A matcher specifies multiple criteria for matching an input string. The match is considered successful if any of the criteria are satisfied. The set of supported match criteria includes a list of exact values and a list of regular expressions. See [Client Name Matcher](#rule-list-rules-spec-client-name-matcher) below.
+`client_name_matcher` - (Optional) Matcher. A matcher specifies multiple criteria for matching an input string. The match is considered successful if any of the criteria are satisfied. The set of supported match criteria includes a list of exact values and a list of regular expressions (`Block`).
 
-`client_selector` - (Optional) Label Selector. This type can be used to establish a 'selector reference' from one object(called selector) to a set of other objects(called selectees) based on the value of expresssions. A label selector is a label query over a set of resources. An empty label selector matches all objects. A null label selector matches no objects. Label selector is immutable. expressions is a list of strings of label selection expression. Each string has ',' separated values which are 'AND' and all strings ar. See [Client Selector](#rule-list-rules-spec-client-selector) below.
+`client_selector` - (Optional) Label Selector. This type can be used to establish a 'selector reference' from one object(called selector) to a set of other objects(called selectees) based on the value of expresssions. A label selector is a label query over a set of resources. An empty label selector matches all objects. A null label selector matches no objects. Label selector is immutable. expressions is a list of strings of label selection expression. Each string has ',' separated values which are 'AND' and all strings ar (`Block`).
 
-`cookie_matchers` - (Optional) Cookie Matchers. A list of predicates for all cookies that need to be matched. The criteria for matching each cookie is described in individual instances of CookieMatcherType. The actual cookie values are extracted from the request API as a list of strings for each cookie name. Note that all specified cookie matcher predicates must evaluate to true. See [Cookie Matchers](#rule-list-rules-spec-cookie-matchers) below.
+`cookie_matchers` - (Optional) Cookie Matchers. A list of predicates for all cookies that need to be matched. The criteria for matching each cookie is described in individual instances of CookieMatcherType. The actual cookie values are extracted from the request API as a list of strings for each cookie name. Note that all specified cookie matcher predicates must evaluate to true (`Block`).
 
-`domain_matcher` - (Optional) Matcher. A matcher specifies multiple criteria for matching an input string. The match is considered successful if any of the criteria are satisfied. The set of supported match criteria includes a list of exact values and a list of regular expressions. See [Domain Matcher](#rule-list-rules-spec-domain-matcher) below.
+`domain_matcher` - (Optional) Matcher. A matcher specifies multiple criteria for matching an input string. The match is considered successful if any of the criteria are satisfied. The set of supported match criteria includes a list of exact values and a list of regular expressions (`Block`).
 
 `expiration_timestamp` - (Optional) Expiration Timestamp. The expiration_timestamp is the RFC 3339 format timestamp at which the containing rule is considered to be logically expired. The rule continues to exist in the configuration but is not applied anymore (`String`).
 
-`headers` - (Optional) HTTP Headers. A list of predicates for various HTTP headers that need to match. The criteria for matching each HTTP header are described in individual HeaderMatcherType instances. The actual HTTP header values are extracted from the request API as a list of strings for each HTTP header type. Note that all specified header predicates must evaluate to true. See [Headers](#rule-list-rules-spec-headers) below.
+`headers` - (Optional) HTTP Headers. A list of predicates for various HTTP headers that need to match. The criteria for matching each HTTP header are described in individual HeaderMatcherType instances. The actual HTTP header values are extracted from the request API as a list of strings for each HTTP header type. Note that all specified header predicates must evaluate to true (`Block`).
 
-`http_method` - (Optional) HTTP Method Matcher. A HTTP method matcher specifies a list of methods to match an input HTTP method. The match is considered successful if the input method is a member of the list. The result of the match based on the method list is inverted if invert_matcher is true. See [HTTP Method](#rule-list-rules-spec-http-method) below.
+`http_method` - (Optional) HTTP Method Matcher. A HTTP method matcher specifies a list of methods to match an input HTTP method. The match is considered successful if the input method is a member of the list. The result of the match based on the method list is inverted if invert_matcher is true (`Block`).
 
-`ip_matcher` - (Optional) IP Prefix Matcher. Match any IP prefix contained in the list of ip_prefix_sets. The result of the match is inverted if invert_matcher is true. See [IP Matcher](#rule-list-rules-spec-ip-matcher) below.
+`ip_matcher` - (Optional) IP Prefix Matcher. Match any IP prefix contained in the list of ip_prefix_sets. The result of the match is inverted if invert_matcher is true (`Block`).
 
-`ip_prefix_list` - (Optional) IP Prefix Match List. List of IP Prefix strings to match against. See [IP Prefix List](#rule-list-rules-spec-ip-prefix-list) below.
+`ip_prefix_list` - (Optional) IP Prefix Match List. List of IP Prefix strings to match against (`Block`).
 
-`ip_threat_category_list` - (Optional) IP Threat Category List Type. List of IP threat categories. See [IP Threat Category List](#rule-list-rules-spec-ip-threat-category-list) below.
+`ip_threat_category_list` - (Optional) IP Threat Category List Type. List of IP threat categories (`Block`).
 
-`ja4_tls_fingerprint` - (Optional) JA4 TLS Fingerprint Matcher. An extended version of JA3 that includes additional fields for more comprehensive fingerprinting of SSL/TLS clients and potentially has a different structure and length. See [Ja4 TLS Fingerprint](#rule-list-rules-spec-ja4-tls-fingerprint) below.
+`ja4_tls_fingerprint` - (Optional) JA4 TLS Fingerprint Matcher. An extended version of JA3 that includes additional fields for more comprehensive fingerprinting of SSL/TLS clients and potentially has a different structure and length (`Block`).
 
-`jwt_claims` - (Optional) JWT Claims. A list of predicates for various JWT claims that need to match. The criteria for matching each JWT claim are described in individual JWTClaimMatcherType instances. The actual JWT claims values are extracted from the JWT payload as a list of strings. Note that all specified JWT claim predicates must evaluate to true. See [JWT Claims](#rule-list-rules-spec-jwt-claims) below.
+`jwt_claims` - (Optional) JWT Claims. A list of predicates for various JWT claims that need to match. The criteria for matching each JWT claim are described in individual JWTClaimMatcherType instances. The actual JWT claims values are extracted from the JWT payload as a list of strings. Note that all specified JWT claim predicates must evaluate to true (`Block`).
 
-`label_matcher` - (Optional) Label Matcher. A label matcher specifies a list of label keys whose values need to match for source/client and destination/server. Note that the actual label values are not specified and do not matter. This allows an ability to scope grouping by the label key name. See [Label Matcher](#rule-list-rules-spec-label-matcher) below.
+`label_matcher` - (Optional) Label Matcher. A label matcher specifies a list of label keys whose values need to match for source/client and destination/server. Note that the actual label values are not specified and do not matter. This allows an ability to scope grouping by the label key name (`Block`).
 
-`mum_action` - (Optional) Select Modification Action. Modify behavior for a matching request. The modification could be to entirely skip processing. See [Mum Action](#rule-list-rules-spec-mum-action) below.
+`mum_action` - (Optional) Select Modification Action. Modify behavior for a matching request. The modification could be to entirely skip processing (`Block`).
 
-`path` - (Optional) Path Matcher. A path matcher specifies multiple criteria for matching an HTTP path string. The match is considered successful if any of the criteria are satisfied. The set of supported match criteria includes a list of path prefixes, a list of exact path values and a list of regular expressions. See [Path](#rule-list-rules-spec-path) below.
+`path` - (Optional) Path Matcher. A path matcher specifies multiple criteria for matching an HTTP path string. The match is considered successful if any of the criteria are satisfied. The set of supported match criteria includes a list of path prefixes, a list of exact path values and a list of regular expressions (`Block`).
 
-`port_matcher` - (Optional) Port Matcher. A port matcher specifies a list of port ranges as match criteria. The match is considered successful if the input port falls within any of the port ranges. The result of the match is inverted if invert_matcher is true. See [Port Matcher](#rule-list-rules-spec-port-matcher) below.
+`port_matcher` - (Optional) Port Matcher. A port matcher specifies a list of port ranges as match criteria. The match is considered successful if the input port falls within any of the port ranges. The result of the match is inverted if invert_matcher is true (`Block`).
 
-`query_params` - (Optional) HTTP Query Parameters. A list of predicates for all query parameters that need to be matched. The criteria for matching each query parameter are described in individual instances of QueryParameterMatcherType. The actual query parameter values are extracted from the request API as a list of strings for each query parameter name. Note that all specified query parameter predicates must evaluate to true. See [Query Params](#rule-list-rules-spec-query-params) below.
+`query_params` - (Optional) HTTP Query Parameters. A list of predicates for all query parameters that need to be matched. The criteria for matching each query parameter are described in individual instances of QueryParameterMatcherType. The actual query parameter values are extracted from the request API as a list of strings for each query parameter name. Note that all specified query parameter predicates must evaluate to true (`Block`).
 
-`request_constraints` - (Optional) Request Constraints. See [Request Constraints](#rule-list-rules-spec-request-constraints) below.
+`request_constraints` - (Optional) Request Constraints (`Block`).
 
-`segment_policy` - (Optional) Configure Segments. Configure source and destination segment for policy. See [Segment Policy](#rule-list-rules-spec-segment-policy) below.
+`segment_policy` - (Optional) Configure Segments. Configure source and destination segment for policy (`Block`).
 
-`tls_fingerprint_matcher` - (Optional) TLS Fingerprint Matcher. A TLS fingerprint matcher specifies multiple criteria for matching a TLS fingerprint. The set of supported positve match criteria includes a list of known classes of TLS fingerprints and a list of exact values. The match is considered successful if either of these positive criteria are satisfied and the input fingerprint is not one of the excluded values. See [TLS Fingerprint Matcher](#rule-list-rules-spec-tls-fingerprint-matcher) below.
+`tls_fingerprint_matcher` - (Optional) TLS Fingerprint Matcher. A TLS fingerprint matcher specifies multiple criteria for matching a TLS fingerprint. The set of supported positve match criteria includes a list of known classes of TLS fingerprints and a list of exact values. The match is considered successful if either of these positive criteria are satisfied and the input fingerprint is not one of the excluded values (`Block`).
 
-`user_identity_matcher` - (Optional) Matcher. A matcher specifies multiple criteria for matching an input string. The match is considered successful if any of the criteria are satisfied. The set of supported match criteria includes a list of exact values and a list of regular expressions. See [User Identity Matcher](#rule-list-rules-spec-user-identity-matcher) below.
+`user_identity_matcher` - (Optional) Matcher. A matcher specifies multiple criteria for matching an input string. The match is considered successful if any of the criteria are satisfied. The set of supported match criteria includes a list of exact values and a list of regular expressions (`Block`).
 
-`waf_action` - (Optional) App Firewall Action. Modify App Firewall behavior for a matching request. The modification could either be to entirely skip firewall processing or to customize the firewall rules to be applied as defined by App Firewall Rule Control settings. See [WAF Action](#rule-list-rules-spec-waf-action) below.
-
-<a id="rule-list-rules-spec-any-asn"></a>
-
-### Rule List Rules Spec Any Asn
-
-<a id="rule-list-rules-spec-any-client"></a>
-
-### Rule List Rules Spec Any Client
-
-<a id="rule-list-rules-spec-any-ip"></a>
-
-### Rule List Rules Spec Any IP
-
-<a id="rule-list-rules-spec-api-group-matcher"></a>
-
-### Rule List Rules Spec API Group Matcher
-
-<a id="rule-list-rules-spec-arg-matchers"></a>
-
-### Rule List Rules Spec Arg Matchers
-
-<a id="rule-list-rules-spec-asn-list"></a>
-
-### Rule List Rules Spec Asn List
-
-<a id="rule-list-rules-spec-asn-matcher"></a>
-
-### Rule List Rules Spec Asn Matcher
-
-<a id="rule-list-rules-spec-body-matcher"></a>
-
-### Rule List Rules Spec Body Matcher
-
-<a id="rule-list-rules-spec-bot-action"></a>
-
-### Rule List Rules Spec Bot Action
-
-<a id="rule-list-rules-spec-client-name-matcher"></a>
-
-### Rule List Rules Spec Client Name Matcher
-
-<a id="rule-list-rules-spec-client-selector"></a>
-
-### Rule List Rules Spec Client Selector
-
-<a id="rule-list-rules-spec-cookie-matchers"></a>
-
-### Rule List Rules Spec Cookie Matchers
-
-<a id="rule-list-rules-spec-domain-matcher"></a>
-
-### Rule List Rules Spec Domain Matcher
-
-<a id="rule-list-rules-spec-headers"></a>
-
-### Rule List Rules Spec Headers
-
-<a id="rule-list-rules-spec-http-method"></a>
-
-### Rule List Rules Spec HTTP Method
-
-<a id="rule-list-rules-spec-ip-matcher"></a>
-
-### Rule List Rules Spec IP Matcher
-
-<a id="rule-list-rules-spec-ip-prefix-list"></a>
-
-### Rule List Rules Spec IP Prefix List
-
-<a id="rule-list-rules-spec-ip-threat-category-list"></a>
-
-### Rule List Rules Spec IP Threat Category List
-
-<a id="rule-list-rules-spec-ja4-tls-fingerprint"></a>
-
-### Rule List Rules Spec Ja4 TLS Fingerprint
-
-<a id="rule-list-rules-spec-jwt-claims"></a>
-
-### Rule List Rules Spec JWT Claims
-
-<a id="rule-list-rules-spec-label-matcher"></a>
-
-### Rule List Rules Spec Label Matcher
-
-<a id="rule-list-rules-spec-mum-action"></a>
-
-### Rule List Rules Spec Mum Action
-
-<a id="rule-list-rules-spec-path"></a>
-
-### Rule List Rules Spec Path
-
-<a id="rule-list-rules-spec-port-matcher"></a>
-
-### Rule List Rules Spec Port Matcher
-
-<a id="rule-list-rules-spec-query-params"></a>
-
-### Rule List Rules Spec Query Params
-
-<a id="rule-list-rules-spec-request-constraints"></a>
-
-### Rule List Rules Spec Request Constraints
-
-<a id="rule-list-rules-spec-segment-policy"></a>
-
-### Rule List Rules Spec Segment Policy
-
-<a id="rule-list-rules-spec-tls-fingerprint-matcher"></a>
-
-### Rule List Rules Spec TLS Fingerprint Matcher
-
-<a id="rule-list-rules-spec-user-identity-matcher"></a>
-
-### Rule List Rules Spec User Identity Matcher
-
-<a id="rule-list-rules-spec-waf-action"></a>
-
-### Rule List Rules Spec WAF Action
+`waf_action` - (Optional) App Firewall Action. Modify App Firewall behavior for a matching request. The modification could either be to entirely skip firewall processing or to customize the firewall rules to be applied as defined by App Firewall Rule Control settings (`Block`).
 
 <a id="server-name-matcher"></a>
 

--- a/docs/resources/service_policy_rule.md
+++ b/docs/resources/service_policy_rule.md
@@ -66,7 +66,7 @@ resource "f5xc_service_policy_rule" "example" {
 
 > **Note:** One of the arguments from this list "any_asn, asn_list, asn_matcher" must be set.
 
-`any_asn` - (Optional) Empty. This can be used for messages where no values are needed. See [Any Asn](#any-asn) below for details.
+`any_asn` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `asn_list` - (Optional) ASN Match List. An unordered set of RFC 6793 defined 4-byte AS numbers that can be used to create allow or deny lists for use in network policy or service policy. It can be used to create the allow list only for DNS Load Balancer. See [Asn List](#asn-list) below for details.
 
@@ -74,7 +74,7 @@ resource "f5xc_service_policy_rule" "example" {
 
 > **Note:** One of the arguments from this list "any_client, client_name, client_name_matcher, client_selector, ip_threat_category_list" must be set.
 
-`any_client` - (Optional) Empty. This can be used for messages where no values are needed. See [Any Client](#any-client) below for details.
+`any_client` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `client_name` - (Optional) Client Name. The expected name of the client invoking the request API. The predicate evaluates to true if any of the actual names is the same as the expected client name (`String`).
 
@@ -86,7 +86,7 @@ resource "f5xc_service_policy_rule" "example" {
 
 > **Note:** One of the arguments from this list "any_ip, ip_matcher, ip_prefix_list" must be set.
 
-`any_ip` - (Optional) Empty. This can be used for messages where no values are needed. See [Any IP](#any-ip) below for details.
+`any_ip` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `ip_matcher` - (Optional) IP Prefix Matcher. Match any IP prefix contained in the list of ip_prefix_sets. The result of the match is inverted if invert_matcher is true. See [IP Matcher](#ip-matcher) below for details.
 
@@ -144,18 +144,6 @@ In addition to all arguments above, the following attributes are exported:
 
 ---
 
-<a id="any-asn"></a>
-
-### Any Asn
-
-<a id="any-client"></a>
-
-### Any Client
-
-<a id="any-ip"></a>
-
-### Any IP
-
 <a id="api-group-matcher"></a>
 
 ### API Group Matcher
@@ -168,23 +156,15 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Arg Matchers
 
-`check_not_present` - (Optional) Empty. This can be used for messages where no values are needed. See [Check Not Present](#arg-matchers-check-not-present) below.
+`check_not_present` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`check_present` - (Optional) Empty. This can be used for messages where no values are needed. See [Check Present](#arg-matchers-check-present) below.
+`check_present` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `invert_matcher` - (Optional) Invert Matcher. Invert Match of the expression defined (`Bool`).
 
 `item` - (Optional) Matcher. A matcher specifies multiple criteria for matching an input string. The match is considered successful if any of the criteria are satisfied. The set of supported match criteria includes a list of exact values and a list of regular expressions. See [Item](#arg-matchers-item) below.
 
 `name` - (Optional) Argument Name. x-example: 'phones[_]' x-example: 'cars.make.toyota.models[1]' x-example: 'cars.make.honda.models[_]' x-example: 'cars.make[_].models[_]' A case-sensitive JSON path in the HTTP request body (`String`).
-
-<a id="arg-matchers-check-not-present"></a>
-
-### Arg Matchers Check Not Present
-
-<a id="arg-matchers-check-present"></a>
-
-### Arg Matchers Check Present
 
 <a id="arg-matchers-item"></a>
 
@@ -236,17 +216,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Bot Action
 
-`bot_skip_processing` - (Optional) Empty. This can be used for messages where no values are needed. See [Bot Skip Processing](#bot-action-bot-skip-processing) below.
+`bot_skip_processing` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`none` - (Optional) Empty. This can be used for messages where no values are needed. See [None](#bot-action-none) below.
-
-<a id="bot-action-bot-skip-processing"></a>
-
-### Bot Action Bot Skip Processing
-
-<a id="bot-action-none"></a>
-
-### Bot Action None
+`none` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="client-name-matcher"></a>
 
@@ -266,23 +238,15 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Cookie Matchers
 
-`check_not_present` - (Optional) Empty. This can be used for messages where no values are needed. See [Check Not Present](#cookie-matchers-check-not-present) below.
+`check_not_present` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`check_present` - (Optional) Empty. This can be used for messages where no values are needed. See [Check Present](#cookie-matchers-check-present) below.
+`check_present` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `invert_matcher` - (Optional) Invert Matcher. Invert Match of the expression defined (`Bool`).
 
 `item` - (Optional) Matcher. A matcher specifies multiple criteria for matching an input string. The match is considered successful if any of the criteria are satisfied. The set of supported match criteria includes a list of exact values and a list of regular expressions. See [Item](#cookie-matchers-item) below.
 
 `name` - (Optional) Cookie Name. A case-sensitive cookie name (`String`).
-
-<a id="cookie-matchers-check-not-present"></a>
-
-### Cookie Matchers Check Not Present
-
-<a id="cookie-matchers-check-present"></a>
-
-### Cookie Matchers Check Present
 
 <a id="cookie-matchers-item"></a>
 
@@ -306,23 +270,15 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Headers
 
-`check_not_present` - (Optional) Empty. This can be used for messages where no values are needed. See [Check Not Present](#headers-check-not-present) below.
+`check_not_present` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`check_present` - (Optional) Empty. This can be used for messages where no values are needed. See [Check Present](#headers-check-present) below.
+`check_present` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `invert_matcher` - (Optional) Invert Header Matcher. Invert the match result (`Bool`).
 
 `item` - (Optional) Matcher. A matcher specifies multiple criteria for matching an input string. The match is considered successful if any of the criteria are satisfied. The set of supported match criteria includes a list of exact values and a list of regular expressions. See [Item](#headers-item) below.
 
 `name` - (Optional) Header Name. A case-insensitive HTTP header name (`String`).
-
-<a id="headers-check-not-present"></a>
-
-### Headers Check Not Present
-
-<a id="headers-check-present"></a>
-
-### Headers Check Present
 
 <a id="headers-item"></a>
 
@@ -388,23 +344,15 @@ In addition to all arguments above, the following attributes are exported:
 
 ### JWT Claims
 
-`check_not_present` - (Optional) Empty. This can be used for messages where no values are needed. See [Check Not Present](#jwt-claims-check-not-present) below.
+`check_not_present` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`check_present` - (Optional) Empty. This can be used for messages where no values are needed. See [Check Present](#jwt-claims-check-present) below.
+`check_present` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `invert_matcher` - (Optional) Invert Matcher. Invert the match result (`Bool`).
 
 `item` - (Optional) Matcher. A matcher specifies multiple criteria for matching an input string. The match is considered successful if any of the criteria are satisfied. The set of supported match criteria includes a list of exact values and a list of regular expressions. See [Item](#jwt-claims-item) below.
 
 `name` - (Optional) JWT Claim Name. JWT claim name (`String`).
-
-<a id="jwt-claims-check-not-present"></a>
-
-### JWT Claims Check Not Present
-
-<a id="jwt-claims-check-present"></a>
-
-### JWT Claims Check Present
 
 <a id="jwt-claims-item"></a>
 
@@ -426,17 +374,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Mum Action
 
-`default` - (Optional) Empty. This can be used for messages where no values are needed. See [Default](#mum-action-default) below.
+`default` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`skip_processing` - (Optional) Empty. This can be used for messages where no values are needed. See [Skip Processing](#mum-action-skip-processing) below.
-
-<a id="mum-action-default"></a>
-
-### Mum Action Default
-
-<a id="mum-action-skip-processing"></a>
-
-### Mum Action Skip Processing
+`skip_processing` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="path"></a>
 
@@ -466,23 +406,15 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Query Params
 
-`check_not_present` - (Optional) Empty. This can be used for messages where no values are needed. See [Check Not Present](#query-params-check-not-present) below.
+`check_not_present` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`check_present` - (Optional) Empty. This can be used for messages where no values are needed. See [Check Present](#query-params-check-present) below.
+`check_present` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `invert_matcher` - (Optional) Invert Query Parameter Matcher. Invert the match result (`Bool`).
 
 `item` - (Optional) Matcher. A matcher specifies multiple criteria for matching an input string. The match is considered successful if any of the criteria are satisfied. The set of supported match criteria includes a list of exact values and a list of regular expressions. See [Item](#query-params-item) below.
 
 `key` - (Optional) Query Parameter Name. A case-sensitive HTTP query parameter name (`String`).
-
-<a id="query-params-check-not-present"></a>
-
-### Query Params Check Not Present
-
-<a id="query-params-check-present"></a>
-
-### Query Params Check Present
 
 <a id="query-params-item"></a>
 
@@ -500,125 +432,69 @@ In addition to all arguments above, the following attributes are exported:
 
 `max_cookie_count_exceeds` - (Optional) Match on the Count for all Cookies that exceed this value (`Number`).
 
-`max_cookie_count_none` - (Optional) Empty. This can be used for messages where no values are needed. See [Max Cookie Count None](#request-constraints-max-cookie-count-none) below.
+`max_cookie_count_none` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `max_cookie_key_size_exceeds` - (Optional) Match on the Name Size per Cookie that exceed this value (`Number`).
 
-`max_cookie_key_size_none` - (Optional) Empty. This can be used for messages where no values are needed. See [Max Cookie Key Size None](#request-constraints-max-cookie-key-size-none) below.
+`max_cookie_key_size_none` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `max_cookie_value_size_exceeds` - (Optional) Match on the Value Size per Cookie that exceed this value (`Number`).
 
-`max_cookie_value_size_none` - (Optional) Empty. This can be used for messages where no values are needed. See [Max Cookie Value Size None](#request-constraints-max-cookie-value-size-none) below.
+`max_cookie_value_size_none` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `max_header_count_exceeds` - (Optional) Match on the Count for all Headers that exceed this value (`Number`).
 
-`max_header_count_none` - (Optional) Empty. This can be used for messages where no values are needed. See [Max Header Count None](#request-constraints-max-header-count-none) below.
+`max_header_count_none` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `max_header_key_size_exceeds` - (Optional) Match on the Name Size per Header that exceed this value (`Number`).
 
-`max_header_key_size_none` - (Optional) Empty. This can be used for messages where no values are needed. See [Max Header Key Size None](#request-constraints-max-header-key-size-none) below.
+`max_header_key_size_none` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `max_header_value_size_exceeds` - (Optional) Match on the Value Size per Header that exceed this value (`Number`).
 
-`max_header_value_size_none` - (Optional) Empty. This can be used for messages where no values are needed. See [Max Header Value Size None](#request-constraints-max-header-value-size-none) below.
+`max_header_value_size_none` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `max_parameter_count_exceeds` - (Optional) Match on the Parameter Count that exceed this value (`Number`).
 
-`max_parameter_count_none` - (Optional) Empty. This can be used for messages where no values are needed. See [Max Parameter Count None](#request-constraints-max-parameter-count-none) below.
+`max_parameter_count_none` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `max_parameter_name_size_exceeds` - (Optional) Match on the Parameter Name Size that exceed this value (`Number`).
 
-`max_parameter_name_size_none` - (Optional) Empty. This can be used for messages where no values are needed. See [Max Parameter Name Size None](#request-constraints-max-parameter-name-size-none) below.
+`max_parameter_name_size_none` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `max_parameter_value_size_exceeds` - (Optional) Match on the Parameter Value Size that exceed this value (`Number`).
 
-`max_parameter_value_size_none` - (Optional) Empty. This can be used for messages where no values are needed. See [Max Parameter Value Size None](#request-constraints-max-parameter-value-size-none) below.
+`max_parameter_value_size_none` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `max_query_size_exceeds` - (Optional) Match on the URL Query Size that exceed this value (`Number`).
 
-`max_query_size_none` - (Optional) Empty. This can be used for messages where no values are needed. See [Max Query Size None](#request-constraints-max-query-size-none) below.
+`max_query_size_none` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `max_request_line_size_exceeds` - (Optional) Match on the Request Line Size that exceed this value (`Number`).
 
-`max_request_line_size_none` - (Optional) Empty. This can be used for messages where no values are needed. See [Max Request Line Size None](#request-constraints-max-request-line-size-none) below.
+`max_request_line_size_none` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `max_request_size_exceeds` - (Optional) Match on the Request Size that exceed this value (`Number`).
 
-`max_request_size_none` - (Optional) Empty. This can be used for messages where no values are needed. See [Max Request Size None](#request-constraints-max-request-size-none) below.
+`max_request_size_none` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `max_url_size_exceeds` - (Optional) Match on the URL Size that exceed this value (`Number`).
 
-`max_url_size_none` - (Optional) Empty. This can be used for messages where no values are needed. See [Max URL Size None](#request-constraints-max-url-size-none) below.
-
-<a id="request-constraints-max-cookie-count-none"></a>
-
-### Request Constraints Max Cookie Count None
-
-<a id="request-constraints-max-cookie-key-size-none"></a>
-
-### Request Constraints Max Cookie Key Size None
-
-<a id="request-constraints-max-cookie-value-size-none"></a>
-
-### Request Constraints Max Cookie Value Size None
-
-<a id="request-constraints-max-header-count-none"></a>
-
-### Request Constraints Max Header Count None
-
-<a id="request-constraints-max-header-key-size-none"></a>
-
-### Request Constraints Max Header Key Size None
-
-<a id="request-constraints-max-header-value-size-none"></a>
-
-### Request Constraints Max Header Value Size None
-
-<a id="request-constraints-max-parameter-count-none"></a>
-
-### Request Constraints Max Parameter Count None
-
-<a id="request-constraints-max-parameter-name-size-none"></a>
-
-### Request Constraints Max Parameter Name Size None
-
-<a id="request-constraints-max-parameter-value-size-none"></a>
-
-### Request Constraints Max Parameter Value Size None
-
-<a id="request-constraints-max-query-size-none"></a>
-
-### Request Constraints Max Query Size None
-
-<a id="request-constraints-max-request-line-size-none"></a>
-
-### Request Constraints Max Request Line Size None
-
-<a id="request-constraints-max-request-size-none"></a>
-
-### Request Constraints Max Request Size None
-
-<a id="request-constraints-max-url-size-none"></a>
-
-### Request Constraints Max URL Size None
+`max_url_size_none` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="segment-policy"></a>
 
 ### Segment Policy
 
-`dst_any` - (Optional) Empty. This can be used for messages where no values are needed. See [Dst Any](#segment-policy-dst-any) below.
+`dst_any` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `dst_segments` - (Optional) Segment List. List of references to Segments. See [Dst Segments](#segment-policy-dst-segments) below.
 
-`intra_segment` - (Optional) Empty. This can be used for messages where no values are needed. See [Intra Segment](#segment-policy-intra-segment) below.
+`intra_segment` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`src_any` - (Optional) Empty. This can be used for messages where no values are needed. See [Src Any](#segment-policy-src-any) below.
+`src_any` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `src_segments` - (Optional) Segment List. List of references to Segments. See [Src Segments](#segment-policy-src-segments) below.
-
-<a id="segment-policy-dst-any"></a>
-
-### Segment Policy Dst Any
 
 <a id="segment-policy-dst-segments"></a>
 
@@ -635,14 +511,6 @@ In addition to all arguments above, the following attributes are exported:
 `namespace` - (Optional) Namespace. When a configuration object(e.g. virtual_host) refers to another(e.g route) then namespace will hold the referred object's(e.g. route's) namespace (`String`).
 
 `tenant` - (Optional) Tenant. When a configuration object(e.g. virtual_host) refers to another(e.g route) then tenant will hold the referred object's(e.g. route's) tenant (`String`).
-
-<a id="segment-policy-intra-segment"></a>
-
-### Segment Policy Intra Segment
-
-<a id="segment-policy-src-any"></a>
-
-### Segment Policy Src Any
 
 <a id="segment-policy-src-segments"></a>
 
@@ -688,9 +556,9 @@ In addition to all arguments above, the following attributes are exported:
 
 `app_firewall_detection_control` - (Optional) App Firewall Detection Control. Define the list of Signature IDs, Violations, Attack Types and Bot Names that should be excluded from triggering on the defined match criteria. See [App Firewall Detection Control](#waf-action-app-firewall-detection-control) below.
 
-`none` - (Optional) Empty. This can be used for messages where no values are needed. See [None](#waf-action-none) below.
+`none` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`waf_skip_processing` - (Optional) Empty. This can be used for messages where no values are needed. See [WAF Skip Processing](#waf-action-waf-skip-processing) below.
+`waf_skip_processing` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="waf-action-app-firewall-detection-control"></a>
 
@@ -739,14 +607,6 @@ In addition to all arguments above, the following attributes are exported:
 `context_name` - (Optional) Context Name. Relevant only for contexts: Header, Cookie and Parameter. Name of the Context that the WAF Exclusion Rules will check. Wildcard matching can be used by prefixing or suffixing the context name with an wildcard asterisk (*) (`String`).
 
 `exclude_violation` - (Optional) App Firewall Violation Type. List of all supported Violation Types VIOL_NONE VIOL_FILETYPE VIOL_METHOD VIOL_MANDATORY_HEADER VIOL_HTTP_RESPONSE_STATUS VIOL_REQUEST_MAX_LENGTH VIOL_FILE_UPLOAD VIOL_FILE_UPLOAD_IN_BODY VIOL_XML_MALFORMED VIOL_JSON_MALFORMED VIOL_ASM_COOKIE_MODIFIED VIOL_HTTP_PROTOCOL_MULTIPLE_HOST_HEADERS VIOL_HTTP_PROTOCOL_BAD_HOST_HEADER_VALUE VIOL_HTTP_PROTOCOL_UNPARSABLE_REQUEST_CONTENT VIOL_HTTP_PROTOCOL_NULL_IN_REQUEST VIOL_HTTP_PROTOCOL_BAD_HTTP_VERSION VIOL_HTTP_PROTOCO... Possible values include `VIOL_NONE`, `VIOL_FILETYPE`, `VIOL_METHOD`, `VIOL_MANDATORY_HEADER`, `VIOL_HTTP_RESPONSE_STATUS`, `VIOL_REQUEST_MAX_LENGTH`, `VIOL_FILE_UPLOAD`, `VIOL_FILE_UPLOAD_IN_BODY`, `VIOL_XML_MALFORMED`, `VIOL_JSON_MALFORMED`, and others (`String`).
-
-<a id="waf-action-none"></a>
-
-### WAF Action None
-
-<a id="waf-action-waf-skip-processing"></a>
-
-### WAF Action WAF Skip Processing
 
 ## Import
 

--- a/docs/resources/site_mesh_group.md
+++ b/docs/resources/site_mesh_group.md
@@ -67,9 +67,9 @@ resource "f5xc_site_mesh_group" "example" {
 
 > **Note:** One of the arguments from this list "disable_re_fallback, enable_re_fallback" must be set.
 
-`disable_re_fallback` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable RE Fallback](#disable-re-fallback) below for details.
+`disable_re_fallback` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`enable_re_fallback` - (Optional) Empty. This can be used for messages where no values are needed. See [Enable RE Fallback](#enable-re-fallback) below for details.
+`enable_re_fallback` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 > **Note:** One of the arguments from this list "full_mesh, hub_mesh, spoke_mesh" must be set.
 
@@ -91,63 +91,31 @@ In addition to all arguments above, the following attributes are exported:
 
 ---
 
-<a id="disable-re-fallback"></a>
-
-### Disable RE Fallback
-
-<a id="enable-re-fallback"></a>
-
-### Enable RE Fallback
-
 <a id="full-mesh"></a>
 
 ### Full Mesh
 
-`control_and_data_plane_mesh` - (Optional) Empty. This can be used for messages where no values are needed. See [Control And Data Plane Mesh](#full-mesh-control-and-data-plane-mesh) below.
+`control_and_data_plane_mesh` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`data_plane_mesh` - (Optional) Empty. This can be used for messages where no values are needed. See [Data Plane Mesh](#full-mesh-data-plane-mesh) below.
-
-<a id="full-mesh-control-and-data-plane-mesh"></a>
-
-### Full Mesh Control And Data Plane Mesh
-
-<a id="full-mesh-data-plane-mesh"></a>
-
-### Full Mesh Data Plane Mesh
+`data_plane_mesh` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="hub-mesh"></a>
 
 ### Hub Mesh
 
-`control_and_data_plane_mesh` - (Optional) Empty. This can be used for messages where no values are needed. See [Control And Data Plane Mesh](#hub-mesh-control-and-data-plane-mesh) below.
+`control_and_data_plane_mesh` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`data_plane_mesh` - (Optional) Empty. This can be used for messages where no values are needed. See [Data Plane Mesh](#hub-mesh-data-plane-mesh) below.
-
-<a id="hub-mesh-control-and-data-plane-mesh"></a>
-
-### Hub Mesh Control And Data Plane Mesh
-
-<a id="hub-mesh-data-plane-mesh"></a>
-
-### Hub Mesh Data Plane Mesh
+`data_plane_mesh` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="spoke-mesh"></a>
 
 ### Spoke Mesh
 
-`control_and_data_plane_mesh` - (Optional) Empty. This can be used for messages where no values are needed. See [Control And Data Plane Mesh](#spoke-mesh-control-and-data-plane-mesh) below.
+`control_and_data_plane_mesh` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`data_plane_mesh` - (Optional) Empty. This can be used for messages where no values are needed. See [Data Plane Mesh](#spoke-mesh-data-plane-mesh) below.
+`data_plane_mesh` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `hub_mesh_group` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Hub Mesh Group](#spoke-mesh-hub-mesh-group) below.
-
-<a id="spoke-mesh-control-and-data-plane-mesh"></a>
-
-### Spoke Mesh Control And Data Plane Mesh
-
-<a id="spoke-mesh-data-plane-mesh"></a>
-
-### Spoke Mesh Data Plane Mesh
 
 <a id="spoke-mesh-hub-mesh-group"></a>
 

--- a/docs/resources/subnet.md
+++ b/docs/resources/subnet.md
@@ -66,9 +66,9 @@ resource "f5xc_subnet" "example" {
 
 `connect_to_layer2` - (Optional) Subnet connection to Layer2 Interface. See [Connect To Layer2](#connect-to-layer2) below for details.
 
-`connect_to_slo` - (Optional) Empty. This can be used for messages where no values are needed. See [Connect To Slo](#connect-to-slo) below for details.
+`connect_to_slo` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`isolated_nw` - (Optional) Empty. This can be used for messages where no values are needed. See [Isolated Nw](#isolated-nw) below for details.
+`isolated_nw` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `site_subnet_params` - (Optional) Site Subnet Parameters. Configure subnet parameters per site. See [Site Subnet Params](#site-subnet-params) below for details.
 
@@ -98,29 +98,17 @@ In addition to all arguments above, the following attributes are exported:
 
 `tenant` - (Optional) Tenant. When a configuration object(e.g. virtual_host) refers to another(e.g route) then tenant will hold the referred object's(e.g. route's) tenant (`String`).
 
-<a id="connect-to-slo"></a>
-
-### Connect To Slo
-
-<a id="isolated-nw"></a>
-
-### Isolated Nw
-
 <a id="site-subnet-params"></a>
 
 ### Site Subnet Params
 
-`dhcp` - (Optional) Empty. This can be used for messages where no values are needed. See [DHCP](#site-subnet-params-dhcp) below.
+`dhcp` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `site` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Site](#site-subnet-params-site) below.
 
-`static_ip` - (Optional) Empty. This can be used for messages where no values are needed. See [Static IP](#site-subnet-params-static-ip) below.
+`static_ip` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `subnet_dhcp_server_params` - (Optional) Subnet DHCP parameters. Subnet DHCP parameters will be a subset of network_interface.DHCPServerParametersType as all features in network_interface.DHCPServerParametersType may not be supported in a subnet. See [Subnet DHCP Server Params](#site-subnet-params-subnet-dhcp-server-params) below.
-
-<a id="site-subnet-params-dhcp"></a>
-
-### Site Subnet Params DHCP
 
 <a id="site-subnet-params-site"></a>
 
@@ -131,10 +119,6 @@ In addition to all arguments above, the following attributes are exported:
 `namespace` - (Optional) Namespace. When a configuration object(e.g. virtual_host) refers to another(e.g route) then namespace will hold the referred object's(e.g. route's) namespace (`String`).
 
 `tenant` - (Optional) Tenant. When a configuration object(e.g. virtual_host) refers to another(e.g route) then tenant will hold the referred object's(e.g. route's) tenant (`String`).
-
-<a id="site-subnet-params-static-ip"></a>
-
-### Site Subnet Params Static IP
 
 <a id="site-subnet-params-subnet-dhcp-server-params"></a>
 

--- a/docs/resources/tcp_loadbalancer.md
+++ b/docs/resources/tcp_loadbalancer.md
@@ -75,9 +75,9 @@ resource "f5xc_tcp_loadbalancer" "example" {
 
 `active_service_policies` - (Optional) Service Policy List. List of service policies. See [Active Service Policies](#active-service-policies) below for details.
 
-`no_service_policies` - (Optional) Empty. This can be used for messages where no values are needed. See [No Service Policies](#no-service-policies) below for details.
+`no_service_policies` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`service_policies_from_namespace` - (Optional) Empty. This can be used for messages where no values are needed. See [Service Policies From Namespace](#service-policies-from-namespace) below for details.
+`service_policies_from_namespace` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 > **Note:** One of the arguments from this list "advertise_custom, advertise_on_public, advertise_on_public_default_vip, do_not_advertise" must be set.
 
@@ -85,37 +85,37 @@ resource "f5xc_tcp_loadbalancer" "example" {
 
 `advertise_on_public` - (Optional) Advertise Public. This defines a way to advertise a load balancer on public. If optional public_ip is provided, it will only be advertised on RE sites where that public_ip is available. See [Advertise On Public](#advertise-on-public) below for details.
 
-`advertise_on_public_default_vip` - (Optional) Empty. This can be used for messages where no values are needed. See [Advertise On Public Default VIP](#advertise-on-public-default-vip) below for details.
+`advertise_on_public_default_vip` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`do_not_advertise` - (Optional) Empty. This can be used for messages where no values are needed. See [Do Not Advertise](#do-not-advertise) below for details.
+`do_not_advertise` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 > **Note:** One of the arguments from this list "default_lb_with_sni, no_sni, sni" must be set.
 
-`default_lb_with_sni` - (Optional) Empty. This can be used for messages where no values are needed. See [Default LB With Sni](#default-lb-with-sni) below for details.
+`default_lb_with_sni` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_sni` - (Optional) Empty. This can be used for messages where no values are needed. See [No Sni](#no-sni) below for details.
+`no_sni` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`sni` - (Optional) Empty. This can be used for messages where no values are needed. See [Sni](#sni) below for details.
+`sni` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `dns_volterra_managed` - (Optional) Automatically Manage DNS Records. DNS records for domains will be managed automatically by Volterra. This requires the domain to be delegated to F5XC using the Delegated Domain feature (`Bool`).
 
 > **Note:** One of the arguments from this list "do_not_retract_cluster, retract_cluster" must be set.
 
-`do_not_retract_cluster` - (Optional) Empty. This can be used for messages where no values are needed. See [Do Not Retract Cluster](#do-not-retract-cluster) below for details.
+`do_not_retract_cluster` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`retract_cluster` - (Optional) Empty. This can be used for messages where no values are needed. See [Retract Cluster](#retract-cluster) below for details.
+`retract_cluster` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `domains` - (Optional) Domains. A list of Domains (host/authority header) that will be matched to this Load Balancer. Supported Domains and search order: 1. Exact Domain names: `www.foo.com.` 2. Domains starting with a Wildcard: *.foo.com. Not supported Domains: - Just a Wildcard: * - A Wildcard and TLD with no root Domain: *.com. - A Wildcard not matching a whole DNS label. e.g. *.foo.com and *.bar.foo.com are valid Wildcards however *bar.foo.com, *-bar.foo.com, and bar*.foo.com are all invalid. Additional notes: A (`List`).
 
 > **Note:** One of the arguments from this list "hash_policy_choice_least_active, hash_policy_choice_random, hash_policy_choice_round_robin, hash_policy_choice_source_ip_stickiness" must be set.
 
-`hash_policy_choice_least_active` - (Optional) Empty. This can be used for messages where no values are needed. See [Hash Policy Choice Least Active](#hash-policy-choice-least-active) below for details.
+`hash_policy_choice_least_active` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`hash_policy_choice_random` - (Optional) Empty. This can be used for messages where no values are needed. See [Hash Policy Choice Random](#hash-policy-choice-random) below for details.
+`hash_policy_choice_random` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`hash_policy_choice_round_robin` - (Optional) Empty. This can be used for messages where no values are needed. See [Hash Policy Choice Round Robin](#hash-policy-choice-round-robin) below for details.
+`hash_policy_choice_round_robin` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`hash_policy_choice_source_ip_stickiness` - (Optional) Empty. This can be used for messages where no values are needed. See [Hash Policy Choice Source IP Stickiness](#hash-policy-choice-source-ip-stickiness) below for details.
+`hash_policy_choice_source_ip_stickiness` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `idle_timeout` - (Optional) Idle Timeout. The amount of time that a stream can exist without upstream or downstream activity, in milliseconds (`Number`).
 
@@ -129,7 +129,7 @@ resource "f5xc_tcp_loadbalancer" "example" {
 
 > **Note:** One of the arguments from this list "tcp, tls_tcp, tls_tcp_auto_cert" must be set.
 
-`tcp` - (Optional) Empty. This can be used for messages where no values are needed. See [TCP](#tcp) below for details.
+`tcp` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `tls_tcp` - (Optional) BYOC TLS over TCP Choice. Choice for selecting TLS over TCP proxy with bring your own certificates. See [TLS TCP](#tls-tcp) below for details.
 
@@ -179,7 +179,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `site` - (Optional) Site. This defines a reference to a CE site along with network type and an optional IP address where a load balancer could be advertised. See [Site](#advertise-custom-advertise-where-site) below.
 
-`use_default_port` - (Optional) Empty. This can be used for messages where no values are needed. See [Use Default Port](#advertise-custom-advertise-where-use-default-port) below.
+`use_default_port` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `virtual_network` - (Optional) Virtual Network. Parameters to advertise on a given virtual network. See [Virtual Network](#advertise-custom-advertise-where-virtual-network) below.
 
@@ -193,11 +193,7 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Advertise Custom Advertise Where Advertise On Public
 
-`public_ip` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Public IP](#advertise-custom-advertise-where-advertise-on-public-public-ip) below.
-
-<a id="advertise-custom-advertise-where-advertise-on-public-public-ip"></a>
-
-### Advertise Custom Advertise Where Advertise On Public Public IP
+`public_ip` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name (`Block`).
 
 <a id="advertise-custom-advertise-where-site"></a>
 
@@ -207,41 +203,21 @@ In addition to all arguments above, the following attributes are exported:
 
 `network` - (Optional) Site Network. This defines network types to be used on site All inside and outside networks. All inside and outside networks with internet VIP support. All inside networks. All outside networks. All outside networks with internet VIP support. vK8s service network. - SITE_NETWORK_IP_FABRIC: VER IP Fabric network for the site This Virtual network type is used for exposing virtual host on IP Fabric network on the VER site or for endpoint in IP Fabric network. Possible values are `SITE_NETWORK_INSIDE_AND_OUTSIDE`, `SITE_NETWORK_INSIDE`, `SITE_NETWORK_OUTSIDE`, `SITE_NETWORK_SERVICE`, `SITE_NETWORK_OUTSIDE_WITH_INTERNET_VIP`, `SITE_NETWORK_INSIDE_AND_OUTSIDE_WITH_INTERNET_VIP`, `SITE_NETWORK_IP_FABRIC`. Defaults to `SITE_NETWORK_INSIDE_AND_OUTSIDE` (`String`).
 
-`site` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Site](#advertise-custom-advertise-where-site-site) below.
-
-<a id="advertise-custom-advertise-where-site-site"></a>
-
-### Advertise Custom Advertise Where Site Site
-
-<a id="advertise-custom-advertise-where-use-default-port"></a>
-
-### Advertise Custom Advertise Where Use Default Port
+`site` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name (`Block`).
 
 <a id="advertise-custom-advertise-where-virtual-network"></a>
 
 ### Advertise Custom Advertise Where Virtual Network
 
-`default_v6_vip` - (Optional) Empty. This can be used for messages where no values are needed. See [Default V6 VIP](#advertise-custom-advertise-where-virtual-network-default-v6-vip) below.
+`default_v6_vip` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`default_vip` - (Optional) Empty. This can be used for messages where no values are needed. See [Default VIP](#advertise-custom-advertise-where-virtual-network-default-vip) below.
+`default_vip` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `specific_v6_vip` - (Optional) Specific V6 VIP. Use given IPv6 address as VIP on virtual Network (`String`).
 
 `specific_vip` - (Optional) Specific V4 VIP. Use given IPv4 address as VIP on virtual Network (`String`).
 
-`virtual_network` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Virtual Network](#advertise-custom-advertise-where-virtual-network-virtual-network) below.
-
-<a id="advertise-custom-advertise-where-virtual-network-default-v6-vip"></a>
-
-### Advertise Custom Advertise Where Virtual Network Default V6 VIP
-
-<a id="advertise-custom-advertise-where-virtual-network-default-vip"></a>
-
-### Advertise Custom Advertise Where Virtual Network Default VIP
-
-<a id="advertise-custom-advertise-where-virtual-network-virtual-network"></a>
-
-### Advertise Custom Advertise Where Virtual Network Virtual Network
+`virtual_network` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name (`Block`).
 
 <a id="advertise-custom-advertise-where-virtual-site"></a>
 
@@ -249,11 +225,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `network` - (Optional) Site Network. This defines network types to be used on site All inside and outside networks. All inside and outside networks with internet VIP support. All inside networks. All outside networks. All outside networks with internet VIP support. vK8s service network. - SITE_NETWORK_IP_FABRIC: VER IP Fabric network for the site This Virtual network type is used for exposing virtual host on IP Fabric network on the VER site or for endpoint in IP Fabric network. Possible values are `SITE_NETWORK_INSIDE_AND_OUTSIDE`, `SITE_NETWORK_INSIDE`, `SITE_NETWORK_OUTSIDE`, `SITE_NETWORK_SERVICE`, `SITE_NETWORK_OUTSIDE_WITH_INTERNET_VIP`, `SITE_NETWORK_INSIDE_AND_OUTSIDE_WITH_INTERNET_VIP`, `SITE_NETWORK_IP_FABRIC`. Defaults to `SITE_NETWORK_INSIDE_AND_OUTSIDE` (`String`).
 
-`virtual_site` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Virtual Site](#advertise-custom-advertise-where-virtual-site-virtual-site) below.
-
-<a id="advertise-custom-advertise-where-virtual-site-virtual-site"></a>
-
-### Advertise Custom Advertise Where Virtual Site Virtual Site
+`virtual_site` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name (`Block`).
 
 <a id="advertise-custom-advertise-where-virtual-site-with-vip"></a>
 
@@ -263,27 +235,15 @@ In addition to all arguments above, the following attributes are exported:
 
 `network` - (Optional) Site Network. This defines network types to be used on virtual-site with specified VIP All outside networks. All inside networks. Possible values are `SITE_NETWORK_SPECIFIED_VIP_OUTSIDE`, `SITE_NETWORK_SPECIFIED_VIP_INSIDE`. Defaults to `SITE_NETWORK_SPECIFIED_VIP_OUTSIDE` (`String`).
 
-`virtual_site` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Virtual Site](#advertise-custom-advertise-where-virtual-site-with-vip-virtual-site) below.
-
-<a id="advertise-custom-advertise-where-virtual-site-with-vip-virtual-site"></a>
-
-### Advertise Custom Advertise Where Virtual Site With VIP Virtual Site
+`virtual_site` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name (`Block`).
 
 <a id="advertise-custom-advertise-where-vk8s-service"></a>
 
 ### Advertise Custom Advertise Where Vk8s Service
 
-`site` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Site](#advertise-custom-advertise-where-vk8s-service-site) below.
+`site` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name (`Block`).
 
-`virtual_site` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Virtual Site](#advertise-custom-advertise-where-vk8s-service-virtual-site) below.
-
-<a id="advertise-custom-advertise-where-vk8s-service-site"></a>
-
-### Advertise Custom Advertise Where Vk8s Service Site
-
-<a id="advertise-custom-advertise-where-vk8s-service-virtual-site"></a>
-
-### Advertise Custom Advertise Where Vk8s Service Virtual Site
+`virtual_site` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name (`Block`).
 
 <a id="advertise-on-public"></a>
 
@@ -301,53 +261,13 @@ In addition to all arguments above, the following attributes are exported:
 
 `tenant` - (Optional) Tenant. When a configuration object(e.g. virtual_host) refers to another(e.g route) then tenant will hold the referred object's(e.g. route's) tenant (`String`).
 
-<a id="advertise-on-public-default-vip"></a>
-
-### Advertise On Public Default VIP
-
-<a id="default-lb-with-sni"></a>
-
-### Default LB With Sni
-
-<a id="do-not-advertise"></a>
-
-### Do Not Advertise
-
-<a id="do-not-retract-cluster"></a>
-
-### Do Not Retract Cluster
-
-<a id="hash-policy-choice-least-active"></a>
-
-### Hash Policy Choice Least Active
-
-<a id="hash-policy-choice-random"></a>
-
-### Hash Policy Choice Random
-
-<a id="hash-policy-choice-round-robin"></a>
-
-### Hash Policy Choice Round Robin
-
-<a id="hash-policy-choice-source-ip-stickiness"></a>
-
-### Hash Policy Choice Source IP Stickiness
-
-<a id="no-service-policies"></a>
-
-### No Service Policies
-
-<a id="no-sni"></a>
-
-### No Sni
-
 <a id="origin-pools-weights"></a>
 
 ### Origin Pools Weights
 
 `cluster` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Cluster](#origin-pools-weights-cluster) below.
 
-`endpoint_subsets` - (Optional) Origin Servers Subsets. Upstream origin pool may be configured to divide its origin servers into subsets based on metadata attached to the origin servers. Routes may then specify the metadata that a endpoint must match in order to be selected by the load balancer For origin servers which are discovered in K8S or Consul cluster, the label of the service is merged with endpoint's labels. In case of Consul, the label is derived from the 'Tag' field. For labels that are common between configured. See [Endpoint Subsets](#origin-pools-weights-endpoint-subsets) below.
+`endpoint_subsets` - (Optional) Origin Servers Subsets. Upstream origin pool may be configured to divide its origin servers into subsets based on metadata attached to the origin servers. Routes may then specify the metadata that a endpoint must match in order to be selected by the load balancer For origin servers which are discovered in K8S or Consul cluster, the label of the service is merged with endpoint's labels. In case of Consul, the label is derived from the 'Tag' field. For labels that are common between configured (`Block`).
 
 `pool` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Pool](#origin-pools-weights-pool) below.
 
@@ -365,10 +285,6 @@ In addition to all arguments above, the following attributes are exported:
 
 `tenant` - (Optional) Tenant. When a configuration object(e.g. virtual_host) refers to another(e.g route) then tenant will hold the referred object's(e.g. route's) tenant (`String`).
 
-<a id="origin-pools-weights-endpoint-subsets"></a>
-
-### Origin Pools Weights Endpoint Subsets
-
 <a id="origin-pools-weights-pool"></a>
 
 ### Origin Pools Weights Pool
@@ -378,22 +294,6 @@ In addition to all arguments above, the following attributes are exported:
 `namespace` - (Optional) Namespace. When a configuration object(e.g. virtual_host) refers to another(e.g route) then namespace will hold the referred object's(e.g. route's) namespace (`String`).
 
 `tenant` - (Optional) Tenant. When a configuration object(e.g. virtual_host) refers to another(e.g route) then tenant will hold the referred object's(e.g. route's) tenant (`String`).
-
-<a id="retract-cluster"></a>
-
-### Retract Cluster
-
-<a id="service-policies-from-namespace"></a>
-
-### Service Policies From Namespace
-
-<a id="sni"></a>
-
-### Sni
-
-<a id="tcp"></a>
-
-### TCP
 
 <a id="timeouts"></a>
 
@@ -421,7 +321,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `certificates` - (Optional) Certificates. Select one or more certificates with any domain names. See [Certificates](#tls-tcp-tls-cert-params-certificates) below.
 
-`no_mtls` - (Optional) Empty. This can be used for messages where no values are needed. See [No mTLS](#tls-tcp-tls-cert-params-no-mtls) below.
+`no_mtls` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `tls_config` - (Optional) TLS Config. This defines various options to configure TLS configuration parameters. See [TLS Config](#tls-tcp-tls-cert-params-tls-config) below.
 
@@ -437,37 +337,17 @@ In addition to all arguments above, the following attributes are exported:
 
 `tenant` - (Optional) Tenant. When a configuration object(e.g. virtual_host) refers to another(e.g route) then tenant will hold the referred object's(e.g. route's) tenant (`String`).
 
-<a id="tls-tcp-tls-cert-params-no-mtls"></a>
-
-### TLS TCP TLS Cert Params No mTLS
-
 <a id="tls-tcp-tls-cert-params-tls-config"></a>
 
 ### TLS TCP TLS Cert Params TLS Config
 
-`custom_security` - (Optional) Custom Ciphers. This defines TLS protocol config including min/max versions and allowed ciphers. See [Custom Security](#tls-tcp-tls-cert-params-tls-config-custom-security) below.
+`custom_security` - (Optional) Custom Ciphers. This defines TLS protocol config including min/max versions and allowed ciphers (`Block`).
 
-`default_security` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Security](#tls-tcp-tls-cert-params-tls-config-default-security) below.
+`default_security` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`low_security` - (Optional) Empty. This can be used for messages where no values are needed. See [Low Security](#tls-tcp-tls-cert-params-tls-config-low-security) below.
+`low_security` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`medium_security` - (Optional) Empty. This can be used for messages where no values are needed. See [Medium Security](#tls-tcp-tls-cert-params-tls-config-medium-security) below.
-
-<a id="tls-tcp-tls-cert-params-tls-config-custom-security"></a>
-
-### TLS TCP TLS Cert Params TLS Config Custom Security
-
-<a id="tls-tcp-tls-cert-params-tls-config-default-security"></a>
-
-### TLS TCP TLS Cert Params TLS Config Default Security
-
-<a id="tls-tcp-tls-cert-params-tls-config-low-security"></a>
-
-### TLS TCP TLS Cert Params TLS Config Low Security
-
-<a id="tls-tcp-tls-cert-params-tls-config-medium-security"></a>
-
-### TLS TCP TLS Cert Params TLS Config Medium Security
+`medium_security` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="tls-tcp-tls-cert-params-use-mtls"></a>
 
@@ -475,43 +355,23 @@ In addition to all arguments above, the following attributes are exported:
 
 `client_certificate_optional` - (Optional) Client Certificate Optional. Client certificate is optional. If the client has provided a certificate, the load balancer will verify it. If certification verification fails, the connection will be terminated. If the client does not provide a certificate, the connection will be accepted (`Bool`).
 
-`crl` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [CRL](#tls-tcp-tls-cert-params-use-mtls-crl) below.
+`crl` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name (`Block`).
 
-`no_crl` - (Optional) Empty. This can be used for messages where no values are needed. See [No CRL](#tls-tcp-tls-cert-params-use-mtls-no-crl) below.
+`no_crl` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`trusted_ca` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Trusted CA](#tls-tcp-tls-cert-params-use-mtls-trusted-ca) below.
+`trusted_ca` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name (`Block`).
 
 `trusted_ca_url` - (Optional) Inline Root CA Certificate (legacy). Upload a Root CA Certificate specifically for this Load Balancer (`String`).
 
-`xfcc_disabled` - (Optional) Empty. This can be used for messages where no values are needed. See [Xfcc Disabled](#tls-tcp-tls-cert-params-use-mtls-xfcc-disabled) below.
+`xfcc_disabled` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`xfcc_options` - (Optional) XFCC Header Elements. X-Forwarded-Client-Cert header elements to be added to requests. See [Xfcc Options](#tls-tcp-tls-cert-params-use-mtls-xfcc-options) below.
-
-<a id="tls-tcp-tls-cert-params-use-mtls-crl"></a>
-
-### TLS TCP TLS Cert Params Use mTLS CRL
-
-<a id="tls-tcp-tls-cert-params-use-mtls-no-crl"></a>
-
-### TLS TCP TLS Cert Params Use mTLS No CRL
-
-<a id="tls-tcp-tls-cert-params-use-mtls-trusted-ca"></a>
-
-### TLS TCP TLS Cert Params Use mTLS Trusted CA
-
-<a id="tls-tcp-tls-cert-params-use-mtls-xfcc-disabled"></a>
-
-### TLS TCP TLS Cert Params Use mTLS Xfcc Disabled
-
-<a id="tls-tcp-tls-cert-params-use-mtls-xfcc-options"></a>
-
-### TLS TCP TLS Cert Params Use mTLS Xfcc Options
+`xfcc_options` - (Optional) XFCC Header Elements. X-Forwarded-Client-Cert header elements to be added to requests (`Block`).
 
 <a id="tls-tcp-tls-parameters"></a>
 
 ### TLS TCP TLS Parameters
 
-`no_mtls` - (Optional) Empty. This can be used for messages where no values are needed. See [No mTLS](#tls-tcp-tls-parameters-no-mtls) below.
+`no_mtls` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `tls_certificates` - (Optional) TLS Certificates. Users can add one or more certificates that share the same set of domains. for example, domain.com and *.domain.com - but use different signature algorithms. See [TLS Certificates](#tls-tcp-tls-parameters-tls-certificates) below.
 
@@ -519,69 +379,33 @@ In addition to all arguments above, the following attributes are exported:
 
 `use_mtls` - (Optional) Clients TLS validation context. Validation context for downstream client TLS connections. See [Use mTLS](#tls-tcp-tls-parameters-use-mtls) below.
 
-<a id="tls-tcp-tls-parameters-no-mtls"></a>
-
-### TLS TCP TLS Parameters No mTLS
-
 <a id="tls-tcp-tls-parameters-tls-certificates"></a>
 
 ### TLS TCP TLS Parameters TLS Certificates
 
 `certificate_url` - (Optional) Certificate. TLS certificate. Certificate or certificate chain in PEM format including the PEM headers (`String`).
 
-`custom_hash_algorithms` - (Optional) Hash Algorithms. Specifies the hash algorithms to be used. See [Custom Hash Algorithms](#tls-tcp-tls-parameters-tls-certificates-custom-hash-algorithms) below.
+`custom_hash_algorithms` - (Optional) Hash Algorithms. Specifies the hash algorithms to be used (`Block`).
 
 `description` - (Optional) Configuration for description (`String`).
 
-`disable_ocsp_stapling` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable OCSP Stapling](#tls-tcp-tls-parameters-tls-certificates-disable-ocsp-stapling) below.
+`disable_ocsp_stapling` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`private_key` - (Optional) Secret. SecretType is used in an object to indicate a sensitive/confidential field. See [Private Key](#tls-tcp-tls-parameters-tls-certificates-private-key) below.
+`private_key` - (Optional) Secret. SecretType is used in an object to indicate a sensitive/confidential field (`Block`).
 
-`use_system_defaults` - (Optional) Empty. This can be used for messages where no values are needed. See [Use System Defaults](#tls-tcp-tls-parameters-tls-certificates-use-system-defaults) below.
-
-<a id="tls-tcp-tls-parameters-tls-certificates-custom-hash-algorithms"></a>
-
-### TLS TCP TLS Parameters TLS Certificates Custom Hash Algorithms
-
-<a id="tls-tcp-tls-parameters-tls-certificates-disable-ocsp-stapling"></a>
-
-### TLS TCP TLS Parameters TLS Certificates Disable OCSP Stapling
-
-<a id="tls-tcp-tls-parameters-tls-certificates-private-key"></a>
-
-### TLS TCP TLS Parameters TLS Certificates Private Key
-
-<a id="tls-tcp-tls-parameters-tls-certificates-use-system-defaults"></a>
-
-### TLS TCP TLS Parameters TLS Certificates Use System Defaults
+`use_system_defaults` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="tls-tcp-tls-parameters-tls-config"></a>
 
 ### TLS TCP TLS Parameters TLS Config
 
-`custom_security` - (Optional) Custom Ciphers. This defines TLS protocol config including min/max versions and allowed ciphers. See [Custom Security](#tls-tcp-tls-parameters-tls-config-custom-security) below.
+`custom_security` - (Optional) Custom Ciphers. This defines TLS protocol config including min/max versions and allowed ciphers (`Block`).
 
-`default_security` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Security](#tls-tcp-tls-parameters-tls-config-default-security) below.
+`default_security` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`low_security` - (Optional) Empty. This can be used for messages where no values are needed. See [Low Security](#tls-tcp-tls-parameters-tls-config-low-security) below.
+`low_security` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`medium_security` - (Optional) Empty. This can be used for messages where no values are needed. See [Medium Security](#tls-tcp-tls-parameters-tls-config-medium-security) below.
-
-<a id="tls-tcp-tls-parameters-tls-config-custom-security"></a>
-
-### TLS TCP TLS Parameters TLS Config Custom Security
-
-<a id="tls-tcp-tls-parameters-tls-config-default-security"></a>
-
-### TLS TCP TLS Parameters TLS Config Default Security
-
-<a id="tls-tcp-tls-parameters-tls-config-low-security"></a>
-
-### TLS TCP TLS Parameters TLS Config Low Security
-
-<a id="tls-tcp-tls-parameters-tls-config-medium-security"></a>
-
-### TLS TCP TLS Parameters TLS Config Medium Security
+`medium_security` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="tls-tcp-tls-parameters-use-mtls"></a>
 
@@ -589,51 +413,27 @@ In addition to all arguments above, the following attributes are exported:
 
 `client_certificate_optional` - (Optional) Client Certificate Optional. Client certificate is optional. If the client has provided a certificate, the load balancer will verify it. If certification verification fails, the connection will be terminated. If the client does not provide a certificate, the connection will be accepted (`Bool`).
 
-`crl` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [CRL](#tls-tcp-tls-parameters-use-mtls-crl) below.
+`crl` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name (`Block`).
 
-`no_crl` - (Optional) Empty. This can be used for messages where no values are needed. See [No CRL](#tls-tcp-tls-parameters-use-mtls-no-crl) below.
+`no_crl` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`trusted_ca` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Trusted CA](#tls-tcp-tls-parameters-use-mtls-trusted-ca) below.
+`trusted_ca` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name (`Block`).
 
 `trusted_ca_url` - (Optional) Inline Root CA Certificate (legacy). Upload a Root CA Certificate specifically for this Load Balancer (`String`).
 
-`xfcc_disabled` - (Optional) Empty. This can be used for messages where no values are needed. See [Xfcc Disabled](#tls-tcp-tls-parameters-use-mtls-xfcc-disabled) below.
+`xfcc_disabled` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`xfcc_options` - (Optional) XFCC Header Elements. X-Forwarded-Client-Cert header elements to be added to requests. See [Xfcc Options](#tls-tcp-tls-parameters-use-mtls-xfcc-options) below.
-
-<a id="tls-tcp-tls-parameters-use-mtls-crl"></a>
-
-### TLS TCP TLS Parameters Use mTLS CRL
-
-<a id="tls-tcp-tls-parameters-use-mtls-no-crl"></a>
-
-### TLS TCP TLS Parameters Use mTLS No CRL
-
-<a id="tls-tcp-tls-parameters-use-mtls-trusted-ca"></a>
-
-### TLS TCP TLS Parameters Use mTLS Trusted CA
-
-<a id="tls-tcp-tls-parameters-use-mtls-xfcc-disabled"></a>
-
-### TLS TCP TLS Parameters Use mTLS Xfcc Disabled
-
-<a id="tls-tcp-tls-parameters-use-mtls-xfcc-options"></a>
-
-### TLS TCP TLS Parameters Use mTLS Xfcc Options
+`xfcc_options` - (Optional) XFCC Header Elements. X-Forwarded-Client-Cert header elements to be added to requests (`Block`).
 
 <a id="tls-tcp-auto-cert"></a>
 
 ### TLS TCP Auto Cert
 
-`no_mtls` - (Optional) Empty. This can be used for messages where no values are needed. See [No mTLS](#tls-tcp-auto-cert-no-mtls) below.
+`no_mtls` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `tls_config` - (Optional) TLS Config. This defines various options to configure TLS configuration parameters. See [TLS Config](#tls-tcp-auto-cert-tls-config) below.
 
 `use_mtls` - (Optional) Clients TLS validation context. Validation context for downstream client TLS connections. See [Use mTLS](#tls-tcp-auto-cert-use-mtls) below.
-
-<a id="tls-tcp-auto-cert-no-mtls"></a>
-
-### TLS TCP Auto Cert No mTLS
 
 <a id="tls-tcp-auto-cert-tls-config"></a>
 
@@ -641,11 +441,11 @@ In addition to all arguments above, the following attributes are exported:
 
 `custom_security` - (Optional) Custom Ciphers. This defines TLS protocol config including min/max versions and allowed ciphers. See [Custom Security](#tls-tcp-auto-cert-tls-config-custom-security) below.
 
-`default_security` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Security](#tls-tcp-auto-cert-tls-config-default-security) below.
+`default_security` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`low_security` - (Optional) Empty. This can be used for messages where no values are needed. See [Low Security](#tls-tcp-auto-cert-tls-config-low-security) below.
+`low_security` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`medium_security` - (Optional) Empty. This can be used for messages where no values are needed. See [Medium Security](#tls-tcp-auto-cert-tls-config-medium-security) below.
+`medium_security` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="tls-tcp-auto-cert-tls-config-custom-security"></a>
 
@@ -657,18 +457,6 @@ In addition to all arguments above, the following attributes are exported:
 
 `min_version` - (Optional) TLS Protocol. TlsProtocol is enumeration of supported TLS versions F5 Distributed Cloud will choose the optimal TLS version. Possible values are `TLS_AUTO`, `TLSv1_0`, `TLSv1_1`, `TLSv1_2`, `TLSv1_3`. Defaults to `TLS_AUTO` (`String`).
 
-<a id="tls-tcp-auto-cert-tls-config-default-security"></a>
-
-### TLS TCP Auto Cert TLS Config Default Security
-
-<a id="tls-tcp-auto-cert-tls-config-low-security"></a>
-
-### TLS TCP Auto Cert TLS Config Low Security
-
-<a id="tls-tcp-auto-cert-tls-config-medium-security"></a>
-
-### TLS TCP Auto Cert TLS Config Medium Security
-
 <a id="tls-tcp-auto-cert-use-mtls"></a>
 
 ### TLS TCP Auto Cert Use mTLS
@@ -677,13 +465,13 @@ In addition to all arguments above, the following attributes are exported:
 
 `crl` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [CRL](#tls-tcp-auto-cert-use-mtls-crl) below.
 
-`no_crl` - (Optional) Empty. This can be used for messages where no values are needed. See [No CRL](#tls-tcp-auto-cert-use-mtls-no-crl) below.
+`no_crl` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `trusted_ca` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Trusted CA](#tls-tcp-auto-cert-use-mtls-trusted-ca) below.
 
 `trusted_ca_url` - (Optional) Inline Root CA Certificate (legacy). Upload a Root CA Certificate specifically for this Load Balancer (`String`).
 
-`xfcc_disabled` - (Optional) Empty. This can be used for messages where no values are needed. See [Xfcc Disabled](#tls-tcp-auto-cert-use-mtls-xfcc-disabled) below.
+`xfcc_disabled` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `xfcc_options` - (Optional) XFCC Header Elements. X-Forwarded-Client-Cert header elements to be added to requests. See [Xfcc Options](#tls-tcp-auto-cert-use-mtls-xfcc-options) below.
 
@@ -697,10 +485,6 @@ In addition to all arguments above, the following attributes are exported:
 
 `tenant` - (Optional) Tenant. When a configuration object(e.g. virtual_host) refers to another(e.g route) then tenant will hold the referred object's(e.g. route's) tenant (`String`).
 
-<a id="tls-tcp-auto-cert-use-mtls-no-crl"></a>
-
-### TLS TCP Auto Cert Use mTLS No CRL
-
 <a id="tls-tcp-auto-cert-use-mtls-trusted-ca"></a>
 
 ### TLS TCP Auto Cert Use mTLS Trusted CA
@@ -710,10 +494,6 @@ In addition to all arguments above, the following attributes are exported:
 `namespace` - (Optional) Namespace. When a configuration object(e.g. virtual_host) refers to another(e.g route) then namespace will hold the referred object's(e.g. route's) namespace (`String`).
 
 `tenant` - (Optional) Tenant. When a configuration object(e.g. virtual_host) refers to another(e.g route) then tenant will hold the referred object's(e.g. route's) tenant (`String`).
-
-<a id="tls-tcp-auto-cert-use-mtls-xfcc-disabled"></a>
-
-### TLS TCP Auto Cert Use mTLS Xfcc Disabled
 
 <a id="tls-tcp-auto-cert-use-mtls-xfcc-options"></a>
 

--- a/docs/resources/tenant_profile.md
+++ b/docs/resources/tenant_profile.md
@@ -104,29 +104,21 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Favicon
 
-`aws_s3` - (Optional) Empty. This can be used for messages where no values are needed. See [AWS S3](#favicon-aws-s3) below.
+`aws_s3` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `content` - (Optional) Configuration for content (`String`).
 
 `content_type` - (Optional) Content Type. Content type of the file (MIME type) (`String`).
-
-<a id="favicon-aws-s3"></a>
-
-### Favicon AWS S3
 
 <a id="logo"></a>
 
 ### Logo
 
-`aws_s3` - (Optional) Empty. This can be used for messages where no values are needed. See [AWS S3](#logo-aws-s3) below.
+`aws_s3` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `content` - (Optional) Configuration for content (`String`).
 
 `content_type` - (Optional) Content Type. Content type of the file (MIME type) (`String`).
-
-<a id="logo-aws-s3"></a>
-
-### Logo AWS S3
 
 <a id="plan"></a>
 

--- a/docs/resources/tunnel.md
+++ b/docs/resources/tunnel.md
@@ -116,53 +116,29 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Local IP IP Address
 
-`auto` - (Optional) Empty. This can be used for messages where no values are needed. See [Auto](#local-ip-ip-address-auto) below.
+`auto` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `ip_address` - (Optional) IP Address. IP Address used to specify an IPv4 or IPv6 address. See [IP Address](#local-ip-ip-address-ip-address) below.
 
 `virtual_network_type` - (Optional) Virtual Network Type. Different types of virtual networks understood by the system. See [Virtual Network Type](#local-ip-ip-address-virtual-network-type) below.
 
-<a id="local-ip-ip-address-auto"></a>
-
-### Local IP IP Address Auto
-
 <a id="local-ip-ip-address-ip-address"></a>
 
 ### Local IP IP Address IP Address
 
-`ipv4` - (Optional) IPv4 Address. IPv4 Address in dot-decimal notation. See [IPv4](#local-ip-ip-address-ip-address-ipv4) below.
+`ipv4` - (Optional) IPv4 Address. IPv4 Address in dot-decimal notation (`Block`).
 
-`ipv6` - (Optional) IPv6 Address. IPv6 Address specified as hexadecimal numbers separated by ':'. See [IPv6](#local-ip-ip-address-ip-address-ipv6) below.
-
-<a id="local-ip-ip-address-ip-address-ipv4"></a>
-
-### Local IP IP Address IP Address IPv4
-
-<a id="local-ip-ip-address-ip-address-ipv6"></a>
-
-### Local IP IP Address IP Address IPv6
+`ipv6` - (Optional) IPv6 Address. IPv6 Address specified as hexadecimal numbers separated by ':' (`Block`).
 
 <a id="local-ip-ip-address-virtual-network-type"></a>
 
 ### Local IP IP Address Virtual Network Type
 
-`public` - (Optional) Empty. This can be used for messages where no values are needed. See [Public](#local-ip-ip-address-virtual-network-type-public) below.
+`public` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`site_local` - (Optional) Empty. This can be used for messages where no values are needed. See [Site Local](#local-ip-ip-address-virtual-network-type-site-local) below.
+`site_local` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`site_local_inside` - (Optional) Empty. This can be used for messages where no values are needed. See [Site Local Inside](#local-ip-ip-address-virtual-network-type-site-local-inside) below.
-
-<a id="local-ip-ip-address-virtual-network-type-public"></a>
-
-### Local IP IP Address Virtual Network Type Public
-
-<a id="local-ip-ip-address-virtual-network-type-site-local"></a>
-
-### Local IP IP Address Virtual Network Type Site Local
-
-<a id="local-ip-ip-address-virtual-network-type-site-local-inside"></a>
-
-### Local IP IP Address Virtual Network Type Site Local Inside
+`site_local_inside` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="params"></a>
 
@@ -180,17 +156,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Params Ipsec Ipsec Psk
 
-`blindfold_secret_info` - (Optional) Blindfold Secret. BlindfoldSecretInfoType specifies information about the Secret managed by F5XC Secret Management. See [Blindfold Secret Info](#params-ipsec-ipsec-psk-blindfold-secret-info) below.
+`blindfold_secret_info` - (Optional) Blindfold Secret. BlindfoldSecretInfoType specifies information about the Secret managed by F5XC Secret Management (`Block`).
 
-`clear_secret_info` - (Optional) In-Clear Secret. ClearSecretInfoType specifies information about the Secret that is not encrypted. See [Clear Secret Info](#params-ipsec-ipsec-psk-clear-secret-info) below.
-
-<a id="params-ipsec-ipsec-psk-blindfold-secret-info"></a>
-
-### Params Ipsec Ipsec Psk Blindfold Secret Info
-
-<a id="params-ipsec-ipsec-psk-clear-secret-info"></a>
-
-### Params Ipsec Ipsec Psk Clear Secret Info
+`clear_secret_info` - (Optional) In-Clear Secret. ClearSecretInfoType specifies information about the Secret that is not encrypted (`Block`).
 
 <a id="remote-ip"></a>
 
@@ -204,11 +172,7 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Remote IP Endpoints
 
-`endpoints` - (Optional) Remote Endpoints. Map of remote attributes to which tunnel will be established on per site node basis Every node can have a different attributes and IP address to connect to Key is ver node name and value is Remote node attributes. See [Endpoints](#remote-ip-endpoints-endpoints) below.
-
-<a id="remote-ip-endpoints-endpoints"></a>
-
-### Remote IP Endpoints Endpoints
+`endpoints` - (Optional) Remote Endpoints. Map of remote attributes to which tunnel will be established on per site node basis Every node can have a different attributes and IP address to connect to Key is ver node name and value is Remote node attributes (`Block`).
 
 <a id="remote-ip-ip"></a>
 

--- a/docs/resources/udp_loadbalancer.md
+++ b/docs/resources/udp_loadbalancer.md
@@ -74,9 +74,9 @@ resource "f5xc_udp_loadbalancer" "example" {
 
 `advertise_on_public` - (Optional) Advertise Public. This defines a way to advertise a load balancer on public. If optional public_ip is provided, it will only be advertised on RE sites where that public_ip is available. See [Advertise On Public](#advertise-on-public) below for details.
 
-`advertise_on_public_default_vip` - (Optional) Empty. This can be used for messages where no values are needed. See [Advertise On Public Default VIP](#advertise-on-public-default-vip) below for details.
+`advertise_on_public_default_vip` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`do_not_advertise` - (Optional) Empty. This can be used for messages where no values are needed. See [Do Not Advertise](#do-not-advertise) below for details.
+`do_not_advertise` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `dns_volterra_managed` - (Optional) Automatically Manage DNS Records. DNS records for domains will be managed automatically by F5 Distributed Cloud. As a prerequisite, the domain to be delegated to F5 Distributed Cloud using the Delegated Domain feature or a DNS CNAME record must be created in your DNS provider's portal (`Bool`).
 
@@ -86,11 +86,11 @@ resource "f5xc_udp_loadbalancer" "example" {
 
 > **Note:** One of the arguments from this list "hash_policy_choice_random, hash_policy_choice_round_robin, hash_policy_choice_source_ip_stickiness" must be set.
 
-`hash_policy_choice_random` - (Optional) Empty. This can be used for messages where no values are needed. See [Hash Policy Choice Random](#hash-policy-choice-random) below for details.
+`hash_policy_choice_random` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`hash_policy_choice_round_robin` - (Optional) Empty. This can be used for messages where no values are needed. See [Hash Policy Choice Round Robin](#hash-policy-choice-round-robin) below for details.
+`hash_policy_choice_round_robin` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`hash_policy_choice_source_ip_stickiness` - (Optional) Empty. This can be used for messages where no values are needed. See [Hash Policy Choice Source IP Stickiness](#hash-policy-choice-source-ip-stickiness) below for details.
+`hash_policy_choice_source_ip_stickiness` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `idle_timeout` - (Optional) Idle Timeout. The amount of time that a session can exist without upstream or downstream activity, in milliseconds (`Number`).
 
@@ -104,7 +104,7 @@ resource "f5xc_udp_loadbalancer" "example" {
 
 `timeouts` - (Optional) See [Timeouts](#timeouts) below for details.
 
-`udp` - (Optional) Empty. This can be used for messages where no values are needed. See [UDP](#udp) below for details.
+`udp` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 ### Attributes Reference
 
@@ -132,7 +132,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `site` - (Optional) Site. This defines a reference to a CE site along with network type and an optional IP address where a load balancer could be advertised. See [Site](#advertise-custom-advertise-where-site) below.
 
-`use_default_port` - (Optional) Empty. This can be used for messages where no values are needed. See [Use Default Port](#advertise-custom-advertise-where-use-default-port) below.
+`use_default_port` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `virtual_network` - (Optional) Virtual Network. Parameters to advertise on a given virtual network. See [Virtual Network](#advertise-custom-advertise-where-virtual-network) below.
 
@@ -146,11 +146,7 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Advertise Custom Advertise Where Advertise On Public
 
-`public_ip` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Public IP](#advertise-custom-advertise-where-advertise-on-public-public-ip) below.
-
-<a id="advertise-custom-advertise-where-advertise-on-public-public-ip"></a>
-
-### Advertise Custom Advertise Where Advertise On Public Public IP
+`public_ip` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name (`Block`).
 
 <a id="advertise-custom-advertise-where-site"></a>
 
@@ -160,41 +156,21 @@ In addition to all arguments above, the following attributes are exported:
 
 `network` - (Optional) Site Network. This defines network types to be used on site All inside and outside networks. All inside and outside networks with internet VIP support. All inside networks. All outside networks. All outside networks with internet VIP support. vK8s service network. - SITE_NETWORK_IP_FABRIC: VER IP Fabric network for the site This Virtual network type is used for exposing virtual host on IP Fabric network on the VER site or for endpoint in IP Fabric network. Possible values are `SITE_NETWORK_INSIDE_AND_OUTSIDE`, `SITE_NETWORK_INSIDE`, `SITE_NETWORK_OUTSIDE`, `SITE_NETWORK_SERVICE`, `SITE_NETWORK_OUTSIDE_WITH_INTERNET_VIP`, `SITE_NETWORK_INSIDE_AND_OUTSIDE_WITH_INTERNET_VIP`, `SITE_NETWORK_IP_FABRIC`. Defaults to `SITE_NETWORK_INSIDE_AND_OUTSIDE` (`String`).
 
-`site` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Site](#advertise-custom-advertise-where-site-site) below.
-
-<a id="advertise-custom-advertise-where-site-site"></a>
-
-### Advertise Custom Advertise Where Site Site
-
-<a id="advertise-custom-advertise-where-use-default-port"></a>
-
-### Advertise Custom Advertise Where Use Default Port
+`site` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name (`Block`).
 
 <a id="advertise-custom-advertise-where-virtual-network"></a>
 
 ### Advertise Custom Advertise Where Virtual Network
 
-`default_v6_vip` - (Optional) Empty. This can be used for messages where no values are needed. See [Default V6 VIP](#advertise-custom-advertise-where-virtual-network-default-v6-vip) below.
+`default_v6_vip` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`default_vip` - (Optional) Empty. This can be used for messages where no values are needed. See [Default VIP](#advertise-custom-advertise-where-virtual-network-default-vip) below.
+`default_vip` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `specific_v6_vip` - (Optional) Specific V6 VIP. Use given IPv6 address as VIP on virtual Network (`String`).
 
 `specific_vip` - (Optional) Specific V4 VIP. Use given IPv4 address as VIP on virtual Network (`String`).
 
-`virtual_network` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Virtual Network](#advertise-custom-advertise-where-virtual-network-virtual-network) below.
-
-<a id="advertise-custom-advertise-where-virtual-network-default-v6-vip"></a>
-
-### Advertise Custom Advertise Where Virtual Network Default V6 VIP
-
-<a id="advertise-custom-advertise-where-virtual-network-default-vip"></a>
-
-### Advertise Custom Advertise Where Virtual Network Default VIP
-
-<a id="advertise-custom-advertise-where-virtual-network-virtual-network"></a>
-
-### Advertise Custom Advertise Where Virtual Network Virtual Network
+`virtual_network` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name (`Block`).
 
 <a id="advertise-custom-advertise-where-virtual-site"></a>
 
@@ -202,11 +178,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `network` - (Optional) Site Network. This defines network types to be used on site All inside and outside networks. All inside and outside networks with internet VIP support. All inside networks. All outside networks. All outside networks with internet VIP support. vK8s service network. - SITE_NETWORK_IP_FABRIC: VER IP Fabric network for the site This Virtual network type is used for exposing virtual host on IP Fabric network on the VER site or for endpoint in IP Fabric network. Possible values are `SITE_NETWORK_INSIDE_AND_OUTSIDE`, `SITE_NETWORK_INSIDE`, `SITE_NETWORK_OUTSIDE`, `SITE_NETWORK_SERVICE`, `SITE_NETWORK_OUTSIDE_WITH_INTERNET_VIP`, `SITE_NETWORK_INSIDE_AND_OUTSIDE_WITH_INTERNET_VIP`, `SITE_NETWORK_IP_FABRIC`. Defaults to `SITE_NETWORK_INSIDE_AND_OUTSIDE` (`String`).
 
-`virtual_site` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Virtual Site](#advertise-custom-advertise-where-virtual-site-virtual-site) below.
-
-<a id="advertise-custom-advertise-where-virtual-site-virtual-site"></a>
-
-### Advertise Custom Advertise Where Virtual Site Virtual Site
+`virtual_site` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name (`Block`).
 
 <a id="advertise-custom-advertise-where-virtual-site-with-vip"></a>
 
@@ -216,27 +188,15 @@ In addition to all arguments above, the following attributes are exported:
 
 `network` - (Optional) Site Network. This defines network types to be used on virtual-site with specified VIP All outside networks. All inside networks. Possible values are `SITE_NETWORK_SPECIFIED_VIP_OUTSIDE`, `SITE_NETWORK_SPECIFIED_VIP_INSIDE`. Defaults to `SITE_NETWORK_SPECIFIED_VIP_OUTSIDE` (`String`).
 
-`virtual_site` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Virtual Site](#advertise-custom-advertise-where-virtual-site-with-vip-virtual-site) below.
-
-<a id="advertise-custom-advertise-where-virtual-site-with-vip-virtual-site"></a>
-
-### Advertise Custom Advertise Where Virtual Site With VIP Virtual Site
+`virtual_site` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name (`Block`).
 
 <a id="advertise-custom-advertise-where-vk8s-service"></a>
 
 ### Advertise Custom Advertise Where Vk8s Service
 
-`site` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Site](#advertise-custom-advertise-where-vk8s-service-site) below.
+`site` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name (`Block`).
 
-`virtual_site` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Virtual Site](#advertise-custom-advertise-where-vk8s-service-virtual-site) below.
-
-<a id="advertise-custom-advertise-where-vk8s-service-site"></a>
-
-### Advertise Custom Advertise Where Vk8s Service Site
-
-<a id="advertise-custom-advertise-where-vk8s-service-virtual-site"></a>
-
-### Advertise Custom Advertise Where Vk8s Service Virtual Site
+`virtual_site` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name (`Block`).
 
 <a id="advertise-on-public"></a>
 
@@ -254,33 +214,13 @@ In addition to all arguments above, the following attributes are exported:
 
 `tenant` - (Optional) Tenant. When a configuration object(e.g. virtual_host) refers to another(e.g route) then tenant will hold the referred object's(e.g. route's) tenant (`String`).
 
-<a id="advertise-on-public-default-vip"></a>
-
-### Advertise On Public Default VIP
-
-<a id="do-not-advertise"></a>
-
-### Do Not Advertise
-
-<a id="hash-policy-choice-random"></a>
-
-### Hash Policy Choice Random
-
-<a id="hash-policy-choice-round-robin"></a>
-
-### Hash Policy Choice Round Robin
-
-<a id="hash-policy-choice-source-ip-stickiness"></a>
-
-### Hash Policy Choice Source IP Stickiness
-
 <a id="origin-pools-weights"></a>
 
 ### Origin Pools Weights
 
 `cluster` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Cluster](#origin-pools-weights-cluster) below.
 
-`endpoint_subsets` - (Optional) Origin Servers Subsets. Upstream origin pool may be configured to divide its origin servers into subsets based on metadata attached to the origin servers. Routes may then specify the metadata that a endpoint must match in order to be selected by the load balancer For origin servers which are discovered in K8S or Consul cluster, the label of the service is merged with endpoint's labels. In case of Consul, the label is derived from the 'Tag' field. For labels that are common between configured. See [Endpoint Subsets](#origin-pools-weights-endpoint-subsets) below.
+`endpoint_subsets` - (Optional) Origin Servers Subsets. Upstream origin pool may be configured to divide its origin servers into subsets based on metadata attached to the origin servers. Routes may then specify the metadata that a endpoint must match in order to be selected by the load balancer For origin servers which are discovered in K8S or Consul cluster, the label of the service is merged with endpoint's labels. In case of Consul, the label is derived from the 'Tag' field. For labels that are common between configured (`Block`).
 
 `pool` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Pool](#origin-pools-weights-pool) below.
 
@@ -297,10 +237,6 @@ In addition to all arguments above, the following attributes are exported:
 `namespace` - (Optional) Namespace. When a configuration object(e.g. virtual_host) refers to another(e.g route) then namespace will hold the referred object's(e.g. route's) namespace (`String`).
 
 `tenant` - (Optional) Tenant. When a configuration object(e.g. virtual_host) refers to another(e.g route) then tenant will hold the referred object's(e.g. route's) tenant (`String`).
-
-<a id="origin-pools-weights-endpoint-subsets"></a>
-
-### Origin Pools Weights Endpoint Subsets
 
 <a id="origin-pools-weights-pool"></a>
 
@@ -323,10 +259,6 @@ In addition to all arguments above, the following attributes are exported:
 `read` - (Optional) A string that can be [parsed as a duration](`HTTPS://pkg.go.dev/time#ParseDuration`) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Read operations occur during any refresh or planning operation when refresh is enabled (`String`).
 
 `update` - (Optional) A string that can be [parsed as a duration](`HTTPS://pkg.go.dev/time#ParseDuration`) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours) (`String`).
-
-<a id="udp"></a>
-
-### UDP
 
 ## Import
 

--- a/docs/resources/user_identification.md
+++ b/docs/resources/user_identification.md
@@ -70,15 +70,15 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Rules
 
-`client_asn` - (Optional) Empty. This can be used for messages where no values are needed. See [Client Asn](#rules-client-asn) below.
+`client_asn` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`client_city` - (Optional) Empty. This can be used for messages where no values are needed. See [Client City](#rules-client-city) below.
+`client_city` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`client_country` - (Optional) Empty. This can be used for messages where no values are needed. See [Client Country](#rules-client-country) below.
+`client_country` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`client_ip` - (Optional) Empty. This can be used for messages where no values are needed. See [Client IP](#rules-client-ip) below.
+`client_ip` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`client_region` - (Optional) Empty. This can be used for messages where no values are needed. See [Client Region](#rules-client-region) below.
+`client_region` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `cookie_name` - (Optional) Cookie Name. Use the HTTP cookie value for the given name as user identifier (`String`).
 
@@ -86,59 +86,19 @@ In addition to all arguments above, the following attributes are exported:
 
 `ip_and_http_header_name` - (Optional) HTTP Header Name. Name of HTTP header from which the value should be extracted (`String`).
 
-`ip_and_ja4_tls_fingerprint` - (Optional) Empty. This can be used for messages where no values are needed. See [IP And Ja4 TLS Fingerprint](#rules-ip-and-ja4-tls-fingerprint) below.
+`ip_and_ja4_tls_fingerprint` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`ip_and_tls_fingerprint` - (Optional) Empty. This can be used for messages where no values are needed. See [IP And TLS Fingerprint](#rules-ip-and-tls-fingerprint) below.
+`ip_and_tls_fingerprint` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`ja4_tls_fingerprint` - (Optional) Empty. This can be used for messages where no values are needed. See [Ja4 TLS Fingerprint](#rules-ja4-tls-fingerprint) below.
+`ja4_tls_fingerprint` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `jwt_claim_name` - (Optional) JWT Claim Name. Use the JWT claim value as user identifier (`String`).
 
-`none` - (Optional) Empty. This can be used for messages where no values are needed. See [None](#rules-none) below.
+`none` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `query_param_key` - (Optional) Query Parameter Key. Use the query parameter value for the given key as user identifier (`String`).
 
-`tls_fingerprint` - (Optional) Empty. This can be used for messages where no values are needed. See [TLS Fingerprint](#rules-tls-fingerprint) below.
-
-<a id="rules-client-asn"></a>
-
-### Rules Client Asn
-
-<a id="rules-client-city"></a>
-
-### Rules Client City
-
-<a id="rules-client-country"></a>
-
-### Rules Client Country
-
-<a id="rules-client-ip"></a>
-
-### Rules Client IP
-
-<a id="rules-client-region"></a>
-
-### Rules Client Region
-
-<a id="rules-ip-and-ja4-tls-fingerprint"></a>
-
-### Rules IP And Ja4 TLS Fingerprint
-
-<a id="rules-ip-and-tls-fingerprint"></a>
-
-### Rules IP And TLS Fingerprint
-
-<a id="rules-ja4-tls-fingerprint"></a>
-
-### Rules Ja4 TLS Fingerprint
-
-<a id="rules-none"></a>
-
-### Rules None
-
-<a id="rules-tls-fingerprint"></a>
-
-### Rules TLS Fingerprint
+`tls_fingerprint` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="timeouts"></a>
 

--- a/docs/resources/virtual_host.md
+++ b/docs/resources/virtual_host.md
@@ -70,9 +70,9 @@ resource "f5xc_virtual_host" "example" {
 
 `append_server_name` - (Optional) Append Server Name if absent. Specifies the value to be used for Server header if it is not already present. If Server Header is already present it is not overwritten. It is just passed (`String`).
 
-`default_header` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Header](#default-header) below for details.
+`default_header` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`pass_through` - (Optional) Empty. This can be used for messages where no values are needed. See [Pass Through](#pass-through) below for details.
+`pass_through` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `server_name` - (Optional) Server Name. Specifies the value to be used for Server header inserted in responses. This will overwrite existing values if any for Server Header (`String`).
 
@@ -80,7 +80,7 @@ resource "f5xc_virtual_host" "example" {
 
 `authentication` - (Optional) Authentication Details. Authentication related information. This allows to configure the URL to redirect after the authentication Authentication Object Reference, configuration of cookie params etc. See [Authentication](#authentication) below for details.
 
-`no_authentication` - (Optional) Empty. This can be used for messages where no values are needed. See [No Authentication](#no-authentication) below for details.
+`no_authentication` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `buffer_policy` - (Optional) Buffer Configuration. Some upstream applications are not capable of handling streamed data. This config enables buffering the entire request before sending to upstream application. We can specify the maximum buffer size and buffer interval with this config. Buffering can be enabled and disabled at VirtualHost and Route levels Route level buffer configuration takes precedence. See [Buffer Policy](#buffer-policy) below for details.
 
@@ -90,7 +90,7 @@ resource "f5xc_virtual_host" "example" {
 
 `js_challenge` - (Optional) Javascript Challenge Parameters. Enables loadbalancer to perform client browser compatibility test by redirecting to a page with Javascript. With this feature enabled, only clients that are capable of executing Javascript(mostly browsers) will be allowed to complete the HTTP request. When loadbalancer is configured to do Javascript Challenge, it will redirect the browser to an HTML page on every new HTTP request. This HTML page will have Javascript embedded in it. Loadbalancer chooses a set o. See [Js Challenge](#js-challenge) below for details.
 
-`no_challenge` - (Optional) Empty. This can be used for messages where no values are needed. See [No Challenge](#no-challenge) below for details.
+`no_challenge` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `coalescing_options` - (Optional) TLS Coalescing Options. TLS connection coalescing configuration (not compatible with mTLS). See [Coalescing Options](#coalescing-options) below for details.
 
@@ -102,13 +102,13 @@ resource "f5xc_virtual_host" "example" {
 
 `csrf_policy` - (Optional) CSRF Policy. To mitigate CSRF attack , the policy checks where a request is coming from to determine if the request's origin is the same as its detination.The policy relies on two pieces of information used in determining if a request originated from the same host. 1. The origin that caused the user agent to issue the request (source origin). 2. The origin that the request is going to (target origin). When the policy evaluating a request, it ensures both pieces of information are present and. See [CSRF Policy](#csrf-policy) below for details.
 
-`custom_errors` - (Optional) Custom Error Responses. Map of integer error codes as keys and string values that can be used to provide custom HTTP pages for each error code. Key of the map can be either response code class or HTTP Error code. Response code classes for key is configured as follows 3 -- for 3xx response code class 4 -- for 4xx response code class 5 -- for 5xx response code class Value is the uri_ref. Currently supported URL schemes is string:///. For string:/// scheme, message needs to be encoded in Base64. See [Custom Errors](#custom-errors) below for details.
+`custom_errors` - (Optional) Custom Error Responses. Map of integer error codes as keys and string values that can be used to provide custom HTTP pages for each error code. Key of the map can be either response code class or HTTP Error code. Response code classes for key is configured as follows 3 -- for 3xx response code class 4 -- for 4xx response code class 5 -- for 5xx response code class Value is the uri_ref. Currently supported URL schemes is string:///. For string:/// scheme, message needs to be encoded in Base64 (`Block`).
 
 > **Note:** One of the arguments from this list "default_loadbalancer, non_default_loadbalancer" must be set.
 
-`default_loadbalancer` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Loadbalancer](#default-loadbalancer) below for details.
+`default_loadbalancer` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`non_default_loadbalancer` - (Optional) Empty. This can be used for messages where no values are needed. See [Non Default Loadbalancer](#non-default-loadbalancer) below for details.
+`non_default_loadbalancer` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `disable_default_error_pages` - (Optional) Disable default error pages. An option to specify whether to disable using default F5XC error pages (`Bool`).
 
@@ -116,9 +116,9 @@ resource "f5xc_virtual_host" "example" {
 
 > **Note:** One of the arguments from this list "disable_path_normalize, enable_path_normalize" must be set.
 
-`disable_path_normalize` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Path Normalize](#disable-path-normalize) below for details.
+`disable_path_normalize` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`enable_path_normalize` - (Optional) Empty. This can be used for messages where no values are needed. See [Enable Path Normalize](#enable-path-normalize) below for details.
+`enable_path_normalize` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `domains` - (Optional) Domains. A list of Domains (host/authority header) that will be matched to this Virtual Host. Wildcard hosts are supported in the suffix or prefix form Supported Domains and search order: 1. Exact Domain names: `www.foo.com.` 2. Domains starting with a Wildcard: *.foo.com. Not supported Domains: - Just a Wildcard: * - A Wildcard and TLD with no root Domain: *.com. - A Wildcard not matching a whole DNS label. e.g. *.foo.com and *.bar.foo.com are valid Wildcards however *bar.foo.com, *-bar.foo.co (`List`).
 
@@ -200,11 +200,11 @@ In addition to all arguments above, the following attributes are exported:
 
 `cookie_params` - (Optional) Cookie Parameters. Specifies different cookie related config parameters for authentication. See [Cookie Params](#authentication-cookie-params) below.
 
-`redirect_dynamic` - (Optional) Empty. This can be used for messages where no values are needed. See [Redirect Dynamic](#authentication-redirect-dynamic) below.
+`redirect_dynamic` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `redirect_url` - (Optional) Configure Redirect URL. user can provide a URL for e.g `HTTPS://abc.xyz.com` where user gets redirected. This URL configured here must match with the redirect URL configured with the OIDC provider (`String`).
 
-`use_auth_object_config` - (Optional) Empty. This can be used for messages where no values are needed. See [Use Auth Object Config](#authentication-use-auth-object-config) below.
+`use_auth_object_config` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="authentication-auth-config"></a>
 
@@ -230,7 +230,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `cookie_refresh_interval` - (Optional) Cookie Refresh Interval. Specifies in seconds refresh interval for session cookie. This is used to keep the active user active and reduce RE-login. When an incoming cookie's session expiry is still valid, and time to expire falls behind this interval, RE-issue a cookie with new expiry and with the same original session expiry. Default refresh interval is 3000 seconds (`Number`).
 
-`kms_key_hmac` - (Optional) KMS Key Reference. Reference to KMS Key Object. See [Kms Key HMAC](#authentication-cookie-params-kms-key-hmac) below.
+`kms_key_hmac` - (Optional) KMS Key Reference. Reference to KMS Key Object (`Block`).
 
 `session_expiry` - (Optional) Session Expiry duration. specifies in seconds max lifetime of an authenticated session after which the user will be forced to login again. Default session expiry is 86400 seconds(24 hours) (`Number`).
 
@@ -238,33 +238,13 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Authentication Cookie Params Auth HMAC
 
-`prim_key` - (Optional) Secret. SecretType is used in an object to indicate a sensitive/confidential field. See [Prim Key](#authentication-cookie-params-auth-hmac-prim-key) below.
+`prim_key` - (Optional) Secret. SecretType is used in an object to indicate a sensitive/confidential field (`Block`).
 
 `prim_key_expiry` - (Optional) HMAC Primary Key Expiry. Primary HMAC Key Expiry time (`String`).
 
-`sec_key` - (Optional) Secret. SecretType is used in an object to indicate a sensitive/confidential field. See [Sec Key](#authentication-cookie-params-auth-hmac-sec-key) below.
+`sec_key` - (Optional) Secret. SecretType is used in an object to indicate a sensitive/confidential field (`Block`).
 
 `sec_key_expiry` - (Optional) HMAC Secondary Key Expiry. Secondary HMAC Key Expiry time (`String`).
-
-<a id="authentication-cookie-params-auth-hmac-prim-key"></a>
-
-### Authentication Cookie Params Auth HMAC Prim Key
-
-<a id="authentication-cookie-params-auth-hmac-sec-key"></a>
-
-### Authentication Cookie Params Auth HMAC Sec Key
-
-<a id="authentication-cookie-params-kms-key-hmac"></a>
-
-### Authentication Cookie Params Kms Key HMAC
-
-<a id="authentication-redirect-dynamic"></a>
-
-### Authentication Redirect Dynamic
-
-<a id="authentication-use-auth-object-config"></a>
-
-### Authentication Use Auth Object Config
 
 <a id="buffer-policy"></a>
 
@@ -286,17 +266,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Coalescing Options
 
-`default_coalescing` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Coalescing](#coalescing-options-default-coalescing) below.
+`default_coalescing` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`strict_coalescing` - (Optional) Empty. This can be used for messages where no values are needed. See [Strict Coalescing](#coalescing-options-strict-coalescing) below.
-
-<a id="coalescing-options-default-coalescing"></a>
-
-### Coalescing Options Default Coalescing
-
-<a id="coalescing-options-strict-coalescing"></a>
-
-### Coalescing Options Strict Coalescing
+`strict_coalescing` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="compression-params"></a>
 
@@ -334,41 +306,17 @@ In addition to all arguments above, the following attributes are exported:
 
 ### CSRF Policy
 
-`all_load_balancer_domains` - (Optional) Empty. This can be used for messages where no values are needed. See [All Load Balancer Domains](#csrf-policy-all-load-balancer-domains) below.
+`all_load_balancer_domains` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `custom_domain_list` - (Optional) Domain name list. List of domain names used for Host header matching. See [Custom Domain List](#csrf-policy-custom-domain-list) below.
 
-`disabled` - (Optional) Empty. This can be used for messages where no values are needed. See [Disabled](#csrf-policy-disabled) below.
-
-<a id="csrf-policy-all-load-balancer-domains"></a>
-
-### CSRF Policy All Load Balancer Domains
+`disabled` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="csrf-policy-custom-domain-list"></a>
 
 ### CSRF Policy Custom Domain List
 
 `domains` - (Optional) Domain names. A list of domain names that will be matched to loadbalancer. These domains are not used for SNI match. Wildcard names are supported in the suffix or prefix form (`List`).
-
-<a id="csrf-policy-disabled"></a>
-
-### CSRF Policy Disabled
-
-<a id="custom-errors"></a>
-
-### Custom Errors
-
-<a id="default-header"></a>
-
-### Default Header
-
-<a id="default-loadbalancer"></a>
-
-### Default Loadbalancer
-
-<a id="disable-path-normalize"></a>
-
-### Disable Path Normalize
 
 <a id="dynamic-reverse-proxy"></a>
 
@@ -396,19 +344,15 @@ In addition to all arguments above, the following attributes are exported:
 
 `uid` - (Optional) UID. When a configuration object(e.g. virtual_host) refers to another(e.g route) then uid will hold the referred object's(e.g. route's) uid (`String`).
 
-<a id="enable-path-normalize"></a>
-
-### Enable Path Normalize
-
 <a id="http-protocol-options"></a>
 
 ### HTTP Protocol Options
 
 `http_protocol_enable_v1_only` - (Optional) HTTP/1.1 Protocol Options. HTTP/1.1 Protocol options for downstream connections. See [HTTP Protocol Enable V1 Only](#http-protocol-options-http-protocol-enable-v1-only) below.
 
-`http_protocol_enable_v1_v2` - (Optional) Empty. This can be used for messages where no values are needed. See [HTTP Protocol Enable V1 V2](#http-protocol-options-http-protocol-enable-v1-v2) below.
+`http_protocol_enable_v1_v2` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`http_protocol_enable_v2_only` - (Optional) Empty. This can be used for messages where no values are needed. See [HTTP Protocol Enable V2 Only](#http-protocol-options-http-protocol-enable-v2-only) below.
+`http_protocol_enable_v2_only` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="http-protocol-options-http-protocol-enable-v1-only"></a>
 
@@ -420,37 +364,13 @@ In addition to all arguments above, the following attributes are exported:
 
 ### HTTP Protocol Options HTTP Protocol Enable V1 Only Header Transformation
 
-`default_header_transformation` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Header Transformation](#http-protocol-options-http-protocol-enable-v1-only-header-transformation-default-header-transformation) below.
+`default_header_transformation` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`legacy_header_transformation` - (Optional) Empty. This can be used for messages where no values are needed. See [Legacy Header Transformation](#http-protocol-options-http-protocol-enable-v1-only-header-transformation-legacy-header-transformation) below.
+`legacy_header_transformation` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`preserve_case_header_transformation` - (Optional) Empty. This can be used for messages where no values are needed. See [Preserve Case Header Transformation](#http-protocol-options-http-protocol-enable-v1-only-header-transformation-preserve-case-header-transformation) below.
+`preserve_case_header_transformation` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`proper_case_header_transformation` - (Optional) Empty. This can be used for messages where no values are needed. See [Proper Case Header Transformation](#http-protocol-options-http-protocol-enable-v1-only-header-transformation-proper-case-header-transformation) below.
-
-<a id="http-protocol-options-http-protocol-enable-v1-only-header-transformation-default-header-transformation"></a>
-
-### HTTP Protocol Options HTTP Protocol Enable V1 Only Header Transformation Default Header Transformation
-
-<a id="http-protocol-options-http-protocol-enable-v1-only-header-transformation-legacy-header-transformation"></a>
-
-### HTTP Protocol Options HTTP Protocol Enable V1 Only Header Transformation Legacy Header Transformation
-
-<a id="http-protocol-options-http-protocol-enable-v1-only-header-transformation-preserve-case-header-transformation"></a>
-
-### HTTP Protocol Options HTTP Protocol Enable V1 Only Header Transformation Preserve Case Header Transformation
-
-<a id="http-protocol-options-http-protocol-enable-v1-only-header-transformation-proper-case-header-transformation"></a>
-
-### HTTP Protocol Options HTTP Protocol Enable V1 Only Header Transformation Proper Case Header Transformation
-
-<a id="http-protocol-options-http-protocol-enable-v1-v2"></a>
-
-### HTTP Protocol Options HTTP Protocol Enable V1 V2
-
-<a id="http-protocol-options-http-protocol-enable-v2-only"></a>
-
-### HTTP Protocol Options HTTP Protocol Enable V2 Only
+`proper_case_header_transformation` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="js-challenge"></a>
 
@@ -461,22 +381,6 @@ In addition to all arguments above, the following attributes are exported:
 `custom_page` - (Optional) Custom Message for Javascript Challenge. Custom message is of type uri_ref. Currently supported URL schemes is string:///. For string:/// scheme, message needs to be encoded in Base64 format. You can specify this message as base64 encoded plain text message e.g. 'Please Wait.' or it can be HTML paragraph or a body string encoded as base64 string E.g. '<p> Please Wait </p>'. Base64 encoded string for this HTML is 'PHA+IFBsZWFzZSBXYWl0IDwvcD4=' (`String`).
 
 `js_script_delay` - (Optional) Javascript Delay. Delay introduced by Javascript, in milliseconds (`Number`).
-
-<a id="no-authentication"></a>
-
-### No Authentication
-
-<a id="no-challenge"></a>
-
-### No Challenge
-
-<a id="non-default-loadbalancer"></a>
-
-### Non Default Loadbalancer
-
-<a id="pass-through"></a>
-
-### Pass Through
 
 <a id="rate-limiter-allowed-prefixes"></a>
 
@@ -576,31 +480,31 @@ In addition to all arguments above, the following attributes are exported:
 
 `add_expiry` - (Optional) Configuration for add_expiry (`String`).
 
-`add_httponly` - (Optional) Empty. This can be used for messages where no values are needed. See [Add Httponly](#response-cookies-to-add-add-httponly) below.
+`add_httponly` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`add_partitioned` - (Optional) Empty. This can be used for messages where no values are needed. See [Add Partitioned](#response-cookies-to-add-add-partitioned) below.
+`add_partitioned` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `add_path` - (Optional) Configuration for add_path (`String`).
 
-`add_secure` - (Optional) Empty. This can be used for messages where no values are needed. See [Add Secure](#response-cookies-to-add-add-secure) below.
+`add_secure` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`ignore_domain` - (Optional) Empty. This can be used for messages where no values are needed. See [Ignore Domain](#response-cookies-to-add-ignore-domain) below.
+`ignore_domain` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`ignore_expiry` - (Optional) Empty. This can be used for messages where no values are needed. See [Ignore Expiry](#response-cookies-to-add-ignore-expiry) below.
+`ignore_expiry` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`ignore_httponly` - (Optional) Empty. This can be used for messages where no values are needed. See [Ignore Httponly](#response-cookies-to-add-ignore-httponly) below.
+`ignore_httponly` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`ignore_max_age` - (Optional) Empty. This can be used for messages where no values are needed. See [Ignore Max Age](#response-cookies-to-add-ignore-max-age) below.
+`ignore_max_age` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`ignore_partitioned` - (Optional) Empty. This can be used for messages where no values are needed. See [Ignore Partitioned](#response-cookies-to-add-ignore-partitioned) below.
+`ignore_partitioned` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`ignore_path` - (Optional) Empty. This can be used for messages where no values are needed. See [Ignore Path](#response-cookies-to-add-ignore-path) below.
+`ignore_path` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`ignore_samesite` - (Optional) Empty. This can be used for messages where no values are needed. See [Ignore Samesite](#response-cookies-to-add-ignore-samesite) below.
+`ignore_samesite` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`ignore_secure` - (Optional) Empty. This can be used for messages where no values are needed. See [Ignore Secure](#response-cookies-to-add-ignore-secure) below.
+`ignore_secure` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`ignore_value` - (Optional) Empty. This can be used for messages where no values are needed. See [Ignore Value](#response-cookies-to-add-ignore-value) below.
+`ignore_value` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `max_age_value` - (Optional) Add Max Age. Add max age attribute (`Number`).
 
@@ -608,75 +512,15 @@ In addition to all arguments above, the following attributes are exported:
 
 `overwrite` - (Optional) Overwrite. Should the value be overwritten? If true, the value is overwritten to existing values. Default value is do not overwrite (`Bool`).
 
-`samesite_lax` - (Optional) Empty. This can be used for messages where no values are needed. See [Samesite Lax](#response-cookies-to-add-samesite-lax) below.
+`samesite_lax` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`samesite_none` - (Optional) Empty. This can be used for messages where no values are needed. See [Samesite None](#response-cookies-to-add-samesite-none) below.
+`samesite_none` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`samesite_strict` - (Optional) Empty. This can be used for messages where no values are needed. See [Samesite Strict](#response-cookies-to-add-samesite-strict) below.
+`samesite_strict` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `secret_value` - (Optional) Secret. SecretType is used in an object to indicate a sensitive/confidential field. See [Secret Value](#response-cookies-to-add-secret-value) below.
 
 `value` - (Optional) Value. Value of the Cookie header (`String`).
-
-<a id="response-cookies-to-add-add-httponly"></a>
-
-### Response Cookies To Add Add Httponly
-
-<a id="response-cookies-to-add-add-partitioned"></a>
-
-### Response Cookies To Add Add Partitioned
-
-<a id="response-cookies-to-add-add-secure"></a>
-
-### Response Cookies To Add Add Secure
-
-<a id="response-cookies-to-add-ignore-domain"></a>
-
-### Response Cookies To Add Ignore Domain
-
-<a id="response-cookies-to-add-ignore-expiry"></a>
-
-### Response Cookies To Add Ignore Expiry
-
-<a id="response-cookies-to-add-ignore-httponly"></a>
-
-### Response Cookies To Add Ignore Httponly
-
-<a id="response-cookies-to-add-ignore-max-age"></a>
-
-### Response Cookies To Add Ignore Max Age
-
-<a id="response-cookies-to-add-ignore-partitioned"></a>
-
-### Response Cookies To Add Ignore Partitioned
-
-<a id="response-cookies-to-add-ignore-path"></a>
-
-### Response Cookies To Add Ignore Path
-
-<a id="response-cookies-to-add-ignore-samesite"></a>
-
-### Response Cookies To Add Ignore Samesite
-
-<a id="response-cookies-to-add-ignore-secure"></a>
-
-### Response Cookies To Add Ignore Secure
-
-<a id="response-cookies-to-add-ignore-value"></a>
-
-### Response Cookies To Add Ignore Value
-
-<a id="response-cookies-to-add-samesite-lax"></a>
-
-### Response Cookies To Add Samesite Lax
-
-<a id="response-cookies-to-add-samesite-none"></a>
-
-### Response Cookies To Add Samesite None
-
-<a id="response-cookies-to-add-samesite-strict"></a>
-
-### Response Cookies To Add Samesite Strict
 
 <a id="response-cookies-to-add-secret-value"></a>
 
@@ -796,15 +640,11 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Slow DDOS Mitigation
 
-`disable_request_timeout` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Request Timeout](#slow-ddos-mitigation-disable-request-timeout) below.
+`disable_request_timeout` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `request_headers_timeout` - (Optional) Request Headers Timeout. The amount of time the client has to send only the headers on the request stream before the stream is cancelled. The default value is 10000 milliseconds. This setting provides protection against Slowloris attacks (`Number`).
 
 `request_timeout` - (Optional) Custom Timeout (`Number`).
-
-<a id="slow-ddos-mitigation-disable-request-timeout"></a>
-
-### Slow DDOS Mitigation Disable Request Timeout
 
 <a id="timeouts"></a>
 
@@ -826,15 +666,15 @@ In addition to all arguments above, the following attributes are exported:
 
 `cipher_suites` - (Optional) Cipher Suites. The following list specifies the supported cipher suite TLS_AES_128_GCM_SHA256 TLS_AES_256_GCM_SHA384 TLS_CHACHA20_POLY1305_SHA256 TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384 TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256 TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256 TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA TLS_ECDHE_RSA_WITH_AES_128_CBC_ (`List`).
 
-`client_certificate_optional` - (Optional) Empty. This can be used for messages where no values are needed. See [Client Certificate Optional](#tls-cert-params-client-certificate-optional) below.
+`client_certificate_optional` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`client_certificate_required` - (Optional) Empty. This can be used for messages where no values are needed. See [Client Certificate Required](#tls-cert-params-client-certificate-required) below.
+`client_certificate_required` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `maximum_protocol_version` - (Optional) TLS Protocol. TlsProtocol is enumeration of supported TLS versions F5 Distributed Cloud will choose the optimal TLS version. Possible values are `TLS_AUTO`, `TLSv1_0`, `TLSv1_1`, `TLSv1_2`, `TLSv1_3`. Defaults to `TLS_AUTO` (`String`).
 
 `minimum_protocol_version` - (Optional) TLS Protocol. TlsProtocol is enumeration of supported TLS versions F5 Distributed Cloud will choose the optimal TLS version. Possible values are `TLS_AUTO`, `TLSv1_0`, `TLSv1_1`, `TLSv1_2`, `TLSv1_3`. Defaults to `TLS_AUTO` (`String`).
 
-`no_client_certificate` - (Optional) Empty. This can be used for messages where no values are needed. See [No Client Certificate](#tls-cert-params-no-client-certificate) below.
+`no_client_certificate` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `validation_params` - (Optional) TLS Certificate Validation Parameters. This includes URL for a trust store, whether SAN verification is required and list of Subject Alt Names for verification. See [Validation Params](#tls-cert-params-validation-params) below.
 
@@ -854,18 +694,6 @@ In addition to all arguments above, the following attributes are exported:
 
 `uid` - (Optional) UID. When a configuration object(e.g. virtual_host) refers to another(e.g route) then uid will hold the referred object's(e.g. route's) uid (`String`).
 
-<a id="tls-cert-params-client-certificate-optional"></a>
-
-### TLS Cert Params Client Certificate Optional
-
-<a id="tls-cert-params-client-certificate-required"></a>
-
-### TLS Cert Params Client Certificate Required
-
-<a id="tls-cert-params-no-client-certificate"></a>
-
-### TLS Cert Params No Client Certificate
-
 <a id="tls-cert-params-validation-params"></a>
 
 ### TLS Cert Params Validation Params
@@ -882,33 +710,21 @@ In addition to all arguments above, the following attributes are exported:
 
 ### TLS Cert Params Validation Params Trusted CA
 
-`trusted_ca_list` - (Optional) Root CA Certificate Reference. Reference to Root CA Certificate. See [Trusted CA List](#tls-cert-params-validation-params-trusted-ca-trusted-ca-list) below.
-
-<a id="tls-cert-params-validation-params-trusted-ca-trusted-ca-list"></a>
-
-### TLS Cert Params Validation Params Trusted CA Trusted CA List
+`trusted_ca_list` - (Optional) Root CA Certificate Reference. Reference to Root CA Certificate (`Block`).
 
 <a id="tls-parameters"></a>
 
 ### TLS Parameters
 
-`client_certificate_optional` - (Optional) Empty. This can be used for messages where no values are needed. See [Client Certificate Optional](#tls-parameters-client-certificate-optional) below.
+`client_certificate_optional` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`client_certificate_required` - (Optional) Empty. This can be used for messages where no values are needed. See [Client Certificate Required](#tls-parameters-client-certificate-required) below.
+`client_certificate_required` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `common_params` - (Optional) TLS Parameters. Information of different aspects for TLS authentication related to ciphers, certificates and trust store. See [Common Params](#tls-parameters-common-params) below.
 
-`no_client_certificate` - (Optional) Empty. This can be used for messages where no values are needed. See [No Client Certificate](#tls-parameters-no-client-certificate) below.
+`no_client_certificate` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `xfcc_header_elements` - (Optional) XFCC Header. X-Forwarded-Client-Cert header elements to be set in an mTLS enabled connections. If none are defined, the header will not be added (`List`).
-
-<a id="tls-parameters-client-certificate-optional"></a>
-
-### TLS Parameters Client Certificate Optional
-
-<a id="tls-parameters-client-certificate-required"></a>
-
-### TLS Parameters Client Certificate Required
 
 <a id="tls-parameters-common-params"></a>
 
@@ -930,31 +746,15 @@ In addition to all arguments above, the following attributes are exported:
 
 `certificate_url` - (Optional) Certificate. TLS certificate. Certificate or certificate chain in PEM format including the PEM headers (`String`).
 
-`custom_hash_algorithms` - (Optional) Hash Algorithms. Specifies the hash algorithms to be used. See [Custom Hash Algorithms](#tls-parameters-common-params-tls-certificates-custom-hash-algorithms) below.
+`custom_hash_algorithms` - (Optional) Hash Algorithms. Specifies the hash algorithms to be used (`Block`).
 
 `description` - (Optional) Configuration for description (`String`).
 
-`disable_ocsp_stapling` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable OCSP Stapling](#tls-parameters-common-params-tls-certificates-disable-ocsp-stapling) below.
+`disable_ocsp_stapling` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`private_key` - (Optional) Secret. SecretType is used in an object to indicate a sensitive/confidential field. See [Private Key](#tls-parameters-common-params-tls-certificates-private-key) below.
+`private_key` - (Optional) Secret. SecretType is used in an object to indicate a sensitive/confidential field (`Block`).
 
-`use_system_defaults` - (Optional) Empty. This can be used for messages where no values are needed. See [Use System Defaults](#tls-parameters-common-params-tls-certificates-use-system-defaults) below.
-
-<a id="tls-parameters-common-params-tls-certificates-custom-hash-algorithms"></a>
-
-### TLS Parameters Common Params TLS Certificates Custom Hash Algorithms
-
-<a id="tls-parameters-common-params-tls-certificates-disable-ocsp-stapling"></a>
-
-### TLS Parameters Common Params TLS Certificates Disable OCSP Stapling
-
-<a id="tls-parameters-common-params-tls-certificates-private-key"></a>
-
-### TLS Parameters Common Params TLS Certificates Private Key
-
-<a id="tls-parameters-common-params-tls-certificates-use-system-defaults"></a>
-
-### TLS Parameters Common Params TLS Certificates Use System Defaults
+`use_system_defaults` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="tls-parameters-common-params-validation-params"></a>
 
@@ -962,19 +762,11 @@ In addition to all arguments above, the following attributes are exported:
 
 `skip_hostname_verification` - (Optional) Skip verification of hostname. When True, skip verification of hostname i.e. CN/Subject Alt Name of certificate is not matched to the connecting hostname (`Bool`).
 
-`trusted_ca` - (Optional) Root CA Certificate Reference. Reference to Root CA Certificate. See [Trusted CA](#tls-parameters-common-params-validation-params-trusted-ca) below.
+`trusted_ca` - (Optional) Root CA Certificate Reference. Reference to Root CA Certificate (`Block`).
 
 `trusted_ca_url` - (Optional) Inline Root CA Certificate (legacy). Inline Root CA Certificate (`String`).
 
 `verify_subject_alt_names` - (Optional) List of SANs for matching. List of acceptable Subject Alt Names/CN in the peer's certificate. When skip_hostname_verification is false and verify_subject_alt_names is empty, the hostname of the peer will be used for matching against SAN/CN of peer's certificate (`List`).
-
-<a id="tls-parameters-common-params-validation-params-trusted-ca"></a>
-
-### TLS Parameters Common Params Validation Params Trusted CA
-
-<a id="tls-parameters-no-client-certificate"></a>
-
-### TLS Parameters No Client Certificate
 
 <a id="user-identification"></a>
 
@@ -996,9 +788,9 @@ In addition to all arguments above, the following attributes are exported:
 
 `app_firewall` - (Optional) App Firewall Reference. A list of references to the app_firewall configuration objects. See [App Firewall](#waf-type-app-firewall) below.
 
-`disable_waf` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable WAF](#waf-type-disable-waf) below.
+`disable_waf` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`inherit_waf` - (Optional) Empty. This can be used for messages where no values are needed. See [Inherit WAF](#waf-type-inherit-waf) below.
+`inherit_waf` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="waf-type-app-firewall"></a>
 
@@ -1019,14 +811,6 @@ In addition to all arguments above, the following attributes are exported:
 `tenant` - (Optional) Tenant. When a configuration object(e.g. virtual_host) refers to another(e.g route) then tenant will hold the referred object's(e.g. route's) tenant (`String`).
 
 `uid` - (Optional) UID. When a configuration object(e.g. virtual_host) refers to another(e.g route) then uid will hold the referred object's(e.g. route's) uid (`String`).
-
-<a id="waf-type-disable-waf"></a>
-
-### WAF Type Disable WAF
-
-<a id="waf-type-inherit-waf"></a>
-
-### WAF Type Inherit WAF
 
 ## Import
 

--- a/docs/resources/virtual_k8s.md
+++ b/docs/resources/virtual_k8s.md
@@ -62,9 +62,9 @@ resource "f5xc_virtual_k8s" "example" {
 
 > **Note:** One of the arguments from this list "disabled, isolated" must be set.
 
-`disabled` - (Optional) Empty. This can be used for messages where no values are needed. See [Disabled](#disabled) below for details.
+`disabled` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`isolated` - (Optional) Empty. This can be used for messages where no values are needed. See [Isolated](#isolated) below for details.
+`isolated` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `timeouts` - (Optional) See [Timeouts](#timeouts) below for details.
 
@@ -87,14 +87,6 @@ In addition to all arguments above, the following attributes are exported:
 `namespace` - (Optional) Namespace. When a configuration object(e.g. virtual_host) refers to another(e.g route) then namespace will hold the referred object's(e.g. route's) namespace (`String`).
 
 `tenant` - (Optional) Tenant. When a configuration object(e.g. virtual_host) refers to another(e.g route) then tenant will hold the referred object's(e.g. route's) tenant (`String`).
-
-<a id="disabled"></a>
-
-### Disabled
-
-<a id="isolated"></a>
-
-### Isolated
 
 <a id="timeouts"></a>
 

--- a/docs/resources/virtual_network.md
+++ b/docs/resources/virtual_network.md
@@ -62,13 +62,13 @@ resource "f5xc_virtual_network" "example" {
 
 > **Note:** One of the arguments from this list "global_network, legacy_type, site_local_inside_network, site_local_network" must be set.
 
-`global_network` - (Optional) Empty. This can be used for messages where no values are needed. See [Global Network](#global-network) below for details.
+`global_network` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `legacy_type` - (Optional) Virtual Network Type. Different types of virtual networks understood by the system Virtual-network of type VIRTUAL_NETWORK_SITE_LOCAL provides connectivity to public (outside) network. This is an insecure network and is connected to public internet via NAT Gateways/firwalls Virtual-network of this type is local to every site. Two virtual networks of this type on different sites are neither related nor connected. Constraints: There can be atmost one virtual network of this type in a given site... Possible values include `VIRTUAL_NETWORK_SITE_LOCAL`, `VIRTUAL_NETWORK_SITE_LOCAL_INSIDE`, `VIRTUAL_NETWORK_PER_SITE`, `VIRTUAL_NETWORK_PUBLIC`, `VIRTUAL_NETWORK_GLOBAL`, `VIRTUAL_NETWORK_SITE_SERVICE`, `VIRTUAL_NETWORK_VER_INTERNAL`, `VIRTUAL_NETWORK_SITE_LOCAL_INSIDE_OUTSIDE`, `VIRTUAL_NETWORK_IP_AUTO`, `VIRTUAL_NETWORK_VOLTADN_PRIVATE_NETWORK`, and others. Defaults to `VIRTUAL_NETWORK_SITE_LOCAL` (`String`).
 
-`site_local_inside_network` - (Optional) Empty. This can be used for messages where no values are needed. See [Site Local Inside Network](#site-local-inside-network) below for details.
+`site_local_inside_network` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`site_local_network` - (Optional) Empty. This can be used for messages where no values are needed. See [Site Local Network](#site-local-network) below for details.
+`site_local_network` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `static_routes` - (Optional) Static Routes. List of static routes on the virtual network. See [Static Routes](#static-routes) below for details.
 
@@ -82,35 +82,19 @@ In addition to all arguments above, the following attributes are exported:
 
 ---
 
-<a id="global-network"></a>
-
-### Global Network
-
-<a id="site-local-inside-network"></a>
-
-### Site Local Inside Network
-
-<a id="site-local-network"></a>
-
-### Site Local Network
-
 <a id="static-routes"></a>
 
 ### Static Routes
 
 `attrs` - (Optional) Attributes. List of attributes that control forwarding, dynamic routing and control plane (host) reachability (`List`).
 
-`default_gateway` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Gateway](#static-routes-default-gateway) below.
+`default_gateway` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `ip_address` - (Optional) IP Address. Traffic matching the IP prefixes is sent to this IP Address (`String`).
 
 `ip_prefixes` - (Optional) IP Prefixes. List of route prefixes that have common next hop and attributes (`List`).
 
 `node_interface` - (Optional) NodeInterfaceType. On multinode site, this type holds the information about per node interfaces. See [Node Interface](#static-routes-node-interface) below.
-
-<a id="static-routes-default-gateway"></a>
-
-### Static Routes Default Gateway
 
 <a id="static-routes-node-interface"></a>
 
@@ -122,13 +106,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Static Routes Node Interface List
 
-`interface` - (Optional) Interface. Interface reference on this node. See [Interface](#static-routes-node-interface-list-interface) below.
+`interface` - (Optional) Interface. Interface reference on this node (`Block`).
 
 `node` - (Optional) Node. Node name on this site (`String`).
-
-<a id="static-routes-node-interface-list-interface"></a>
-
-### Static Routes Node Interface List Interface
 
 <a id="timeouts"></a>
 

--- a/docs/resources/voltshare_admin_policy.md
+++ b/docs/resources/voltshare_admin_policy.md
@@ -82,17 +82,13 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Author Restrictions
 
-`allow_all` - (Optional) Empty. This can be used for messages where no values are needed. See [Allow All](#author-restrictions-allow-all) below.
+`allow_all` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `allow_list` - (Optional) Custom List. Custom List contains user customized list of matcher values. See [Allow List](#author-restrictions-allow-list) below.
 
-`deny_all` - (Optional) Empty. This can be used for messages where no values are needed. See [Deny All](#author-restrictions-deny-all) below.
+`deny_all` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `deny_list` - (Optional) Custom List. Custom List contains user customized list of matcher values. See [Deny List](#author-restrictions-deny-list) below.
-
-<a id="author-restrictions-allow-all"></a>
-
-### Author Restrictions Allow All
 
 <a id="author-restrictions-allow-list"></a>
 
@@ -107,10 +103,6 @@ In addition to all arguments above, the following attributes are exported:
 `exact_value` - (Optional) Exact User Id. exact_match contains user_id to match against (`String`).
 
 `regex_pattern` - (Optional) Regex For User Id. regex_values contains a regex pattern to match against (`String`).
-
-<a id="author-restrictions-deny-all"></a>
-
-### Author Restrictions Deny All
 
 <a id="author-restrictions-deny-list"></a>
 
@@ -142,61 +134,37 @@ In addition to all arguments above, the following attributes are exported:
 
 ### User Restrictions
 
-`all_tenants` - (Optional) Empty. This can be used for messages where no values are needed. See [All Tenants](#user-restrictions-all-tenants) below.
+`all_tenants` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`individual_users` - (Optional) Empty. This can be used for messages where no values are needed. See [Individual Users](#user-restrictions-individual-users) below.
+`individual_users` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `tenant` - (Optional) Team/Tenant. Team/Tenant for which this rule is valid (`String`).
 
 `user_restrictions` - (Optional) User Matcher. user_matcher contains contains the allow/deny list of users/authors. See [User Restrictions](#user-restrictions-user-restrictions) below.
 
-<a id="user-restrictions-all-tenants"></a>
-
-### User Restrictions All Tenants
-
-<a id="user-restrictions-individual-users"></a>
-
-### User Restrictions Individual Users
-
 <a id="user-restrictions-user-restrictions"></a>
 
 ### User Restrictions User Restrictions
 
-`allow_all` - (Optional) Empty. This can be used for messages where no values are needed. See [Allow All](#user-restrictions-user-restrictions-allow-all) below.
+`allow_all` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `allow_list` - (Optional) Custom List. Custom List contains user customized list of matcher values. See [Allow List](#user-restrictions-user-restrictions-allow-list) below.
 
-`deny_all` - (Optional) Empty. This can be used for messages where no values are needed. See [Deny All](#user-restrictions-user-restrictions-deny-all) below.
+`deny_all` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `deny_list` - (Optional) Custom List. Custom List contains user customized list of matcher values. See [Deny List](#user-restrictions-user-restrictions-deny-list) below.
-
-<a id="user-restrictions-user-restrictions-allow-all"></a>
-
-### User Restrictions User Restrictions Allow All
 
 <a id="user-restrictions-user-restrictions-allow-list"></a>
 
 ### User Restrictions User Restrictions Allow List
 
-`custom_list` - (Optional) List of User Id(s). List of user id(s). See [Custom List](#user-restrictions-user-restrictions-allow-list-custom-list) below.
-
-<a id="user-restrictions-user-restrictions-allow-list-custom-list"></a>
-
-### User Restrictions User Restrictions Allow List Custom List
-
-<a id="user-restrictions-user-restrictions-deny-all"></a>
-
-### User Restrictions User Restrictions Deny All
+`custom_list` - (Optional) List of User Id(s). List of user id(s) (`Block`).
 
 <a id="user-restrictions-user-restrictions-deny-list"></a>
 
 ### User Restrictions User Restrictions Deny List
 
-`custom_list` - (Optional) List of User Id(s). List of user id(s). See [Custom List](#user-restrictions-user-restrictions-deny-list-custom-list) below.
-
-<a id="user-restrictions-user-restrictions-deny-list-custom-list"></a>
-
-### User Restrictions User Restrictions Deny List Custom List
+`custom_list` - (Optional) List of User Id(s). List of user id(s) (`Block`).
 
 ## Import
 

--- a/docs/resources/voltstack_site.md
+++ b/docs/resources/voltstack_site.md
@@ -76,9 +76,9 @@ resource "f5xc_voltstack_site" "example" {
 
 > **Note:** One of the arguments from this list "allow_all_usb, deny_all_usb, usb_policy" must be set.
 
-`allow_all_usb` - (Optional) Empty. This can be used for messages where no values are needed. See [Allow All Usb](#allow-all-usb) below for details.
+`allow_all_usb` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`deny_all_usb` - (Optional) Empty. This can be used for messages where no values are needed. See [Deny All Usb](#deny-all-usb) below for details.
+`deny_all_usb` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `usb_policy` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Usb Policy](#usb-policy) below for details.
 
@@ -86,13 +86,13 @@ resource "f5xc_voltstack_site" "example" {
 
 `blocked_services` - (Optional) Disable Node Local Services. Disable node local services on this site. Note: The chosen services will get disabled on all nodes in the site. See [Blocked Services](#blocked-services) below for details.
 
-`default_blocked_services` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Blocked Services](#default-blocked-services) below for details.
+`default_blocked_services` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 > **Note:** One of the arguments from this list "bond_device_list, no_bond_devices" must be set.
 
 `bond_device_list` - (Optional) Bond Devices List. List of bond devices for this fleet. See [Bond Device List](#bond-device-list) below for details.
 
-`no_bond_devices` - (Optional) Empty. This can be used for messages where no values are needed. See [No Bond Devices](#no-bond-devices) below for details.
+`no_bond_devices` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `coordinates` - (Optional) Site Coordinates. Coordinates of the site which provides the site physical location. See [Coordinates](#coordinates) below for details.
 
@@ -102,39 +102,39 @@ resource "f5xc_voltstack_site" "example" {
 
 `custom_network_config` - (Optional) VssNetworkConfiguration. See [Custom Network Config](#custom-network-config) below for details.
 
-`default_network_config` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Network Config](#default-network-config) below for details.
+`default_network_config` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 > **Note:** One of the arguments from this list "custom_storage_config, default_storage_config" must be set.
 
 `custom_storage_config` - (Optional) VssStorageConfiguration. See [Custom Storage Config](#custom-storage-config) below for details.
 
-`default_storage_config` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Storage Config](#default-storage-config) below for details.
+`default_storage_config` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 > **Note:** One of the arguments from this list "default_sriov_interface, sriov_interfaces" must be set.
 
-`default_sriov_interface` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Sriov Interface](#default-sriov-interface) below for details.
+`default_sriov_interface` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `sriov_interfaces` - (Optional) Custom SR-IOV interfaces Configuration List. List of all custom SR-IOV interfaces configuration. See [Sriov Interfaces](#sriov-interfaces) below for details.
 
 > **Note:** One of the arguments from this list "disable_gpu, enable_gpu, enable_vgpu" must be set.
 
-`disable_gpu` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable GPU](#disable-gpu) below for details.
+`disable_gpu` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`enable_gpu` - (Optional) Empty. This can be used for messages where no values are needed. See [Enable GPU](#enable-gpu) below for details.
+`enable_gpu` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `enable_vgpu` - (Optional) vGPU Configuration. Licensing configuration for NVIDIA vGPU. See [Enable Vgpu](#enable-vgpu) below for details.
 
 > **Note:** One of the arguments from this list "disable_vm, enable_vm" must be set.
 
-`disable_vm` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable VM](#disable-vm) below for details.
+`disable_vm` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`enable_vm` - (Optional) VM Configuration. VMs support configuration. See [Enable VM](#enable-vm) below for details.
+`enable_vm` - (Optional) VM Configuration. VMs support configuration (`Block`).
 
 > **Note:** One of the arguments from this list "k8s_cluster, no_k8s_cluster" must be set.
 
 `k8s_cluster` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [K8s Cluster](#k8s-cluster) below for details.
 
-`no_k8s_cluster` - (Optional) Empty. This can be used for messages where no values are needed. See [No K8s Cluster](#no-k8s-cluster) below for details.
+`no_k8s_cluster` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `kubernetes_upgrade_drain` - (Optional) Node by Node Upgrade. Specify how worker nodes within a site will be upgraded. See [Kubernetes Upgrade Drain](#kubernetes-upgrade-drain) below for details.
 
@@ -142,13 +142,13 @@ resource "f5xc_voltstack_site" "example" {
 
 `local_control_plane` - (Optional) Local Control Plane. Enable local control plane for L3VPN, SRV6, EVPN etc. See [Local Control Plane](#local-control-plane) below for details.
 
-`no_local_control_plane` - (Optional) Empty. This can be used for messages where no values are needed. See [No Local Control Plane](#no-local-control-plane) below for details.
+`no_local_control_plane` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 > **Note:** One of the arguments from this list "log_receiver, logs_streaming_disabled" must be set.
 
 `log_receiver` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Log Receiver](#log-receiver) below for details.
 
-`logs_streaming_disabled` - (Optional) Empty. This can be used for messages where no values are needed. See [Logs Streaming Disabled](#logs-streaming-disabled) below for details.
+`logs_streaming_disabled` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `master_node_configuration` - (Optional) Master Nodes. Configuration of master nodes. See [Master Node Configuration](#master-node-configuration) below for details.
 
@@ -172,10 +172,6 @@ In addition to all arguments above, the following attributes are exported:
 
 ---
 
-<a id="allow-all-usb"></a>
-
-### Allow All Usb
-
 <a id="blocked-services"></a>
 
 ### Blocked Services
@@ -186,25 +182,13 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Blocked Services Blocked Sevice
 
-`dns` - (Optional) Empty. This can be used for messages where no values are needed. See [DNS](#blocked-services-blocked-sevice-dns) below.
+`dns` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `network_type` - (Optional) Virtual Network Type. Different types of virtual networks understood by the system Virtual-network of type VIRTUAL_NETWORK_SITE_LOCAL provides connectivity to public (outside) network. This is an insecure network and is connected to public internet via NAT Gateways/firwalls Virtual-network of this type is local to every site. Two virtual networks of this type on different sites are neither related nor connected. Constraints: There can be atmost one virtual network of this type in a given site... Possible values include `VIRTUAL_NETWORK_SITE_LOCAL`, `VIRTUAL_NETWORK_SITE_LOCAL_INSIDE`, `VIRTUAL_NETWORK_PER_SITE`, `VIRTUAL_NETWORK_PUBLIC`, `VIRTUAL_NETWORK_GLOBAL`, `VIRTUAL_NETWORK_SITE_SERVICE`, `VIRTUAL_NETWORK_VER_INTERNAL`, `VIRTUAL_NETWORK_SITE_LOCAL_INSIDE_OUTSIDE`, `VIRTUAL_NETWORK_IP_AUTO`, `VIRTUAL_NETWORK_VOLTADN_PRIVATE_NETWORK`, and others. Defaults to `VIRTUAL_NETWORK_SITE_LOCAL` (`String`).
 
-`ssh` - (Optional) Empty. This can be used for messages where no values are needed. See [SSH](#blocked-services-blocked-sevice-ssh) below.
+`ssh` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`web_user_interface` - (Optional) Empty. This can be used for messages where no values are needed. See [Web User Interface](#blocked-services-blocked-sevice-web-user-interface) below.
-
-<a id="blocked-services-blocked-sevice-dns"></a>
-
-### Blocked Services Blocked Sevice DNS
-
-<a id="blocked-services-blocked-sevice-ssh"></a>
-
-### Blocked Services Blocked Sevice SSH
-
-<a id="blocked-services-blocked-sevice-web-user-interface"></a>
-
-### Blocked Services Blocked Sevice Web User Interface
+`web_user_interface` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="bond-device-list"></a>
 
@@ -216,7 +200,7 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Bond Device List Bond Devices
 
-`active_backup` - (Optional) Empty. This can be used for messages where no values are needed. See [Active Backup](#bond-device-list-bond-devices-active-backup) below.
+`active_backup` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `devices` - (Optional) Member Ethernet Devices. Ethernet devices that will make up this bond (`List`).
 
@@ -227,10 +211,6 @@ In addition to all arguments above, the following attributes are exported:
 `link_up_delay` - (Optional) Link Up Delay. Milliseconds wait before link is declared up (`Number`).
 
 `name` - (Optional) Bond Device Name. Name for the Bond. Ex 'bond0' (`String`).
-
-<a id="bond-device-list-bond-devices-active-backup"></a>
-
-### Bond Device List Bond Devices Active Backup
 
 <a id="bond-device-list-bond-devices-lacp"></a>
 
@@ -268,23 +248,23 @@ In addition to all arguments above, the following attributes are exported:
 
 `bgp_router_id` - (Optional) BGP Router ID. Optional BGP router id that can be used as parameter for BGP configuration when BGP is configured to fetch BGP router ID from site object (`String`).
 
-`default_config` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Config](#custom-network-config-default-config) below.
+`default_config` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`default_interface_config` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Interface Config](#custom-network-config-default-interface-config) below.
+`default_interface_config` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`default_sli_config` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Sli Config](#custom-network-config-default-sli-config) below.
+`default_sli_config` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`forward_proxy_allow_all` - (Optional) Empty. This can be used for messages where no values are needed. See [Forward Proxy Allow All](#custom-network-config-forward-proxy-allow-all) below.
+`forward_proxy_allow_all` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `global_network_list` - (Optional) Global Network Connection List. List of global network connections. See [Global Network List](#custom-network-config-global-network-list) below.
 
 `interface_list` - (Optional) List of Interface. Configure network interfaces for this App Stack site. See [Interface List](#custom-network-config-interface-list) below.
 
-`no_forward_proxy` - (Optional) Empty. This can be used for messages where no values are needed. See [No Forward Proxy](#custom-network-config-no-forward-proxy) below.
+`no_forward_proxy` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_global_network` - (Optional) Empty. This can be used for messages where no values are needed. See [No Global Network](#custom-network-config-no-global-network) below.
+`no_global_network` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_network_policy` - (Optional) Empty. This can be used for messages where no values are needed. See [No Network Policy](#custom-network-config-no-network-policy) below.
+`no_network_policy` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `outside_nameserver` - (Optional) DNS V4 Server for Local Network. Optional DNS server V4 IP to be used for name resolution in local network (`String`).
 
@@ -296,9 +276,9 @@ In addition to all arguments above, the following attributes are exported:
 
 `slo_config` - (Optional) Site Local Network Configuration. Site local network configuration. See [Slo Config](#custom-network-config-slo-config) below.
 
-`sm_connection_public_ip` - (Optional) Empty. This can be used for messages where no values are needed. See [Sm Connection Public IP](#custom-network-config-sm-connection-public-ip) below.
+`sm_connection_public_ip` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`sm_connection_pvt_ip` - (Optional) Empty. This can be used for messages where no values are needed. See [Sm Connection Pvt IP](#custom-network-config-sm-connection-pvt-ip) below.
+`sm_connection_pvt_ip` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `tunnel_dead_timeout` - (Optional) Tunnel Dead Timeout (msec). Time interval, in millisec, within which any ipsec / SSL connection from the site going down is detected. When not set (== 0), a default value of 10000 msec will be used (`Number`).
 
@@ -352,22 +332,6 @@ In addition to all arguments above, the following attributes are exported:
 
 `tenant` - (Optional) Tenant. When a configuration object(e.g. virtual_host) refers to another(e.g route) then tenant will hold the referred object's(e.g. route's) tenant (`String`).
 
-<a id="custom-network-config-default-config"></a>
-
-### Custom Network Config Default Config
-
-<a id="custom-network-config-default-interface-config"></a>
-
-### Custom Network Config Default Interface Config
-
-<a id="custom-network-config-default-sli-config"></a>
-
-### Custom Network Config Default Sli Config
-
-<a id="custom-network-config-forward-proxy-allow-all"></a>
-
-### Custom Network Config Forward Proxy Allow All
-
 <a id="custom-network-config-global-network-list"></a>
 
 ### Custom Network Config Global Network List
@@ -378,17 +342,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Custom Network Config Global Network List Global Network Connections
 
-`sli_to_global_dr` - (Optional) Global Network. Global network reference for direct connection. See [Sli To Global DR](#custom-network-config-global-network-list-global-network-connections-sli-to-global-dr) below.
+`sli_to_global_dr` - (Optional) Global Network. Global network reference for direct connection (`Block`).
 
-`slo_to_global_dr` - (Optional) Global Network. Global network reference for direct connection. See [Slo To Global DR](#custom-network-config-global-network-list-global-network-connections-slo-to-global-dr) below.
-
-<a id="custom-network-config-global-network-list-global-network-connections-sli-to-global-dr"></a>
-
-### Custom Network Config Global Network List Global Network Connections Sli To Global DR
-
-<a id="custom-network-config-global-network-list-global-network-connections-slo-to-global-dr"></a>
-
-### Custom Network Config Global Network List Global Network Connections Slo To Global DR
+`slo_to_global_dr` - (Optional) Global Network. Global network reference for direct connection (`Block`).
 
 <a id="custom-network-config-interface-list"></a>
 
@@ -400,101 +356,45 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Custom Network Config Interface List Interfaces
 
-`dc_cluster_group_connectivity_interface_disabled` - (Optional) Empty. This can be used for messages where no values are needed. See [Dc Cluster Group Connectivity Interface Disabled](#custom-network-config-interface-list-interfaces-dc-cluster-group-connectivity-interface-disabled) below.
+`dc_cluster_group_connectivity_interface_disabled` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`dc_cluster_group_connectivity_interface_enabled` - (Optional) Empty. This can be used for messages where no values are needed. See [Dc Cluster Group Connectivity Interface Enabled](#custom-network-config-interface-list-interfaces-dc-cluster-group-connectivity-interface-enabled) below.
+`dc_cluster_group_connectivity_interface_enabled` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`dedicated_interface` - (Optional) Dedicated Interface. Dedicated Interface Configuration. See [Dedicated Interface](#custom-network-config-interface-list-interfaces-dedicated-interface) below.
+`dedicated_interface` - (Optional) Dedicated Interface. Dedicated Interface Configuration (`Block`).
 
-`dedicated_management_interface` - (Optional) Dedicated Management Interface. Dedicated Interface Configuration. See [Dedicated Management Interface](#custom-network-config-interface-list-interfaces-dedicated-management-interface) below.
+`dedicated_management_interface` - (Optional) Dedicated Management Interface. Dedicated Interface Configuration (`Block`).
 
 `description` - (Optional) Interface Description. Description for this Interface (`String`).
 
-`ethernet_interface` - (Optional) Ethernet Interface. Ethernet Interface Configuration. See [Ethernet Interface](#custom-network-config-interface-list-interfaces-ethernet-interface) below.
+`ethernet_interface` - (Optional) Ethernet Interface. Ethernet Interface Configuration (`Block`).
 
-`labels` - (Optional) Interface Labels. Add Labels for this Interface, these labels can be used in firewall policy. See [Labels](#custom-network-config-interface-list-interfaces-labels) below.
+`labels` - (Optional) Interface Labels. Add Labels for this Interface, these labels can be used in firewall policy (`Block`).
 
-`tunnel_interface` - (Optional) Tunnel Interface. Tunnel Interface Configuration. See [Tunnel Interface](#custom-network-config-interface-list-interfaces-tunnel-interface) below.
-
-<a id="custom-network-config-interface-list-interfaces-dc-cluster-group-connectivity-interface-disabled"></a>
-
-### Custom Network Config Interface List Interfaces Dc Cluster Group Connectivity Interface Disabled
-
-<a id="custom-network-config-interface-list-interfaces-dc-cluster-group-connectivity-interface-enabled"></a>
-
-### Custom Network Config Interface List Interfaces Dc Cluster Group Connectivity Interface Enabled
-
-<a id="custom-network-config-interface-list-interfaces-dedicated-interface"></a>
-
-### Custom Network Config Interface List Interfaces Dedicated Interface
-
-<a id="custom-network-config-interface-list-interfaces-dedicated-management-interface"></a>
-
-### Custom Network Config Interface List Interfaces Dedicated Management Interface
-
-<a id="custom-network-config-interface-list-interfaces-ethernet-interface"></a>
-
-### Custom Network Config Interface List Interfaces Ethernet Interface
-
-<a id="custom-network-config-interface-list-interfaces-labels"></a>
-
-### Custom Network Config Interface List Interfaces Labels
-
-<a id="custom-network-config-interface-list-interfaces-tunnel-interface"></a>
-
-### Custom Network Config Interface List Interfaces Tunnel Interface
-
-<a id="custom-network-config-no-forward-proxy"></a>
-
-### Custom Network Config No Forward Proxy
-
-<a id="custom-network-config-no-global-network"></a>
-
-### Custom Network Config No Global Network
-
-<a id="custom-network-config-no-network-policy"></a>
-
-### Custom Network Config No Network Policy
+`tunnel_interface` - (Optional) Tunnel Interface. Tunnel Interface Configuration (`Block`).
 
 <a id="custom-network-config-sli-config"></a>
 
 ### Custom Network Config Sli Config
 
-`no_static_routes` - (Optional) Empty. This can be used for messages where no values are needed. See [No Static Routes](#custom-network-config-sli-config-no-static-routes) below.
+`no_static_routes` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_v6_static_routes` - (Optional) Empty. This can be used for messages where no values are needed. See [No V6 Static Routes](#custom-network-config-sli-config-no-v6-static-routes) below.
+`no_v6_static_routes` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `static_routes` - (Optional) Static Routes List. List of static routes. See [Static Routes](#custom-network-config-sli-config-static-routes) below.
 
 `static_v6_routes` - (Optional) Static IPv6 Routes List. List of IPv6 static routes. See [Static V6 Routes](#custom-network-config-sli-config-static-v6-routes) below.
 
-<a id="custom-network-config-sli-config-no-static-routes"></a>
-
-### Custom Network Config Sli Config No Static Routes
-
-<a id="custom-network-config-sli-config-no-v6-static-routes"></a>
-
-### Custom Network Config Sli Config No V6 Static Routes
-
 <a id="custom-network-config-sli-config-static-routes"></a>
 
 ### Custom Network Config Sli Config Static Routes
 
-`static_routes` - (Optional) Static Routes. List of static routes. See [Static Routes](#custom-network-config-sli-config-static-routes-static-routes) below.
-
-<a id="custom-network-config-sli-config-static-routes-static-routes"></a>
-
-### Custom Network Config Sli Config Static Routes Static Routes
+`static_routes` - (Optional) Static Routes. List of static routes (`Block`).
 
 <a id="custom-network-config-sli-config-static-v6-routes"></a>
 
 ### Custom Network Config Sli Config Static V6 Routes
 
-`static_routes` - (Optional) Static IPv6 Routes. List of IPv6 static routes. See [Static Routes](#custom-network-config-sli-config-static-v6-routes-static-routes) below.
-
-<a id="custom-network-config-sli-config-static-v6-routes-static-routes"></a>
-
-### Custom Network Config Sli Config Static V6 Routes Static Routes
+`static_routes` - (Optional) Static IPv6 Routes. List of IPv6 static routes (`Block`).
 
 <a id="custom-network-config-slo-config"></a>
 
@@ -502,13 +402,13 @@ In addition to all arguments above, the following attributes are exported:
 
 `dc_cluster_group` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Dc Cluster Group](#custom-network-config-slo-config-dc-cluster-group) below.
 
-`labels` - (Optional) Network Labels. Add Labels for this network, these labels can be used in firewall policy. See [Labels](#custom-network-config-slo-config-labels) below.
+`labels` - (Optional) Network Labels. Add Labels for this network, these labels can be used in firewall policy (`Block`).
 
-`no_dc_cluster_group` - (Optional) Empty. This can be used for messages where no values are needed. See [No Dc Cluster Group](#custom-network-config-slo-config-no-dc-cluster-group) below.
+`no_dc_cluster_group` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_static_routes` - (Optional) Empty. This can be used for messages where no values are needed. See [No Static Routes](#custom-network-config-slo-config-no-static-routes) below.
+`no_static_routes` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_static_v6_routes` - (Optional) Empty. This can be used for messages where no values are needed. See [No Static V6 Routes](#custom-network-config-slo-config-no-static-v6-routes) below.
+`no_static_v6_routes` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `static_routes` - (Optional) Static Routes List. List of static routes. See [Static Routes](#custom-network-config-slo-config-static-routes) below.
 
@@ -524,61 +424,29 @@ In addition to all arguments above, the following attributes are exported:
 
 `tenant` - (Optional) Tenant. When a configuration object(e.g. virtual_host) refers to another(e.g route) then tenant will hold the referred object's(e.g. route's) tenant (`String`).
 
-<a id="custom-network-config-slo-config-labels"></a>
-
-### Custom Network Config Slo Config Labels
-
-<a id="custom-network-config-slo-config-no-dc-cluster-group"></a>
-
-### Custom Network Config Slo Config No Dc Cluster Group
-
-<a id="custom-network-config-slo-config-no-static-routes"></a>
-
-### Custom Network Config Slo Config No Static Routes
-
-<a id="custom-network-config-slo-config-no-static-v6-routes"></a>
-
-### Custom Network Config Slo Config No Static V6 Routes
-
 <a id="custom-network-config-slo-config-static-routes"></a>
 
 ### Custom Network Config Slo Config Static Routes
 
-`static_routes` - (Optional) Static Routes. List of static routes. See [Static Routes](#custom-network-config-slo-config-static-routes-static-routes) below.
-
-<a id="custom-network-config-slo-config-static-routes-static-routes"></a>
-
-### Custom Network Config Slo Config Static Routes Static Routes
+`static_routes` - (Optional) Static Routes. List of static routes (`Block`).
 
 <a id="custom-network-config-slo-config-static-v6-routes"></a>
 
 ### Custom Network Config Slo Config Static V6 Routes
 
-`static_routes` - (Optional) Static IPv6 Routes. List of IPv6 static routes. See [Static Routes](#custom-network-config-slo-config-static-v6-routes-static-routes) below.
-
-<a id="custom-network-config-slo-config-static-v6-routes-static-routes"></a>
-
-### Custom Network Config Slo Config Static V6 Routes Static Routes
-
-<a id="custom-network-config-sm-connection-public-ip"></a>
-
-### Custom Network Config Sm Connection Public IP
-
-<a id="custom-network-config-sm-connection-pvt-ip"></a>
-
-### Custom Network Config Sm Connection Pvt IP
+`static_routes` - (Optional) Static IPv6 Routes. List of IPv6 static routes (`Block`).
 
 <a id="custom-storage-config"></a>
 
 ### Custom Storage Config
 
-`default_storage_class` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Storage Class](#custom-storage-config-default-storage-class) below.
+`default_storage_class` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_static_routes` - (Optional) Empty. This can be used for messages where no values are needed. See [No Static Routes](#custom-storage-config-no-static-routes) below.
+`no_static_routes` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_storage_device` - (Optional) Empty. This can be used for messages where no values are needed. See [No Storage Device](#custom-storage-config-no-storage-device) below.
+`no_storage_device` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_storage_interfaces` - (Optional) Empty. This can be used for messages where no values are needed. See [No Storage Interfaces](#custom-storage-config-no-storage-interfaces) below.
+`no_storage_interfaces` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `static_routes` - (Optional) Static Routes List. List of static routes. See [Static Routes](#custom-storage-config-static-routes) below.
 
@@ -587,22 +455,6 @@ In addition to all arguments above, the following attributes are exported:
 `storage_device_list` - (Optional) Custom Storage Device List. Add additional custom storage classes in kubernetes for this fleet. See [Storage Device List](#custom-storage-config-storage-device-list) below.
 
 `storage_interface_list` - (Optional) List of Interface. Configure storage interfaces for this App Stack site. See [Storage Interface List](#custom-storage-config-storage-interface-list) below.
-
-<a id="custom-storage-config-default-storage-class"></a>
-
-### Custom Storage Config Default Storage Class
-
-<a id="custom-storage-config-no-static-routes"></a>
-
-### Custom Storage Config No Static Routes
-
-<a id="custom-storage-config-no-storage-device"></a>
-
-### Custom Storage Config No Storage Device
-
-<a id="custom-storage-config-no-storage-interfaces"></a>
-
-### Custom Storage Config No Storage Interfaces
 
 <a id="custom-storage-config-static-routes"></a>
 
@@ -616,21 +468,13 @@ In addition to all arguments above, the following attributes are exported:
 
 `attrs` - (Optional) Attributes. List of attributes that control forwarding, dynamic routing and control plane (host) reachability (`List`).
 
-`default_gateway` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Gateway](#custom-storage-config-static-routes-static-routes-default-gateway) below.
+`default_gateway` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `ip_address` - (Optional) IP Address. Traffic matching the IP prefixes is sent to this IP Address (`String`).
 
 `ip_prefixes` - (Optional) IP Prefixes. List of route prefixes that have common next hop and attributes (`List`).
 
-`node_interface` - (Optional) NodeInterfaceType. On multinode site, this type holds the information about per node interfaces. See [Node Interface](#custom-storage-config-static-routes-static-routes-node-interface) below.
-
-<a id="custom-storage-config-static-routes-static-routes-default-gateway"></a>
-
-### Custom Storage Config Static Routes Static Routes Default Gateway
-
-<a id="custom-storage-config-static-routes-static-routes-node-interface"></a>
-
-### Custom Storage Config Static Routes Static Routes Node Interface
+`node_interface` - (Optional) NodeInterfaceType. On multinode site, this type holds the information about per node interfaces (`Block`).
 
 <a id="custom-storage-config-storage-class-list"></a>
 
@@ -642,47 +486,27 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Custom Storage Config Storage Class List Storage Classes
 
-`advanced_storage_parameters` - (Optional) Advanced Parameters. Map of parameter name and string value. See [Advanced Storage Parameters](#custom-storage-config-storage-class-list-storage-classes-advanced-storage-parameters) below.
+`advanced_storage_parameters` - (Optional) Advanced Parameters. Map of parameter name and string value (`Block`).
 
 `allow_volume_expansion` - (Optional) Allow Volume Expansion. Allow volume expansion (`Bool`).
 
-`custom_storage` - (Optional) Custom StorageClass. Custom Storage Class allows to insert Kubernetes storageclass definition which will be applied into given site. See [Custom Storage](#custom-storage-config-storage-class-list-storage-classes-custom-storage) below.
+`custom_storage` - (Optional) Custom StorageClass. Custom Storage Class allows to insert Kubernetes storageclass definition which will be applied into given site (`Block`).
 
 `default_storage_class` - (Optional) Default Storage Class. Make this storage class default storage class for the K8s cluster (`Bool`).
 
 `description` - (Optional) Storage Class Description. Description for this storage class (`String`).
 
-`hpe_storage` - (Optional) HPE Storage. Storage class Device configuration for HPE Storage. See [Hpe Storage](#custom-storage-config-storage-class-list-storage-classes-hpe-storage) below.
+`hpe_storage` - (Optional) HPE Storage. Storage class Device configuration for HPE Storage (`Block`).
 
-`netapp_trident` - (Optional) NetApp Trident Storage. Storage class Device configuration for NetApp Trident. See [Netapp Trident](#custom-storage-config-storage-class-list-storage-classes-netapp-trident) below.
+`netapp_trident` - (Optional) NetApp Trident Storage. Storage class Device configuration for NetApp Trident (`Block`).
 
-`pure_service_orchestrator` - (Optional) Pure Storage Service Orchestrator. Storage class Device configuration for Pure Service Orchestrator. See [Pure Service Orchestrator](#custom-storage-config-storage-class-list-storage-classes-pure-service-orchestrator) below.
+`pure_service_orchestrator` - (Optional) Pure Storage Service Orchestrator. Storage class Device configuration for Pure Service Orchestrator (`Block`).
 
 `reclaim_policy` - (Optional) Reclaim Policy. Reclaim Policy (`String`).
 
 `storage_class_name` - (Optional) Storage Class Name. Name of the storage class as it will appear in K8s (`String`).
 
 `storage_device` - (Optional) Storage Device. Storage device that this class will use. The Device name defined at previous step (`String`).
-
-<a id="custom-storage-config-storage-class-list-storage-classes-advanced-storage-parameters"></a>
-
-### Custom Storage Config Storage Class List Storage Classes Advanced Storage Parameters
-
-<a id="custom-storage-config-storage-class-list-storage-classes-custom-storage"></a>
-
-### Custom Storage Config Storage Class List Storage Classes Custom Storage
-
-<a id="custom-storage-config-storage-class-list-storage-classes-hpe-storage"></a>
-
-### Custom Storage Config Storage Class List Storage Classes Hpe Storage
-
-<a id="custom-storage-config-storage-class-list-storage-classes-netapp-trident"></a>
-
-### Custom Storage Config Storage Class List Storage Classes Netapp Trident
-
-<a id="custom-storage-config-storage-class-list-storage-classes-pure-service-orchestrator"></a>
-
-### Custom Storage Config Storage Class List Storage Classes Pure Service Orchestrator
 
 <a id="custom-storage-config-storage-device-list"></a>
 
@@ -694,37 +518,17 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Custom Storage Config Storage Device List Storage Devices
 
-`advanced_advanced_parameters` - (Optional) Advanced Parameters. Map of parameter name and string value. See [Advanced Advanced Parameters](#custom-storage-config-storage-device-list-storage-devices-advanced-advanced-parameters) below.
+`advanced_advanced_parameters` - (Optional) Advanced Parameters. Map of parameter name and string value (`Block`).
 
-`custom_storage` - (Optional) Empty. This can be used for messages where no values are needed. See [Custom Storage](#custom-storage-config-storage-device-list-storage-devices-custom-storage) below.
+`custom_storage` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`hpe_storage` - (Optional) HPE Storage. Device configuration for HPE Storage. See [Hpe Storage](#custom-storage-config-storage-device-list-storage-devices-hpe-storage) below.
+`hpe_storage` - (Optional) HPE Storage. Device configuration for HPE Storage (`Block`).
 
-`netapp_trident` - (Optional) NetApp Trident. Device configuration for NetApp Trident Storage. See [Netapp Trident](#custom-storage-config-storage-device-list-storage-devices-netapp-trident) below.
+`netapp_trident` - (Optional) NetApp Trident. Device configuration for NetApp Trident Storage (`Block`).
 
-`pure_service_orchestrator` - (Optional) Pure Storage Service Orchestrator. Device configuration for Pure Storage Service Orchestrator. See [Pure Service Orchestrator](#custom-storage-config-storage-device-list-storage-devices-pure-service-orchestrator) below.
+`pure_service_orchestrator` - (Optional) Pure Storage Service Orchestrator. Device configuration for Pure Storage Service Orchestrator (`Block`).
 
 `storage_device` - (Optional) Storage Device. Storage device and device unit (`String`).
-
-<a id="custom-storage-config-storage-device-list-storage-devices-advanced-advanced-parameters"></a>
-
-### Custom Storage Config Storage Device List Storage Devices Advanced Advanced Parameters
-
-<a id="custom-storage-config-storage-device-list-storage-devices-custom-storage"></a>
-
-### Custom Storage Config Storage Device List Storage Devices Custom Storage
-
-<a id="custom-storage-config-storage-device-list-storage-devices-hpe-storage"></a>
-
-### Custom Storage Config Storage Device List Storage Devices Hpe Storage
-
-<a id="custom-storage-config-storage-device-list-storage-devices-netapp-trident"></a>
-
-### Custom Storage Config Storage Device List Storage Devices Netapp Trident
-
-<a id="custom-storage-config-storage-device-list-storage-devices-pure-service-orchestrator"></a>
-
-### Custom Storage Config Storage Device List Storage Devices Pure Service Orchestrator
 
 <a id="custom-storage-config-storage-interface-list"></a>
 
@@ -738,49 +542,9 @@ In addition to all arguments above, the following attributes are exported:
 
 `description` - (Optional) Interface Description. Description for this Interface (`String`).
 
-`labels` - (Optional) Interface Labels. Add Labels for this Interface, these labels can be used in firewall policy. See [Labels](#custom-storage-config-storage-interface-list-storage-interfaces-labels) below.
+`labels` - (Optional) Interface Labels. Add Labels for this Interface, these labels can be used in firewall policy (`Block`).
 
-`storage_interface` - (Optional) Ethernet Interface. Ethernet Interface Configuration. See [Storage Interface](#custom-storage-config-storage-interface-list-storage-interfaces-storage-interface) below.
-
-<a id="custom-storage-config-storage-interface-list-storage-interfaces-labels"></a>
-
-### Custom Storage Config Storage Interface List Storage Interfaces Labels
-
-<a id="custom-storage-config-storage-interface-list-storage-interfaces-storage-interface"></a>
-
-### Custom Storage Config Storage Interface List Storage Interfaces Storage Interface
-
-<a id="default-blocked-services"></a>
-
-### Default Blocked Services
-
-<a id="default-network-config"></a>
-
-### Default Network Config
-
-<a id="default-sriov-interface"></a>
-
-### Default Sriov Interface
-
-<a id="default-storage-config"></a>
-
-### Default Storage Config
-
-<a id="deny-all-usb"></a>
-
-### Deny All Usb
-
-<a id="disable-gpu"></a>
-
-### Disable GPU
-
-<a id="disable-vm"></a>
-
-### Disable VM
-
-<a id="enable-gpu"></a>
-
-### Enable GPU
+`storage_interface` - (Optional) Ethernet Interface. Ethernet Interface Configuration (`Block`).
 
 <a id="enable-vgpu"></a>
 
@@ -791,10 +555,6 @@ In addition to all arguments above, the following attributes are exported:
 `server_address` - (Optional) License Server Address. Set License Server Address (`String`).
 
 `server_port` - (Optional) License Server Port Number. Set License Server port number (`Number`).
-
-<a id="enable-vm"></a>
-
-### Enable VM
 
 <a id="k8s-cluster"></a>
 
@@ -810,33 +570,21 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Kubernetes Upgrade Drain
 
-`disable_upgrade_drain` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Upgrade Drain](#kubernetes-upgrade-drain-disable-upgrade-drain) below.
+`disable_upgrade_drain` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `enable_upgrade_drain` - (Optional) Enable Node by Node Upgrade. Specify batch upgrade settings for worker nodes within a site. See [Enable Upgrade Drain](#kubernetes-upgrade-drain-enable-upgrade-drain) below.
-
-<a id="kubernetes-upgrade-drain-disable-upgrade-drain"></a>
-
-### Kubernetes Upgrade Drain Disable Upgrade Drain
 
 <a id="kubernetes-upgrade-drain-enable-upgrade-drain"></a>
 
 ### Kubernetes Upgrade Drain Enable Upgrade Drain
 
-`disable_vega_upgrade_mode` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable Vega Upgrade Mode](#kubernetes-upgrade-drain-enable-upgrade-drain-disable-vega-upgrade-mode) below.
+`disable_vega_upgrade_mode` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `drain_max_unavailable_node_count` - (Optional) Node Batch Size Count (`Number`).
 
 `drain_node_timeout` - (Optional) Upgrade Wait Time. Seconds to wait before initiating upgrade on the next set of nodes. Setting it to 0 will wait indefinitely for all services on nodes to be upgraded gracefully before proceeding to the next set of nodes. (Warning: It may block upgrade if services on a node cannot be gracefully upgraded. It is recommended to use the default value) (`Number`).
 
-`enable_vega_upgrade_mode` - (Optional) Empty. This can be used for messages where no values are needed. See [Enable Vega Upgrade Mode](#kubernetes-upgrade-drain-enable-upgrade-drain-enable-vega-upgrade-mode) below.
-
-<a id="kubernetes-upgrade-drain-enable-upgrade-drain-disable-vega-upgrade-mode"></a>
-
-### Kubernetes Upgrade Drain Enable Upgrade Drain Disable Vega Upgrade Mode
-
-<a id="kubernetes-upgrade-drain-enable-upgrade-drain-enable-vega-upgrade-mode"></a>
-
-### Kubernetes Upgrade Drain Enable Upgrade Drain Enable Vega Upgrade Mode
+`enable_vega_upgrade_mode` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="local-control-plane"></a>
 
@@ -844,9 +592,9 @@ In addition to all arguments above, the following attributes are exported:
 
 `bgp_config` - (Optional) BGP Configuration. BGP configuration parameters. See [BGP Config](#local-control-plane-bgp-config) below.
 
-`inside_vn` - (Optional) Empty. This can be used for messages where no values are needed. See [Inside Vn](#local-control-plane-inside-vn) below.
+`inside_vn` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`outside_vn` - (Optional) Empty. This can be used for messages where no values are needed. See [Outside Vn](#local-control-plane-outside-vn) below.
+`outside_vn` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="local-control-plane-bgp-config"></a>
 
@@ -860,63 +608,23 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Local Control Plane BGP Config Peers
 
-`bfd_disabled` - (Optional) Empty. This can be used for messages where no values are needed. See [Bfd Disabled](#local-control-plane-bgp-config-peers-bfd-disabled) below.
+`bfd_disabled` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`bfd_enabled` - (Optional) BFD. BFD parameters. See [Bfd Enabled](#local-control-plane-bgp-config-peers-bfd-enabled) below.
+`bfd_enabled` - (Optional) BFD. BFD parameters (`Block`).
 
-`disable` - (Optional) Empty. This can be used for messages where no values are needed. See [Disable](#local-control-plane-bgp-config-peers-disable) below.
+`disable` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`external` - (Optional) External BGP Peer. External BGP Peer parameters. See [External](#local-control-plane-bgp-config-peers-external) below.
+`external` - (Optional) External BGP Peer. External BGP Peer parameters (`Block`).
 
 `label` - (Optional) Label. Specify whether this peer should be (`String`).
 
-`metadata` - (Optional) Message Metadata. MessageMetaType is metadata (common attributes) of a message that only certain messages have. This information is propagated to the metadata of a child object that gets created from the containing message during view processing. The information in this type can be specified by user during create and replace APIs. See [Metadata](#local-control-plane-bgp-config-peers-metadata) below.
+`metadata` - (Optional) Message Metadata. MessageMetaType is metadata (common attributes) of a message that only certain messages have. This information is propagated to the metadata of a child object that gets created from the containing message during view processing. The information in this type can be specified by user during create and replace APIs (`Block`).
 
-`passive_mode_disabled` - (Optional) Empty. This can be used for messages where no values are needed. See [Passive Mode Disabled](#local-control-plane-bgp-config-peers-passive-mode-disabled) below.
+`passive_mode_disabled` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`passive_mode_enabled` - (Optional) Empty. This can be used for messages where no values are needed. See [Passive Mode Enabled](#local-control-plane-bgp-config-peers-passive-mode-enabled) below.
+`passive_mode_enabled` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`routing_policies` - (Optional) BGP Routing Policy. List of rules which can be applied on all or particular nodes. See [Routing Policies](#local-control-plane-bgp-config-peers-routing-policies) below.
-
-<a id="local-control-plane-bgp-config-peers-bfd-disabled"></a>
-
-### Local Control Plane BGP Config Peers Bfd Disabled
-
-<a id="local-control-plane-bgp-config-peers-bfd-enabled"></a>
-
-### Local Control Plane BGP Config Peers Bfd Enabled
-
-<a id="local-control-plane-bgp-config-peers-disable"></a>
-
-### Local Control Plane BGP Config Peers Disable
-
-<a id="local-control-plane-bgp-config-peers-external"></a>
-
-### Local Control Plane BGP Config Peers External
-
-<a id="local-control-plane-bgp-config-peers-metadata"></a>
-
-### Local Control Plane BGP Config Peers Metadata
-
-<a id="local-control-plane-bgp-config-peers-passive-mode-disabled"></a>
-
-### Local Control Plane BGP Config Peers Passive Mode Disabled
-
-<a id="local-control-plane-bgp-config-peers-passive-mode-enabled"></a>
-
-### Local Control Plane BGP Config Peers Passive Mode Enabled
-
-<a id="local-control-plane-bgp-config-peers-routing-policies"></a>
-
-### Local Control Plane BGP Config Peers Routing Policies
-
-<a id="local-control-plane-inside-vn"></a>
-
-### Local Control Plane Inside Vn
-
-<a id="local-control-plane-outside-vn"></a>
-
-### Local Control Plane Outside Vn
+`routing_policies` - (Optional) BGP Routing Policy. List of rules which can be applied on all or particular nodes (`Block`).
 
 <a id="log-receiver"></a>
 
@@ -928,10 +636,6 @@ In addition to all arguments above, the following attributes are exported:
 
 `tenant` - (Optional) Tenant. When a configuration object(e.g. virtual_host) refers to another(e.g route) then tenant will hold the referred object's(e.g. route's) tenant (`String`).
 
-<a id="logs-streaming-disabled"></a>
-
-### Logs Streaming Disabled
-
 <a id="master-node-configuration"></a>
 
 ### Master Node Configuration
@@ -940,45 +644,21 @@ In addition to all arguments above, the following attributes are exported:
 
 `public_ip` - (Optional) Public IP. IP Address of the master node. This IP will be used when other sites connect via Site Mesh Group (`String`).
 
-<a id="no-bond-devices"></a>
-
-### No Bond Devices
-
-<a id="no-k8s-cluster"></a>
-
-### No K8s Cluster
-
-<a id="no-local-control-plane"></a>
-
-### No Local Control Plane
-
 <a id="offline-survivability-mode"></a>
 
 ### Offline Survivability Mode
 
-`enable_offline_survivability_mode` - (Optional) Empty. This can be used for messages where no values are needed. See [Enable Offline Survivability Mode](#offline-survivability-mode-enable-offline-survivability-mode) below.
+`enable_offline_survivability_mode` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`no_offline_survivability_mode` - (Optional) Empty. This can be used for messages where no values are needed. See [No Offline Survivability Mode](#offline-survivability-mode-no-offline-survivability-mode) below.
-
-<a id="offline-survivability-mode-enable-offline-survivability-mode"></a>
-
-### Offline Survivability Mode Enable Offline Survivability Mode
-
-<a id="offline-survivability-mode-no-offline-survivability-mode"></a>
-
-### Offline Survivability Mode No Offline Survivability Mode
+`no_offline_survivability_mode` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="os"></a>
 
 ### OS
 
-`default_os_version` - (Optional) Empty. This can be used for messages where no values are needed. See [Default OS Version](#os-default-os-version) below.
+`default_os_version` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `operating_system_version` - (Optional) Operating System Version. Specify a OS version to be used e.g. 9.2024.6 (`String`).
-
-<a id="os-default-os-version"></a>
-
-### OS Default OS Version
 
 <a id="sriov-interfaces"></a>
 
@@ -1000,13 +680,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Sw
 
-`default_sw_version` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Sw Version](#sw-default-sw-version) below.
+`default_sw_version` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `volterra_software_version` - (Optional) F5XC Software Version. Specify a F5XC Software Version to be used e.g. crt-20210329-1002 (`String`).
-
-<a id="sw-default-sw-version"></a>
-
-### Sw Default Sw Version
 
 <a id="timeouts"></a>
 

--- a/docs/resources/waf_exclusion_policy.md
+++ b/docs/resources/waf_exclusion_policy.md
@@ -90,9 +90,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ### WAF Exclusion Rules
 
-`any_domain` - (Optional) Empty. This can be used for messages where no values are needed. See [Any Domain](#waf-exclusion-rules-any-domain) below.
+`any_domain` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`any_path` - (Optional) Empty. This can be used for messages where no values are needed. See [Any Path](#waf-exclusion-rules-any-path) below.
+`any_path` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `app_firewall_detection_control` - (Optional) App Firewall Detection Control. Define the list of Signature IDs, Violations, Attack Types and Bot Names that should be excluded from triggering on the defined match criteria. See [App Firewall Detection Control](#waf-exclusion-rules-app-firewall-detection-control) below.
 
@@ -110,15 +110,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `suffix_value` - (Optional) Suffix Value. Suffix of domain name e.g 'xyz.com' will match '*.xyz.com' and 'xyz.com' (`String`).
 
-`waf_skip_processing` - (Optional) Empty. This can be used for messages where no values are needed. See [WAF Skip Processing](#waf-exclusion-rules-waf-skip-processing) below.
-
-<a id="waf-exclusion-rules-any-domain"></a>
-
-### WAF Exclusion Rules Any Domain
-
-<a id="waf-exclusion-rules-any-path"></a>
-
-### WAF Exclusion Rules Any Path
+`waf_skip_processing` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="waf-exclusion-rules-app-firewall-detection-control"></a>
 
@@ -175,10 +167,6 @@ In addition to all arguments above, the following attributes are exported:
 `description` - (Optional) Description. Human readable description (`String`).
 
 `name` - (Optional) Name. This is the name of the message. The value of name has to follow DNS-1035 format (`String`).
-
-<a id="waf-exclusion-rules-waf-skip-processing"></a>
-
-### WAF Exclusion Rules WAF Skip Processing
 
 ## Import
 

--- a/docs/resources/workload.md
+++ b/docs/resources/workload.md
@@ -111,17 +111,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Job Configuration Parameters
 
-`env_var` - (Optional) Environment Variable. Environment Variable. See [Env Var](#job-configuration-parameters-env-var) below.
+`env_var` - (Optional) Environment Variable. Environment Variable (`Block`).
 
-`file` - (Optional) Configuration File. Configuration File for the workload. See [File](#job-configuration-parameters-file) below.
-
-<a id="job-configuration-parameters-env-var"></a>
-
-### Job Configuration Parameters Env Var
-
-<a id="job-configuration-parameters-file"></a>
-
-### Job Configuration Parameters File
+`file` - (Optional) Configuration File. Configuration File for the workload (`Block`).
 
 <a id="job-containers"></a>
 
@@ -133,7 +125,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `custom_flavor` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Custom Flavor](#job-containers-custom-flavor) below.
 
-`default_flavor` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Flavor](#job-containers-default-flavor) below.
+`default_flavor` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `flavor` - (Optional) Container Flavor Type. Container Flavor type - CONTAINER_FLAVOR_TYPE_TINY: Tiny Tiny containers have limit of 0.1 vCPU and 256 MiB (mebibyte) memory - CONTAINER_FLAVOR_TYPE_MEDIUM: Medium Medium containers have limit of 0.25 vCPU and 512 MiB (mebibyte) memory - CONTAINER_FLAVOR_TYPE_LARGE: Large Large containers have limit of 1 vCPU and 2048 MiB (mebibyte) memory. Possible values are `CONTAINER_FLAVOR_TYPE_TINY`, `CONTAINER_FLAVOR_TYPE_MEDIUM`, `CONTAINER_FLAVOR_TYPE_LARGE`. Defaults to `CONTAINER_FLAVOR_TYPE_TINY` (`String`).
 
@@ -157,101 +149,65 @@ In addition to all arguments above, the following attributes are exported:
 
 `tenant` - (Optional) Tenant. When a configuration object(e.g. virtual_host) refers to another(e.g route) then tenant will hold the referred object's(e.g. route's) tenant (`String`).
 
-<a id="job-containers-default-flavor"></a>
-
-### Job Containers Default Flavor
-
 <a id="job-containers-image"></a>
 
 ### Job Containers Image
 
-`container_registry` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Container Registry](#job-containers-image-container-registry) below.
+`container_registry` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name (`Block`).
 
 `name` - (Optional) Image Name. Name is a container image which are usually given a name such as alpine, ubuntu, or quay.io/etcd:0.13. The format is registry/image:tag or registry/image@image-digest. If registry is not specified, the Docker public registry is assumed. If tag is not specified, latest is assumed (`String`).
 
-`public` - (Optional) Empty. This can be used for messages where no values are needed. See [Public](#job-containers-image-public) below.
+`public` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `pull_policy` - (Optional) Image Pull Policy Type. Image pull policy type enumerates the policy choices to use for pulling the image prior to starting the workload - IMAGE_PULL_POLICY_DEFAULT: Default Default will always pull image if :latest tag is specified in image name. If :latest tag is not specified in image name, it will pull image only if it does not already exist on the node - IMAGE_PULL_POLICY_IF_NOT_PRESENT: IfNotPresent Only pull the image if it does not already exist on the node - IMAGE_PULL_POLICY_ALWAYS:... Possible values are `IMAGE_PULL_POLICY_DEFAULT`, `IMAGE_PULL_POLICY_IF_NOT_PRESENT`, `IMAGE_PULL_POLICY_ALWAYS`, `IMAGE_PULL_POLICY_NEVER`. Defaults to `IMAGE_PULL_POLICY_DEFAULT` (`String`).
-
-<a id="job-containers-image-container-registry"></a>
-
-### Job Containers Image Container Registry
-
-<a id="job-containers-image-public"></a>
-
-### Job Containers Image Public
 
 <a id="job-containers-liveness-check"></a>
 
 ### Job Containers Liveness Check
 
-`exec_health_check` - (Optional) Exec Health Check. ExecHealthCheckType describes a health check based on 'run in container' action. Exit status of 0 is treated as live/healthy and non-zero is unhealthy. See [Exec Health Check](#job-containers-liveness-check-exec-health-check) below.
+`exec_health_check` - (Optional) Exec Health Check. ExecHealthCheckType describes a health check based on 'run in container' action. Exit status of 0 is treated as live/healthy and non-zero is unhealthy (`Block`).
 
 `healthy_threshold` - (Optional) Healthy Threshold. Number of consecutive successful responses after having failed before declaring healthy. In other words, this is the number of healthy health checks required before marking healthy. Note that during startup and liveliness, only a single successful health check is required to mark a container healthy (`Number`).
 
-`http_health_check` - (Optional) HTTP Health Check. HTTPHealthCheckType describes a health check based on HTTP GET requests. See [HTTP Health Check](#job-containers-liveness-check-http-health-check) below.
+`http_health_check` - (Optional) HTTP Health Check. HTTPHealthCheckType describes a health check based on HTTP GET requests (`Block`).
 
 `initial_delay` - (Optional) Initial Delay. Number of seconds after the container has started before health checks are initiated (`Number`).
 
 `interval` - (Optional) Interval. Time interval in seconds between two health check requests (`Number`).
 
-`tcp_health_check` - (Optional) TCP Health Check. TCPHealthCheckType describes a health check based on opening a TCP connection. See [TCP Health Check](#job-containers-liveness-check-tcp-health-check) below.
+`tcp_health_check` - (Optional) TCP Health Check. TCPHealthCheckType describes a health check based on opening a TCP connection (`Block`).
 
 `timeout` - (Optional) Timeout. Timeout in seconds to wait for successful response. In other words, it is the time to wait for a health check response. If the timeout is reached the health check attempt will be considered a failure (`Number`).
 
 `unhealthy_threshold` - (Optional) Unhealthy Threshold. Number of consecutive failed responses before declaring unhealthy. In other words, this is the number of unhealthy health checks required before a container is marked unhealthy (`Number`).
-
-<a id="job-containers-liveness-check-exec-health-check"></a>
-
-### Job Containers Liveness Check Exec Health Check
-
-<a id="job-containers-liveness-check-http-health-check"></a>
-
-### Job Containers Liveness Check HTTP Health Check
-
-<a id="job-containers-liveness-check-tcp-health-check"></a>
-
-### Job Containers Liveness Check TCP Health Check
 
 <a id="job-containers-readiness-check"></a>
 
 ### Job Containers Readiness Check
 
-`exec_health_check` - (Optional) Exec Health Check. ExecHealthCheckType describes a health check based on 'run in container' action. Exit status of 0 is treated as live/healthy and non-zero is unhealthy. See [Exec Health Check](#job-containers-readiness-check-exec-health-check) below.
+`exec_health_check` - (Optional) Exec Health Check. ExecHealthCheckType describes a health check based on 'run in container' action. Exit status of 0 is treated as live/healthy and non-zero is unhealthy (`Block`).
 
 `healthy_threshold` - (Optional) Healthy Threshold. Number of consecutive successful responses after having failed before declaring healthy. In other words, this is the number of healthy health checks required before marking healthy. Note that during startup and liveliness, only a single successful health check is required to mark a container healthy (`Number`).
 
-`http_health_check` - (Optional) HTTP Health Check. HTTPHealthCheckType describes a health check based on HTTP GET requests. See [HTTP Health Check](#job-containers-readiness-check-http-health-check) below.
+`http_health_check` - (Optional) HTTP Health Check. HTTPHealthCheckType describes a health check based on HTTP GET requests (`Block`).
 
 `initial_delay` - (Optional) Initial Delay. Number of seconds after the container has started before health checks are initiated (`Number`).
 
 `interval` - (Optional) Interval. Time interval in seconds between two health check requests (`Number`).
 
-`tcp_health_check` - (Optional) TCP Health Check. TCPHealthCheckType describes a health check based on opening a TCP connection. See [TCP Health Check](#job-containers-readiness-check-tcp-health-check) below.
+`tcp_health_check` - (Optional) TCP Health Check. TCPHealthCheckType describes a health check based on opening a TCP connection (`Block`).
 
 `timeout` - (Optional) Timeout. Timeout in seconds to wait for successful response. In other words, it is the time to wait for a health check response. If the timeout is reached the health check attempt will be considered a failure (`Number`).
 
 `unhealthy_threshold` - (Optional) Unhealthy Threshold. Number of consecutive failed responses before declaring unhealthy. In other words, this is the number of unhealthy health checks required before a container is marked unhealthy (`Number`).
 
-<a id="job-containers-readiness-check-exec-health-check"></a>
-
-### Job Containers Readiness Check Exec Health Check
-
-<a id="job-containers-readiness-check-http-health-check"></a>
-
-### Job Containers Readiness Check HTTP Health Check
-
-<a id="job-containers-readiness-check-tcp-health-check"></a>
-
-### Job Containers Readiness Check TCP Health Check
-
 <a id="job-deploy-options"></a>
 
 ### Job Deploy Options
 
-`all_res` - (Optional) Empty. This can be used for messages where no values are needed. See [All Res](#job-deploy-options-all-res) below.
+`all_res` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`default_virtual_sites` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Virtual Sites](#job-deploy-options-default-virtual-sites) below.
+`default_virtual_sites` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `deploy_ce_sites` - (Optional) Customer Sites. This defines a way to deploy a workload on specific Customer sites. See [Deploy CE Sites](#job-deploy-options-deploy-ce-sites) below.
 
@@ -261,53 +217,29 @@ In addition to all arguments above, the following attributes are exported:
 
 `deploy_re_virtual_sites` - (Optional) Regional Edge Virtual Sites. This defines a way to deploy a workload on specific Regional Edge virtual sites. See [Deploy RE Virtual Sites](#job-deploy-options-deploy-re-virtual-sites) below.
 
-<a id="job-deploy-options-all-res"></a>
-
-### Job Deploy Options All Res
-
-<a id="job-deploy-options-default-virtual-sites"></a>
-
-### Job Deploy Options Default Virtual Sites
-
 <a id="job-deploy-options-deploy-ce-sites"></a>
 
 ### Job Deploy Options Deploy CE Sites
 
-`site` - (Optional) List of Customer Sites to Deploy. Which customer sites should this workload be deployed. See [Site](#job-deploy-options-deploy-ce-sites-site) below.
-
-<a id="job-deploy-options-deploy-ce-sites-site"></a>
-
-### Job Deploy Options Deploy CE Sites Site
+`site` - (Optional) List of Customer Sites to Deploy. Which customer sites should this workload be deployed (`Block`).
 
 <a id="job-deploy-options-deploy-ce-virtual-sites"></a>
 
 ### Job Deploy Options Deploy CE Virtual Sites
 
-`virtual_site` - (Optional) List of Customer Virtual Sites to Deploy. Which customer virtual sites should this workload be deployed. See [Virtual Site](#job-deploy-options-deploy-ce-virtual-sites-virtual-site) below.
-
-<a id="job-deploy-options-deploy-ce-virtual-sites-virtual-site"></a>
-
-### Job Deploy Options Deploy CE Virtual Sites Virtual Site
+`virtual_site` - (Optional) List of Customer Virtual Sites to Deploy. Which customer virtual sites should this workload be deployed (`Block`).
 
 <a id="job-deploy-options-deploy-re-sites"></a>
 
 ### Job Deploy Options Deploy RE Sites
 
-`site` - (Optional) List of Regional Edge Sites to Deploy. Which regional edge sites should this workload be deployed. See [Site](#job-deploy-options-deploy-re-sites-site) below.
-
-<a id="job-deploy-options-deploy-re-sites-site"></a>
-
-### Job Deploy Options Deploy RE Sites Site
+`site` - (Optional) List of Regional Edge Sites to Deploy. Which regional edge sites should this workload be deployed (`Block`).
 
 <a id="job-deploy-options-deploy-re-virtual-sites"></a>
 
 ### Job Deploy Options Deploy RE Virtual Sites
 
-`virtual_site` - (Optional) List of Regional Edge Virtual Sites to Deploy. Which regional edge virtual sites should this workload be deployed. See [Virtual Site](#job-deploy-options-deploy-re-virtual-sites-virtual-site) below.
-
-<a id="job-deploy-options-deploy-re-virtual-sites-virtual-site"></a>
-
-### Job Deploy Options Deploy RE Virtual Sites Virtual Site
+`virtual_site` - (Optional) List of Regional Edge Virtual Sites to Deploy. Which regional edge virtual sites should this workload be deployed (`Block`).
 
 <a id="job-volumes"></a>
 
@@ -325,41 +257,25 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Job Volumes Empty Dir
 
-`mount` - (Optional) Volume Mount. Volume mount describes how volume is mounted inside a workload. See [Mount](#job-volumes-empty-dir-mount) below.
+`mount` - (Optional) Volume Mount. Volume mount describes how volume is mounted inside a workload (`Block`).
 
 `size_limit` - (Optional) Size Limit (in GiB) (`Number`).
-
-<a id="job-volumes-empty-dir-mount"></a>
-
-### Job Volumes Empty Dir Mount
 
 <a id="job-volumes-host-path"></a>
 
 ### Job Volumes Host Path
 
-`mount` - (Optional) Volume Mount. Volume mount describes how volume is mounted inside a workload. See [Mount](#job-volumes-host-path-mount) below.
+`mount` - (Optional) Volume Mount. Volume mount describes how volume is mounted inside a workload (`Block`).
 
 `path` - (Optional) Path. Path of the directory on the host (`String`).
-
-<a id="job-volumes-host-path-mount"></a>
-
-### Job Volumes Host Path Mount
 
 <a id="job-volumes-persistent-volume"></a>
 
 ### Job Volumes Persistent Volume
 
-`mount` - (Optional) Volume Mount. Volume mount describes how volume is mounted inside a workload. See [Mount](#job-volumes-persistent-volume-mount) below.
+`mount` - (Optional) Volume Mount. Volume mount describes how volume is mounted inside a workload (`Block`).
 
-`storage` - (Optional) Persistence Storage Configuration. Persistent storage configuration is used to configure Persistent Volume Claim (PVC). See [Storage](#job-volumes-persistent-volume-storage) below.
-
-<a id="job-volumes-persistent-volume-mount"></a>
-
-### Job Volumes Persistent Volume Mount
-
-<a id="job-volumes-persistent-volume-storage"></a>
-
-### Job Volumes Persistent Volume Storage
+`storage` - (Optional) Persistence Storage Configuration. Persistent storage configuration is used to configure Persistent Volume Claim (PVC) (`Block`).
 
 <a id="service"></a>
 
@@ -375,7 +291,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `num_replicas` - (Optional) Number of Replicas. Number of replicas of service to spawn per site (`Number`).
 
-`scale_to_zero` - (Optional) Empty. This can be used for messages where no values are needed. See [Scale To Zero](#service-scale-to-zero) below.
+`scale_to_zero` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `volumes` - (Optional) Configuration for volumes. See [Volumes](#service-volumes) below.
 
@@ -389,59 +305,31 @@ In addition to all arguments above, the following attributes are exported:
 
 `advertise_on_public` - (Optional) Advertise On Internet. Advertise this workload via loadbalancer on Internet with default VIP. See [Advertise On Public](#service-advertise-options-advertise-on-public) below.
 
-`do_not_advertise` - (Optional) Empty. This can be used for messages where no values are needed. See [Do Not Advertise](#service-advertise-options-do-not-advertise) below.
+`do_not_advertise` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="service-advertise-options-advertise-custom"></a>
 
 ### Service Advertise Options Advertise Custom
 
-`advertise_where` - (Optional) List of Sites to Advertise. Where should this load balancer be available. See [Advertise Where](#service-advertise-options-advertise-custom-advertise-where) below.
+`advertise_where` - (Optional) List of Sites to Advertise. Where should this load balancer be available (`Block`).
 
-`ports` - (Optional) Configuration for ports. See [Ports](#service-advertise-options-advertise-custom-ports) below.
-
-<a id="service-advertise-options-advertise-custom-advertise-where"></a>
-
-### Service Advertise Options Advertise Custom Advertise Where
-
-<a id="service-advertise-options-advertise-custom-ports"></a>
-
-### Service Advertise Options Advertise Custom Ports
+`ports` - (Optional) Configuration for ports (`Block`).
 
 <a id="service-advertise-options-advertise-in-cluster"></a>
 
 ### Service Advertise Options Advertise In Cluster
 
-`multi_ports` - (Optional) Multiple Ports. Multiple ports. See [Multi Ports](#service-advertise-options-advertise-in-cluster-multi-ports) below.
+`multi_ports` - (Optional) Multiple Ports. Multiple ports (`Block`).
 
-`port` - (Optional) Configuration for port. See [Port](#service-advertise-options-advertise-in-cluster-port) below.
-
-<a id="service-advertise-options-advertise-in-cluster-multi-ports"></a>
-
-### Service Advertise Options Advertise In Cluster Multi Ports
-
-<a id="service-advertise-options-advertise-in-cluster-port"></a>
-
-### Service Advertise Options Advertise In Cluster Port
+`port` - (Optional) Configuration for port (`Block`).
 
 <a id="service-advertise-options-advertise-on-public"></a>
 
 ### Service Advertise Options Advertise On Public
 
-`multi_ports` - (Optional) Advertise Multiple Ports. Advertise multiple ports. See [Multi Ports](#service-advertise-options-advertise-on-public-multi-ports) below.
+`multi_ports` - (Optional) Advertise Multiple Ports. Advertise multiple ports (`Block`).
 
-`port` - (Optional) Advertise Port. Advertise single port. See [Port](#service-advertise-options-advertise-on-public-port) below.
-
-<a id="service-advertise-options-advertise-on-public-multi-ports"></a>
-
-### Service Advertise Options Advertise On Public Multi Ports
-
-<a id="service-advertise-options-advertise-on-public-port"></a>
-
-### Service Advertise Options Advertise On Public Port
-
-<a id="service-advertise-options-do-not-advertise"></a>
-
-### Service Advertise Options Do Not Advertise
+`port` - (Optional) Advertise Port. Advertise single port (`Block`).
 
 <a id="service-configuration"></a>
 
@@ -453,17 +341,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Service Configuration Parameters
 
-`env_var` - (Optional) Environment Variable. Environment Variable. See [Env Var](#service-configuration-parameters-env-var) below.
+`env_var` - (Optional) Environment Variable. Environment Variable (`Block`).
 
-`file` - (Optional) Configuration File. Configuration File for the workload. See [File](#service-configuration-parameters-file) below.
-
-<a id="service-configuration-parameters-env-var"></a>
-
-### Service Configuration Parameters Env Var
-
-<a id="service-configuration-parameters-file"></a>
-
-### Service Configuration Parameters File
+`file` - (Optional) Configuration File. Configuration File for the workload (`Block`).
 
 <a id="service-containers"></a>
 
@@ -475,7 +355,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `custom_flavor` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Custom Flavor](#service-containers-custom-flavor) below.
 
-`default_flavor` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Flavor](#service-containers-default-flavor) below.
+`default_flavor` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `flavor` - (Optional) Container Flavor Type. Container Flavor type - CONTAINER_FLAVOR_TYPE_TINY: Tiny Tiny containers have limit of 0.1 vCPU and 256 MiB (mebibyte) memory - CONTAINER_FLAVOR_TYPE_MEDIUM: Medium Medium containers have limit of 0.25 vCPU and 512 MiB (mebibyte) memory - CONTAINER_FLAVOR_TYPE_LARGE: Large Large containers have limit of 1 vCPU and 2048 MiB (mebibyte) memory. Possible values are `CONTAINER_FLAVOR_TYPE_TINY`, `CONTAINER_FLAVOR_TYPE_MEDIUM`, `CONTAINER_FLAVOR_TYPE_LARGE`. Defaults to `CONTAINER_FLAVOR_TYPE_TINY` (`String`).
 
@@ -499,101 +379,65 @@ In addition to all arguments above, the following attributes are exported:
 
 `tenant` - (Optional) Tenant. When a configuration object(e.g. virtual_host) refers to another(e.g route) then tenant will hold the referred object's(e.g. route's) tenant (`String`).
 
-<a id="service-containers-default-flavor"></a>
-
-### Service Containers Default Flavor
-
 <a id="service-containers-image"></a>
 
 ### Service Containers Image
 
-`container_registry` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Container Registry](#service-containers-image-container-registry) below.
+`container_registry` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name (`Block`).
 
 `name` - (Optional) Image Name. Name is a container image which are usually given a name such as alpine, ubuntu, or quay.io/etcd:0.13. The format is registry/image:tag or registry/image@image-digest. If registry is not specified, the Docker public registry is assumed. If tag is not specified, latest is assumed (`String`).
 
-`public` - (Optional) Empty. This can be used for messages where no values are needed. See [Public](#service-containers-image-public) below.
+`public` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `pull_policy` - (Optional) Image Pull Policy Type. Image pull policy type enumerates the policy choices to use for pulling the image prior to starting the workload - IMAGE_PULL_POLICY_DEFAULT: Default Default will always pull image if :latest tag is specified in image name. If :latest tag is not specified in image name, it will pull image only if it does not already exist on the node - IMAGE_PULL_POLICY_IF_NOT_PRESENT: IfNotPresent Only pull the image if it does not already exist on the node - IMAGE_PULL_POLICY_ALWAYS:... Possible values are `IMAGE_PULL_POLICY_DEFAULT`, `IMAGE_PULL_POLICY_IF_NOT_PRESENT`, `IMAGE_PULL_POLICY_ALWAYS`, `IMAGE_PULL_POLICY_NEVER`. Defaults to `IMAGE_PULL_POLICY_DEFAULT` (`String`).
-
-<a id="service-containers-image-container-registry"></a>
-
-### Service Containers Image Container Registry
-
-<a id="service-containers-image-public"></a>
-
-### Service Containers Image Public
 
 <a id="service-containers-liveness-check"></a>
 
 ### Service Containers Liveness Check
 
-`exec_health_check` - (Optional) Exec Health Check. ExecHealthCheckType describes a health check based on 'run in container' action. Exit status of 0 is treated as live/healthy and non-zero is unhealthy. See [Exec Health Check](#service-containers-liveness-check-exec-health-check) below.
+`exec_health_check` - (Optional) Exec Health Check. ExecHealthCheckType describes a health check based on 'run in container' action. Exit status of 0 is treated as live/healthy and non-zero is unhealthy (`Block`).
 
 `healthy_threshold` - (Optional) Healthy Threshold. Number of consecutive successful responses after having failed before declaring healthy. In other words, this is the number of healthy health checks required before marking healthy. Note that during startup and liveliness, only a single successful health check is required to mark a container healthy (`Number`).
 
-`http_health_check` - (Optional) HTTP Health Check. HTTPHealthCheckType describes a health check based on HTTP GET requests. See [HTTP Health Check](#service-containers-liveness-check-http-health-check) below.
+`http_health_check` - (Optional) HTTP Health Check. HTTPHealthCheckType describes a health check based on HTTP GET requests (`Block`).
 
 `initial_delay` - (Optional) Initial Delay. Number of seconds after the container has started before health checks are initiated (`Number`).
 
 `interval` - (Optional) Interval. Time interval in seconds between two health check requests (`Number`).
 
-`tcp_health_check` - (Optional) TCP Health Check. TCPHealthCheckType describes a health check based on opening a TCP connection. See [TCP Health Check](#service-containers-liveness-check-tcp-health-check) below.
+`tcp_health_check` - (Optional) TCP Health Check. TCPHealthCheckType describes a health check based on opening a TCP connection (`Block`).
 
 `timeout` - (Optional) Timeout. Timeout in seconds to wait for successful response. In other words, it is the time to wait for a health check response. If the timeout is reached the health check attempt will be considered a failure (`Number`).
 
 `unhealthy_threshold` - (Optional) Unhealthy Threshold. Number of consecutive failed responses before declaring unhealthy. In other words, this is the number of unhealthy health checks required before a container is marked unhealthy (`Number`).
-
-<a id="service-containers-liveness-check-exec-health-check"></a>
-
-### Service Containers Liveness Check Exec Health Check
-
-<a id="service-containers-liveness-check-http-health-check"></a>
-
-### Service Containers Liveness Check HTTP Health Check
-
-<a id="service-containers-liveness-check-tcp-health-check"></a>
-
-### Service Containers Liveness Check TCP Health Check
 
 <a id="service-containers-readiness-check"></a>
 
 ### Service Containers Readiness Check
 
-`exec_health_check` - (Optional) Exec Health Check. ExecHealthCheckType describes a health check based on 'run in container' action. Exit status of 0 is treated as live/healthy and non-zero is unhealthy. See [Exec Health Check](#service-containers-readiness-check-exec-health-check) below.
+`exec_health_check` - (Optional) Exec Health Check. ExecHealthCheckType describes a health check based on 'run in container' action. Exit status of 0 is treated as live/healthy and non-zero is unhealthy (`Block`).
 
 `healthy_threshold` - (Optional) Healthy Threshold. Number of consecutive successful responses after having failed before declaring healthy. In other words, this is the number of healthy health checks required before marking healthy. Note that during startup and liveliness, only a single successful health check is required to mark a container healthy (`Number`).
 
-`http_health_check` - (Optional) HTTP Health Check. HTTPHealthCheckType describes a health check based on HTTP GET requests. See [HTTP Health Check](#service-containers-readiness-check-http-health-check) below.
+`http_health_check` - (Optional) HTTP Health Check. HTTPHealthCheckType describes a health check based on HTTP GET requests (`Block`).
 
 `initial_delay` - (Optional) Initial Delay. Number of seconds after the container has started before health checks are initiated (`Number`).
 
 `interval` - (Optional) Interval. Time interval in seconds between two health check requests (`Number`).
 
-`tcp_health_check` - (Optional) TCP Health Check. TCPHealthCheckType describes a health check based on opening a TCP connection. See [TCP Health Check](#service-containers-readiness-check-tcp-health-check) below.
+`tcp_health_check` - (Optional) TCP Health Check. TCPHealthCheckType describes a health check based on opening a TCP connection (`Block`).
 
 `timeout` - (Optional) Timeout. Timeout in seconds to wait for successful response. In other words, it is the time to wait for a health check response. If the timeout is reached the health check attempt will be considered a failure (`Number`).
 
 `unhealthy_threshold` - (Optional) Unhealthy Threshold. Number of consecutive failed responses before declaring unhealthy. In other words, this is the number of unhealthy health checks required before a container is marked unhealthy (`Number`).
 
-<a id="service-containers-readiness-check-exec-health-check"></a>
-
-### Service Containers Readiness Check Exec Health Check
-
-<a id="service-containers-readiness-check-http-health-check"></a>
-
-### Service Containers Readiness Check HTTP Health Check
-
-<a id="service-containers-readiness-check-tcp-health-check"></a>
-
-### Service Containers Readiness Check TCP Health Check
-
 <a id="service-deploy-options"></a>
 
 ### Service Deploy Options
 
-`all_res` - (Optional) Empty. This can be used for messages where no values are needed. See [All Res](#service-deploy-options-all-res) below.
+`all_res` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`default_virtual_sites` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Virtual Sites](#service-deploy-options-default-virtual-sites) below.
+`default_virtual_sites` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `deploy_ce_sites` - (Optional) Customer Sites. This defines a way to deploy a workload on specific Customer sites. See [Deploy CE Sites](#service-deploy-options-deploy-ce-sites) below.
 
@@ -603,57 +447,29 @@ In addition to all arguments above, the following attributes are exported:
 
 `deploy_re_virtual_sites` - (Optional) Regional Edge Virtual Sites. This defines a way to deploy a workload on specific Regional Edge virtual sites. See [Deploy RE Virtual Sites](#service-deploy-options-deploy-re-virtual-sites) below.
 
-<a id="service-deploy-options-all-res"></a>
-
-### Service Deploy Options All Res
-
-<a id="service-deploy-options-default-virtual-sites"></a>
-
-### Service Deploy Options Default Virtual Sites
-
 <a id="service-deploy-options-deploy-ce-sites"></a>
 
 ### Service Deploy Options Deploy CE Sites
 
-`site` - (Optional) List of Customer Sites to Deploy. Which customer sites should this workload be deployed. See [Site](#service-deploy-options-deploy-ce-sites-site) below.
-
-<a id="service-deploy-options-deploy-ce-sites-site"></a>
-
-### Service Deploy Options Deploy CE Sites Site
+`site` - (Optional) List of Customer Sites to Deploy. Which customer sites should this workload be deployed (`Block`).
 
 <a id="service-deploy-options-deploy-ce-virtual-sites"></a>
 
 ### Service Deploy Options Deploy CE Virtual Sites
 
-`virtual_site` - (Optional) List of Customer Virtual Sites to Deploy. Which customer virtual sites should this workload be deployed. See [Virtual Site](#service-deploy-options-deploy-ce-virtual-sites-virtual-site) below.
-
-<a id="service-deploy-options-deploy-ce-virtual-sites-virtual-site"></a>
-
-### Service Deploy Options Deploy CE Virtual Sites Virtual Site
+`virtual_site` - (Optional) List of Customer Virtual Sites to Deploy. Which customer virtual sites should this workload be deployed (`Block`).
 
 <a id="service-deploy-options-deploy-re-sites"></a>
 
 ### Service Deploy Options Deploy RE Sites
 
-`site` - (Optional) List of Regional Edge Sites to Deploy. Which regional edge sites should this workload be deployed. See [Site](#service-deploy-options-deploy-re-sites-site) below.
-
-<a id="service-deploy-options-deploy-re-sites-site"></a>
-
-### Service Deploy Options Deploy RE Sites Site
+`site` - (Optional) List of Regional Edge Sites to Deploy. Which regional edge sites should this workload be deployed (`Block`).
 
 <a id="service-deploy-options-deploy-re-virtual-sites"></a>
 
 ### Service Deploy Options Deploy RE Virtual Sites
 
-`virtual_site` - (Optional) List of Regional Edge Virtual Sites to Deploy. Which regional edge virtual sites should this workload be deployed. See [Virtual Site](#service-deploy-options-deploy-re-virtual-sites-virtual-site) below.
-
-<a id="service-deploy-options-deploy-re-virtual-sites-virtual-site"></a>
-
-### Service Deploy Options Deploy RE Virtual Sites Virtual Site
-
-<a id="service-scale-to-zero"></a>
-
-### Service Scale To Zero
+`virtual_site` - (Optional) List of Regional Edge Virtual Sites to Deploy. Which regional edge virtual sites should this workload be deployed (`Block`).
 
 <a id="service-volumes"></a>
 
@@ -671,41 +487,25 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Service Volumes Empty Dir
 
-`mount` - (Optional) Volume Mount. Volume mount describes how volume is mounted inside a workload. See [Mount](#service-volumes-empty-dir-mount) below.
+`mount` - (Optional) Volume Mount. Volume mount describes how volume is mounted inside a workload (`Block`).
 
 `size_limit` - (Optional) Size Limit (in GiB) (`Number`).
-
-<a id="service-volumes-empty-dir-mount"></a>
-
-### Service Volumes Empty Dir Mount
 
 <a id="service-volumes-host-path"></a>
 
 ### Service Volumes Host Path
 
-`mount` - (Optional) Volume Mount. Volume mount describes how volume is mounted inside a workload. See [Mount](#service-volumes-host-path-mount) below.
+`mount` - (Optional) Volume Mount. Volume mount describes how volume is mounted inside a workload (`Block`).
 
 `path` - (Optional) Path. Path of the directory on the host (`String`).
-
-<a id="service-volumes-host-path-mount"></a>
-
-### Service Volumes Host Path Mount
 
 <a id="service-volumes-persistent-volume"></a>
 
 ### Service Volumes Persistent Volume
 
-`mount` - (Optional) Volume Mount. Volume mount describes how volume is mounted inside a workload. See [Mount](#service-volumes-persistent-volume-mount) below.
+`mount` - (Optional) Volume Mount. Volume mount describes how volume is mounted inside a workload (`Block`).
 
-`storage` - (Optional) Persistence Storage Configuration. Persistent storage configuration is used to configure Persistent Volume Claim (PVC). See [Storage](#service-volumes-persistent-volume-storage) below.
-
-<a id="service-volumes-persistent-volume-mount"></a>
-
-### Service Volumes Persistent Volume Mount
-
-<a id="service-volumes-persistent-volume-storage"></a>
-
-### Service Volumes Persistent Volume Storage
+`storage` - (Optional) Persistence Storage Configuration. Persistent storage configuration is used to configure Persistent Volume Claim (PVC) (`Block`).
 
 <a id="simple-service"></a>
 
@@ -715,9 +515,9 @@ In addition to all arguments above, the following attributes are exported:
 
 `container` - (Optional) Container Configuration. ContainerType configures the container information. See [Container](#simple-service-container) below.
 
-`disabled` - (Optional) Empty. This can be used for messages where no values are needed. See [Disabled](#simple-service-disabled) below.
+`disabled` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`do_not_advertise` - (Optional) Empty. This can be used for messages where no values are needed. See [Do Not Advertise](#simple-service-do-not-advertise) below.
+`do_not_advertise` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `enabled` - (Optional) Persistent Storage Volume. Persistent storage volume configuration for the workload. See [Enabled](#simple-service-enabled) below.
 
@@ -735,17 +535,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Simple Service Configuration Parameters
 
-`env_var` - (Optional) Environment Variable. Environment Variable. See [Env Var](#simple-service-configuration-parameters-env-var) below.
+`env_var` - (Optional) Environment Variable. Environment Variable (`Block`).
 
-`file` - (Optional) Configuration File. Configuration File for the workload. See [File](#simple-service-configuration-parameters-file) below.
-
-<a id="simple-service-configuration-parameters-env-var"></a>
-
-### Simple Service Configuration Parameters Env Var
-
-<a id="simple-service-configuration-parameters-file"></a>
-
-### Simple Service Configuration Parameters File
+`file` - (Optional) Configuration File. Configuration File for the workload (`Block`).
 
 <a id="simple-service-container"></a>
 
@@ -757,7 +549,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `custom_flavor` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Custom Flavor](#simple-service-container-custom-flavor) below.
 
-`default_flavor` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Flavor](#simple-service-container-default-flavor) below.
+`default_flavor` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `flavor` - (Optional) Container Flavor Type. Container Flavor type - CONTAINER_FLAVOR_TYPE_TINY: Tiny Tiny containers have limit of 0.1 vCPU and 256 MiB (mebibyte) memory - CONTAINER_FLAVOR_TYPE_MEDIUM: Medium Medium containers have limit of 0.25 vCPU and 512 MiB (mebibyte) memory - CONTAINER_FLAVOR_TYPE_LARGE: Large Large containers have limit of 1 vCPU and 2048 MiB (mebibyte) memory. Possible values are `CONTAINER_FLAVOR_TYPE_TINY`, `CONTAINER_FLAVOR_TYPE_MEDIUM`, `CONTAINER_FLAVOR_TYPE_LARGE`. Defaults to `CONTAINER_FLAVOR_TYPE_TINY` (`String`).
 
@@ -781,101 +573,57 @@ In addition to all arguments above, the following attributes are exported:
 
 `tenant` - (Optional) Tenant. When a configuration object(e.g. virtual_host) refers to another(e.g route) then tenant will hold the referred object's(e.g. route's) tenant (`String`).
 
-<a id="simple-service-container-default-flavor"></a>
-
-### Simple Service Container Default Flavor
-
 <a id="simple-service-container-image"></a>
 
 ### Simple Service Container Image
 
-`container_registry` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Container Registry](#simple-service-container-image-container-registry) below.
+`container_registry` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name (`Block`).
 
 `name` - (Optional) Image Name. Name is a container image which are usually given a name such as alpine, ubuntu, or quay.io/etcd:0.13. The format is registry/image:tag or registry/image@image-digest. If registry is not specified, the Docker public registry is assumed. If tag is not specified, latest is assumed (`String`).
 
-`public` - (Optional) Empty. This can be used for messages where no values are needed. See [Public](#simple-service-container-image-public) below.
+`public` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `pull_policy` - (Optional) Image Pull Policy Type. Image pull policy type enumerates the policy choices to use for pulling the image prior to starting the workload - IMAGE_PULL_POLICY_DEFAULT: Default Default will always pull image if :latest tag is specified in image name. If :latest tag is not specified in image name, it will pull image only if it does not already exist on the node - IMAGE_PULL_POLICY_IF_NOT_PRESENT: IfNotPresent Only pull the image if it does not already exist on the node - IMAGE_PULL_POLICY_ALWAYS:... Possible values are `IMAGE_PULL_POLICY_DEFAULT`, `IMAGE_PULL_POLICY_IF_NOT_PRESENT`, `IMAGE_PULL_POLICY_ALWAYS`, `IMAGE_PULL_POLICY_NEVER`. Defaults to `IMAGE_PULL_POLICY_DEFAULT` (`String`).
-
-<a id="simple-service-container-image-container-registry"></a>
-
-### Simple Service Container Image Container Registry
-
-<a id="simple-service-container-image-public"></a>
-
-### Simple Service Container Image Public
 
 <a id="simple-service-container-liveness-check"></a>
 
 ### Simple Service Container Liveness Check
 
-`exec_health_check` - (Optional) Exec Health Check. ExecHealthCheckType describes a health check based on 'run in container' action. Exit status of 0 is treated as live/healthy and non-zero is unhealthy. See [Exec Health Check](#simple-service-container-liveness-check-exec-health-check) below.
+`exec_health_check` - (Optional) Exec Health Check. ExecHealthCheckType describes a health check based on 'run in container' action. Exit status of 0 is treated as live/healthy and non-zero is unhealthy (`Block`).
 
 `healthy_threshold` - (Optional) Healthy Threshold. Number of consecutive successful responses after having failed before declaring healthy. In other words, this is the number of healthy health checks required before marking healthy. Note that during startup and liveliness, only a single successful health check is required to mark a container healthy (`Number`).
 
-`http_health_check` - (Optional) HTTP Health Check. HTTPHealthCheckType describes a health check based on HTTP GET requests. See [HTTP Health Check](#simple-service-container-liveness-check-http-health-check) below.
+`http_health_check` - (Optional) HTTP Health Check. HTTPHealthCheckType describes a health check based on HTTP GET requests (`Block`).
 
 `initial_delay` - (Optional) Initial Delay. Number of seconds after the container has started before health checks are initiated (`Number`).
 
 `interval` - (Optional) Interval. Time interval in seconds between two health check requests (`Number`).
 
-`tcp_health_check` - (Optional) TCP Health Check. TCPHealthCheckType describes a health check based on opening a TCP connection. See [TCP Health Check](#simple-service-container-liveness-check-tcp-health-check) below.
+`tcp_health_check` - (Optional) TCP Health Check. TCPHealthCheckType describes a health check based on opening a TCP connection (`Block`).
 
 `timeout` - (Optional) Timeout. Timeout in seconds to wait for successful response. In other words, it is the time to wait for a health check response. If the timeout is reached the health check attempt will be considered a failure (`Number`).
 
 `unhealthy_threshold` - (Optional) Unhealthy Threshold. Number of consecutive failed responses before declaring unhealthy. In other words, this is the number of unhealthy health checks required before a container is marked unhealthy (`Number`).
-
-<a id="simple-service-container-liveness-check-exec-health-check"></a>
-
-### Simple Service Container Liveness Check Exec Health Check
-
-<a id="simple-service-container-liveness-check-http-health-check"></a>
-
-### Simple Service Container Liveness Check HTTP Health Check
-
-<a id="simple-service-container-liveness-check-tcp-health-check"></a>
-
-### Simple Service Container Liveness Check TCP Health Check
 
 <a id="simple-service-container-readiness-check"></a>
 
 ### Simple Service Container Readiness Check
 
-`exec_health_check` - (Optional) Exec Health Check. ExecHealthCheckType describes a health check based on 'run in container' action. Exit status of 0 is treated as live/healthy and non-zero is unhealthy. See [Exec Health Check](#simple-service-container-readiness-check-exec-health-check) below.
+`exec_health_check` - (Optional) Exec Health Check. ExecHealthCheckType describes a health check based on 'run in container' action. Exit status of 0 is treated as live/healthy and non-zero is unhealthy (`Block`).
 
 `healthy_threshold` - (Optional) Healthy Threshold. Number of consecutive successful responses after having failed before declaring healthy. In other words, this is the number of healthy health checks required before marking healthy. Note that during startup and liveliness, only a single successful health check is required to mark a container healthy (`Number`).
 
-`http_health_check` - (Optional) HTTP Health Check. HTTPHealthCheckType describes a health check based on HTTP GET requests. See [HTTP Health Check](#simple-service-container-readiness-check-http-health-check) below.
+`http_health_check` - (Optional) HTTP Health Check. HTTPHealthCheckType describes a health check based on HTTP GET requests (`Block`).
 
 `initial_delay` - (Optional) Initial Delay. Number of seconds after the container has started before health checks are initiated (`Number`).
 
 `interval` - (Optional) Interval. Time interval in seconds between two health check requests (`Number`).
 
-`tcp_health_check` - (Optional) TCP Health Check. TCPHealthCheckType describes a health check based on opening a TCP connection. See [TCP Health Check](#simple-service-container-readiness-check-tcp-health-check) below.
+`tcp_health_check` - (Optional) TCP Health Check. TCPHealthCheckType describes a health check based on opening a TCP connection (`Block`).
 
 `timeout` - (Optional) Timeout. Timeout in seconds to wait for successful response. In other words, it is the time to wait for a health check response. If the timeout is reached the health check attempt will be considered a failure (`Number`).
 
 `unhealthy_threshold` - (Optional) Unhealthy Threshold. Number of consecutive failed responses before declaring unhealthy. In other words, this is the number of unhealthy health checks required before a container is marked unhealthy (`Number`).
-
-<a id="simple-service-container-readiness-check-exec-health-check"></a>
-
-### Simple Service Container Readiness Check Exec Health Check
-
-<a id="simple-service-container-readiness-check-http-health-check"></a>
-
-### Simple Service Container Readiness Check HTTP Health Check
-
-<a id="simple-service-container-readiness-check-tcp-health-check"></a>
-
-### Simple Service Container Readiness Check TCP Health Check
-
-<a id="simple-service-disabled"></a>
-
-### Simple Service Disabled
-
-<a id="simple-service-do-not-advertise"></a>
-
-### Simple Service Do Not Advertise
 
 <a id="simple-service-enabled"></a>
 
@@ -889,17 +637,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Simple Service Enabled Persistent Volume
 
-`mount` - (Optional) Volume Mount. Volume mount describes how volume is mounted inside a workload. See [Mount](#simple-service-enabled-persistent-volume-mount) below.
+`mount` - (Optional) Volume Mount. Volume mount describes how volume is mounted inside a workload (`Block`).
 
-`storage` - (Optional) Persistence Storage Configuration. Persistent storage configuration is used to configure Persistent Volume Claim (PVC). See [Storage](#simple-service-enabled-persistent-volume-storage) below.
-
-<a id="simple-service-enabled-persistent-volume-mount"></a>
-
-### Simple Service Enabled Persistent Volume Mount
-
-<a id="simple-service-enabled-persistent-volume-storage"></a>
-
-### Simple Service Enabled Persistent Volume Storage
+`storage` - (Optional) Persistence Storage Configuration. Persistent storage configuration is used to configure Persistent Volume Claim (PVC) (`Block`).
 
 <a id="simple-service-simple-advertise"></a>
 
@@ -925,7 +665,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `persistent_volumes` - (Optional) Persistent Storage Configuration. Persistent storage configuration for the service. See [Persistent Volumes](#stateful-service-persistent-volumes) below.
 
-`scale_to_zero` - (Optional) Empty. This can be used for messages where no values are needed. See [Scale To Zero](#stateful-service-scale-to-zero) below.
+`scale_to_zero` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `volumes` - (Optional) Ephemeral Volumes. Ephemeral volumes for the service. See [Volumes](#stateful-service-volumes) below.
 
@@ -939,59 +679,31 @@ In addition to all arguments above, the following attributes are exported:
 
 `advertise_on_public` - (Optional) Advertise On Internet. Advertise this workload via loadbalancer on Internet with default VIP. See [Advertise On Public](#stateful-service-advertise-options-advertise-on-public) below.
 
-`do_not_advertise` - (Optional) Empty. This can be used for messages where no values are needed. See [Do Not Advertise](#stateful-service-advertise-options-do-not-advertise) below.
+`do_not_advertise` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 <a id="stateful-service-advertise-options-advertise-custom"></a>
 
 ### Stateful Service Advertise Options Advertise Custom
 
-`advertise_where` - (Optional) List of Sites to Advertise. Where should this load balancer be available. See [Advertise Where](#stateful-service-advertise-options-advertise-custom-advertise-where) below.
+`advertise_where` - (Optional) List of Sites to Advertise. Where should this load balancer be available (`Block`).
 
-`ports` - (Optional) Configuration for ports. See [Ports](#stateful-service-advertise-options-advertise-custom-ports) below.
-
-<a id="stateful-service-advertise-options-advertise-custom-advertise-where"></a>
-
-### Stateful Service Advertise Options Advertise Custom Advertise Where
-
-<a id="stateful-service-advertise-options-advertise-custom-ports"></a>
-
-### Stateful Service Advertise Options Advertise Custom Ports
+`ports` - (Optional) Configuration for ports (`Block`).
 
 <a id="stateful-service-advertise-options-advertise-in-cluster"></a>
 
 ### Stateful Service Advertise Options Advertise In Cluster
 
-`multi_ports` - (Optional) Multiple Ports. Multiple ports. See [Multi Ports](#stateful-service-advertise-options-advertise-in-cluster-multi-ports) below.
+`multi_ports` - (Optional) Multiple Ports. Multiple ports (`Block`).
 
-`port` - (Optional) Configuration for port. See [Port](#stateful-service-advertise-options-advertise-in-cluster-port) below.
-
-<a id="stateful-service-advertise-options-advertise-in-cluster-multi-ports"></a>
-
-### Stateful Service Advertise Options Advertise In Cluster Multi Ports
-
-<a id="stateful-service-advertise-options-advertise-in-cluster-port"></a>
-
-### Stateful Service Advertise Options Advertise In Cluster Port
+`port` - (Optional) Configuration for port (`Block`).
 
 <a id="stateful-service-advertise-options-advertise-on-public"></a>
 
 ### Stateful Service Advertise Options Advertise On Public
 
-`multi_ports` - (Optional) Advertise Multiple Ports. Advertise multiple ports. See [Multi Ports](#stateful-service-advertise-options-advertise-on-public-multi-ports) below.
+`multi_ports` - (Optional) Advertise Multiple Ports. Advertise multiple ports (`Block`).
 
-`port` - (Optional) Advertise Port. Advertise single port. See [Port](#stateful-service-advertise-options-advertise-on-public-port) below.
-
-<a id="stateful-service-advertise-options-advertise-on-public-multi-ports"></a>
-
-### Stateful Service Advertise Options Advertise On Public Multi Ports
-
-<a id="stateful-service-advertise-options-advertise-on-public-port"></a>
-
-### Stateful Service Advertise Options Advertise On Public Port
-
-<a id="stateful-service-advertise-options-do-not-advertise"></a>
-
-### Stateful Service Advertise Options Do Not Advertise
+`port` - (Optional) Advertise Port. Advertise single port (`Block`).
 
 <a id="stateful-service-configuration"></a>
 
@@ -1003,17 +715,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Stateful Service Configuration Parameters
 
-`env_var` - (Optional) Environment Variable. Environment Variable. See [Env Var](#stateful-service-configuration-parameters-env-var) below.
+`env_var` - (Optional) Environment Variable. Environment Variable (`Block`).
 
-`file` - (Optional) Configuration File. Configuration File for the workload. See [File](#stateful-service-configuration-parameters-file) below.
-
-<a id="stateful-service-configuration-parameters-env-var"></a>
-
-### Stateful Service Configuration Parameters Env Var
-
-<a id="stateful-service-configuration-parameters-file"></a>
-
-### Stateful Service Configuration Parameters File
+`file` - (Optional) Configuration File. Configuration File for the workload (`Block`).
 
 <a id="stateful-service-containers"></a>
 
@@ -1025,7 +729,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `custom_flavor` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Custom Flavor](#stateful-service-containers-custom-flavor) below.
 
-`default_flavor` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Flavor](#stateful-service-containers-default-flavor) below.
+`default_flavor` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `flavor` - (Optional) Container Flavor Type. Container Flavor type - CONTAINER_FLAVOR_TYPE_TINY: Tiny Tiny containers have limit of 0.1 vCPU and 256 MiB (mebibyte) memory - CONTAINER_FLAVOR_TYPE_MEDIUM: Medium Medium containers have limit of 0.25 vCPU and 512 MiB (mebibyte) memory - CONTAINER_FLAVOR_TYPE_LARGE: Large Large containers have limit of 1 vCPU and 2048 MiB (mebibyte) memory. Possible values are `CONTAINER_FLAVOR_TYPE_TINY`, `CONTAINER_FLAVOR_TYPE_MEDIUM`, `CONTAINER_FLAVOR_TYPE_LARGE`. Defaults to `CONTAINER_FLAVOR_TYPE_TINY` (`String`).
 
@@ -1049,101 +753,65 @@ In addition to all arguments above, the following attributes are exported:
 
 `tenant` - (Optional) Tenant. When a configuration object(e.g. virtual_host) refers to another(e.g route) then tenant will hold the referred object's(e.g. route's) tenant (`String`).
 
-<a id="stateful-service-containers-default-flavor"></a>
-
-### Stateful Service Containers Default Flavor
-
 <a id="stateful-service-containers-image"></a>
 
 ### Stateful Service Containers Image
 
-`container_registry` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name. See [Container Registry](#stateful-service-containers-image-container-registry) below.
+`container_registry` - (Optional) Object reference. This type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name (`Block`).
 
 `name` - (Optional) Image Name. Name is a container image which are usually given a name such as alpine, ubuntu, or quay.io/etcd:0.13. The format is registry/image:tag or registry/image@image-digest. If registry is not specified, the Docker public registry is assumed. If tag is not specified, latest is assumed (`String`).
 
-`public` - (Optional) Empty. This can be used for messages where no values are needed. See [Public](#stateful-service-containers-image-public) below.
+`public` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `pull_policy` - (Optional) Image Pull Policy Type. Image pull policy type enumerates the policy choices to use for pulling the image prior to starting the workload - IMAGE_PULL_POLICY_DEFAULT: Default Default will always pull image if :latest tag is specified in image name. If :latest tag is not specified in image name, it will pull image only if it does not already exist on the node - IMAGE_PULL_POLICY_IF_NOT_PRESENT: IfNotPresent Only pull the image if it does not already exist on the node - IMAGE_PULL_POLICY_ALWAYS:... Possible values are `IMAGE_PULL_POLICY_DEFAULT`, `IMAGE_PULL_POLICY_IF_NOT_PRESENT`, `IMAGE_PULL_POLICY_ALWAYS`, `IMAGE_PULL_POLICY_NEVER`. Defaults to `IMAGE_PULL_POLICY_DEFAULT` (`String`).
-
-<a id="stateful-service-containers-image-container-registry"></a>
-
-### Stateful Service Containers Image Container Registry
-
-<a id="stateful-service-containers-image-public"></a>
-
-### Stateful Service Containers Image Public
 
 <a id="stateful-service-containers-liveness-check"></a>
 
 ### Stateful Service Containers Liveness Check
 
-`exec_health_check` - (Optional) Exec Health Check. ExecHealthCheckType describes a health check based on 'run in container' action. Exit status of 0 is treated as live/healthy and non-zero is unhealthy. See [Exec Health Check](#stateful-service-containers-liveness-check-exec-health-check) below.
+`exec_health_check` - (Optional) Exec Health Check. ExecHealthCheckType describes a health check based on 'run in container' action. Exit status of 0 is treated as live/healthy and non-zero is unhealthy (`Block`).
 
 `healthy_threshold` - (Optional) Healthy Threshold. Number of consecutive successful responses after having failed before declaring healthy. In other words, this is the number of healthy health checks required before marking healthy. Note that during startup and liveliness, only a single successful health check is required to mark a container healthy (`Number`).
 
-`http_health_check` - (Optional) HTTP Health Check. HTTPHealthCheckType describes a health check based on HTTP GET requests. See [HTTP Health Check](#stateful-service-containers-liveness-check-http-health-check) below.
+`http_health_check` - (Optional) HTTP Health Check. HTTPHealthCheckType describes a health check based on HTTP GET requests (`Block`).
 
 `initial_delay` - (Optional) Initial Delay. Number of seconds after the container has started before health checks are initiated (`Number`).
 
 `interval` - (Optional) Interval. Time interval in seconds between two health check requests (`Number`).
 
-`tcp_health_check` - (Optional) TCP Health Check. TCPHealthCheckType describes a health check based on opening a TCP connection. See [TCP Health Check](#stateful-service-containers-liveness-check-tcp-health-check) below.
+`tcp_health_check` - (Optional) TCP Health Check. TCPHealthCheckType describes a health check based on opening a TCP connection (`Block`).
 
 `timeout` - (Optional) Timeout. Timeout in seconds to wait for successful response. In other words, it is the time to wait for a health check response. If the timeout is reached the health check attempt will be considered a failure (`Number`).
 
 `unhealthy_threshold` - (Optional) Unhealthy Threshold. Number of consecutive failed responses before declaring unhealthy. In other words, this is the number of unhealthy health checks required before a container is marked unhealthy (`Number`).
-
-<a id="stateful-service-containers-liveness-check-exec-health-check"></a>
-
-### Stateful Service Containers Liveness Check Exec Health Check
-
-<a id="stateful-service-containers-liveness-check-http-health-check"></a>
-
-### Stateful Service Containers Liveness Check HTTP Health Check
-
-<a id="stateful-service-containers-liveness-check-tcp-health-check"></a>
-
-### Stateful Service Containers Liveness Check TCP Health Check
 
 <a id="stateful-service-containers-readiness-check"></a>
 
 ### Stateful Service Containers Readiness Check
 
-`exec_health_check` - (Optional) Exec Health Check. ExecHealthCheckType describes a health check based on 'run in container' action. Exit status of 0 is treated as live/healthy and non-zero is unhealthy. See [Exec Health Check](#stateful-service-containers-readiness-check-exec-health-check) below.
+`exec_health_check` - (Optional) Exec Health Check. ExecHealthCheckType describes a health check based on 'run in container' action. Exit status of 0 is treated as live/healthy and non-zero is unhealthy (`Block`).
 
 `healthy_threshold` - (Optional) Healthy Threshold. Number of consecutive successful responses after having failed before declaring healthy. In other words, this is the number of healthy health checks required before marking healthy. Note that during startup and liveliness, only a single successful health check is required to mark a container healthy (`Number`).
 
-`http_health_check` - (Optional) HTTP Health Check. HTTPHealthCheckType describes a health check based on HTTP GET requests. See [HTTP Health Check](#stateful-service-containers-readiness-check-http-health-check) below.
+`http_health_check` - (Optional) HTTP Health Check. HTTPHealthCheckType describes a health check based on HTTP GET requests (`Block`).
 
 `initial_delay` - (Optional) Initial Delay. Number of seconds after the container has started before health checks are initiated (`Number`).
 
 `interval` - (Optional) Interval. Time interval in seconds between two health check requests (`Number`).
 
-`tcp_health_check` - (Optional) TCP Health Check. TCPHealthCheckType describes a health check based on opening a TCP connection. See [TCP Health Check](#stateful-service-containers-readiness-check-tcp-health-check) below.
+`tcp_health_check` - (Optional) TCP Health Check. TCPHealthCheckType describes a health check based on opening a TCP connection (`Block`).
 
 `timeout` - (Optional) Timeout. Timeout in seconds to wait for successful response. In other words, it is the time to wait for a health check response. If the timeout is reached the health check attempt will be considered a failure (`Number`).
 
 `unhealthy_threshold` - (Optional) Unhealthy Threshold. Number of consecutive failed responses before declaring unhealthy. In other words, this is the number of unhealthy health checks required before a container is marked unhealthy (`Number`).
 
-<a id="stateful-service-containers-readiness-check-exec-health-check"></a>
-
-### Stateful Service Containers Readiness Check Exec Health Check
-
-<a id="stateful-service-containers-readiness-check-http-health-check"></a>
-
-### Stateful Service Containers Readiness Check HTTP Health Check
-
-<a id="stateful-service-containers-readiness-check-tcp-health-check"></a>
-
-### Stateful Service Containers Readiness Check TCP Health Check
-
 <a id="stateful-service-deploy-options"></a>
 
 ### Stateful Service Deploy Options
 
-`all_res` - (Optional) Empty. This can be used for messages where no values are needed. See [All Res](#stateful-service-deploy-options-all-res) below.
+`all_res` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
-`default_virtual_sites` - (Optional) Empty. This can be used for messages where no values are needed. See [Default Virtual Sites](#stateful-service-deploy-options-default-virtual-sites) below.
+`default_virtual_sites` - (Optional) Empty. This can be used for messages where no values are needed (`Block`).
 
 `deploy_ce_sites` - (Optional) Customer Sites. This defines a way to deploy a workload on specific Customer sites. See [Deploy CE Sites](#stateful-service-deploy-options-deploy-ce-sites) below.
 
@@ -1153,53 +821,29 @@ In addition to all arguments above, the following attributes are exported:
 
 `deploy_re_virtual_sites` - (Optional) Regional Edge Virtual Sites. This defines a way to deploy a workload on specific Regional Edge virtual sites. See [Deploy RE Virtual Sites](#stateful-service-deploy-options-deploy-re-virtual-sites) below.
 
-<a id="stateful-service-deploy-options-all-res"></a>
-
-### Stateful Service Deploy Options All Res
-
-<a id="stateful-service-deploy-options-default-virtual-sites"></a>
-
-### Stateful Service Deploy Options Default Virtual Sites
-
 <a id="stateful-service-deploy-options-deploy-ce-sites"></a>
 
 ### Stateful Service Deploy Options Deploy CE Sites
 
-`site` - (Optional) List of Customer Sites to Deploy. Which customer sites should this workload be deployed. See [Site](#stateful-service-deploy-options-deploy-ce-sites-site) below.
-
-<a id="stateful-service-deploy-options-deploy-ce-sites-site"></a>
-
-### Stateful Service Deploy Options Deploy CE Sites Site
+`site` - (Optional) List of Customer Sites to Deploy. Which customer sites should this workload be deployed (`Block`).
 
 <a id="stateful-service-deploy-options-deploy-ce-virtual-sites"></a>
 
 ### Stateful Service Deploy Options Deploy CE Virtual Sites
 
-`virtual_site` - (Optional) List of Customer Virtual Sites to Deploy. Which customer virtual sites should this workload be deployed. See [Virtual Site](#stateful-service-deploy-options-deploy-ce-virtual-sites-virtual-site) below.
-
-<a id="stateful-service-deploy-options-deploy-ce-virtual-sites-virtual-site"></a>
-
-### Stateful Service Deploy Options Deploy CE Virtual Sites Virtual Site
+`virtual_site` - (Optional) List of Customer Virtual Sites to Deploy. Which customer virtual sites should this workload be deployed (`Block`).
 
 <a id="stateful-service-deploy-options-deploy-re-sites"></a>
 
 ### Stateful Service Deploy Options Deploy RE Sites
 
-`site` - (Optional) List of Regional Edge Sites to Deploy. Which regional edge sites should this workload be deployed. See [Site](#stateful-service-deploy-options-deploy-re-sites-site) below.
-
-<a id="stateful-service-deploy-options-deploy-re-sites-site"></a>
-
-### Stateful Service Deploy Options Deploy RE Sites Site
+`site` - (Optional) List of Regional Edge Sites to Deploy. Which regional edge sites should this workload be deployed (`Block`).
 
 <a id="stateful-service-deploy-options-deploy-re-virtual-sites"></a>
 
 ### Stateful Service Deploy Options Deploy RE Virtual Sites
 
-`virtual_site` - (Optional) List of Regional Edge Virtual Sites to Deploy. Which regional edge virtual sites should this workload be deployed. See [Virtual Site](#stateful-service-deploy-options-deploy-re-virtual-sites-virtual-site) below.
-
-<a id="stateful-service-deploy-options-deploy-re-virtual-sites-virtual-site"></a>
-
-### Stateful Service Deploy Options Deploy RE Virtual Sites Virtual Site
+`virtual_site` - (Optional) List of Regional Edge Virtual Sites to Deploy. Which regional edge virtual sites should this workload be deployed (`Block`).
 
 <a id="stateful-service-persistent-volumes"></a>
 
@@ -1213,21 +857,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Stateful Service Persistent Volumes Persistent Volume
 
-`mount` - (Optional) Volume Mount. Volume mount describes how volume is mounted inside a workload. See [Mount](#stateful-service-persistent-volumes-persistent-volume-mount) below.
+`mount` - (Optional) Volume Mount. Volume mount describes how volume is mounted inside a workload (`Block`).
 
-`storage` - (Optional) Persistence Storage Configuration. Persistent storage configuration is used to configure Persistent Volume Claim (PVC). See [Storage](#stateful-service-persistent-volumes-persistent-volume-storage) below.
-
-<a id="stateful-service-persistent-volumes-persistent-volume-mount"></a>
-
-### Stateful Service Persistent Volumes Persistent Volume Mount
-
-<a id="stateful-service-persistent-volumes-persistent-volume-storage"></a>
-
-### Stateful Service Persistent Volumes Persistent Volume Storage
-
-<a id="stateful-service-scale-to-zero"></a>
-
-### Stateful Service Scale To Zero
+`storage` - (Optional) Persistence Storage Configuration. Persistent storage configuration is used to configure Persistent Volume Claim (PVC) (`Block`).
 
 <a id="stateful-service-volumes"></a>
 
@@ -1243,25 +875,17 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Stateful Service Volumes Empty Dir
 
-`mount` - (Optional) Volume Mount. Volume mount describes how volume is mounted inside a workload. See [Mount](#stateful-service-volumes-empty-dir-mount) below.
+`mount` - (Optional) Volume Mount. Volume mount describes how volume is mounted inside a workload (`Block`).
 
 `size_limit` - (Optional) Size Limit (in GiB) (`Number`).
-
-<a id="stateful-service-volumes-empty-dir-mount"></a>
-
-### Stateful Service Volumes Empty Dir Mount
 
 <a id="stateful-service-volumes-host-path"></a>
 
 ### Stateful Service Volumes Host Path
 
-`mount` - (Optional) Volume Mount. Volume mount describes how volume is mounted inside a workload. See [Mount](#stateful-service-volumes-host-path-mount) below.
+`mount` - (Optional) Volume Mount. Volume mount describes how volume is mounted inside a workload (`Block`).
 
 `path` - (Optional) Path. Path of the directory on the host (`String`).
-
-<a id="stateful-service-volumes-host-path-mount"></a>
-
-### Stateful Service Volumes Host Path Mount
 
 <a id="timeouts"></a>
 


### PR DESCRIPTION
## Summary

- Updated `tools/transform-docs.go` to skip generating anchor links and headers for empty nested block sections
- F5 XC API "empty message" types are now handled correctly - they no longer produce dangling links

## Related Issue

Closes #61

## Changes Made

- Added content tracking during first pass to identify which anchors have actual attributes
- Updated `writeAttr()` to only generate "See...below" links for non-empty anchors
- Updated nested block processing to skip empty sections (both anchor and header)
- Rewrote `transformAnchorsOnly()` for idempotent handling of already-transformed files

## Testing

- [x] Verified transformation removes empty sections from `cluster.md`
- [x] Verified idempotency - running transformation twice produces same result
- [x] Build passes: `go build ./...`

## Before/After Example

**Before**: `auto_http_config` had link pointing to empty section:
```markdown
`auto_http_config` - (Optional) Empty. This can be used for messages where no values are needed. See [Auto HTTP Config](#auto-http-config) below for details.

### Auto HTTP Config
(empty section)
```

**After**: Link removed, empty section not output:
```markdown
`auto_http_config` - (Optional) Empty. This can be used for messages where no values are needed.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)