### PR TITLE
fix(tools): remove description truncation from schema generator

### DIFF
--- a/tools/generate-all-schemas.go
+++ b/tools/generate-all-schemas.go
@@ -727,10 +727,6 @@ func cleanDescription(desc string) string {
 	desc = strings.TrimSpace(desc)
 	// Remove trailing periods that were left after cleanup
 	desc = regexp.MustCompile(`\.\s*\.`).ReplaceAllString(desc, ".")
-	// Limit description length to prevent overly long strings
-	if len(desc) > 500 {
-		desc = desc[:497] + "..."
-	}
 	return desc
 }
 
@@ -816,12 +812,6 @@ func formatEnumDescription(desc string, enumValues []interface{}) string {
 	// Format based on number of values per HashiCorp standards
 	if len(formattedValues) == 1 {
 		return fmt.Sprintf("%s The only possible value is %s.", desc, formattedValues[0])
-	}
-
-	// Limit to first 10 values to avoid overly long descriptions
-	if len(formattedValues) > 10 {
-		formattedValues = formattedValues[:10]
-		return fmt.Sprintf("%s Possible values include %s, and others.", desc, strings.Join(formattedValues, ", "))
 	}
 
 	return fmt.Sprintf("%s Possible values are %s.", desc, strings.Join(formattedValues, ", "))


### PR DESCRIPTION
## Summary

Remove artificial limits from `tools/generate-all-schemas.go` that caused incomplete and truncated documentation.

## Related Issue

Closes #63

## Changes Made

- Remove 500-character description limit from `cleanDescription()` that truncated text mid-sentence (e.g., "If there is a subset with the e.")
- Remove 10-value enum limit from `formatEnumDescription()` that hid valid options

## Testing

- [x] Code compiles successfully
- [x] Changes are source-only (generator tool)
- [x] CI will regenerate resources with full descriptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)