### PR TITLE
fix(ci): trigger resource regeneration on generator tool changes

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -3,12 +3,13 @@
 name: Generate Provider Code
 
 on:
-  # Trigger when OpenAPI specs are updated in the repository
+  # Trigger when OpenAPI specs are updated OR generator tool changes
   push:
     branches:
       - main
     paths:
       - 'docs/specifications/api/**'
+      - 'tools/generate-all-schemas.go'
 
   # Manual trigger with options
   workflow_dispatch:

--- a/tools/generate-all-schemas.go
+++ b/tools/generate-all-schemas.go
@@ -4,6 +4,10 @@
 // generate-all-schemas.go - Batch generator for all F5 XC Terraform resources
 // This tool processes all OpenAPI spec files and generates comprehensive Terraform schemas.
 //
+// CI/CD Integration:
+//   Changes to this file trigger the generate.yml workflow which regenerates all
+//   provider resources from the latest OpenAPI specifications.
+//
 // Usage: go run tools/generate-all-schemas.go [--spec-dir=/path/to/specs] [--dry-run]
 //
 // Environment Variables:


### PR DESCRIPTION
## Summary

Add `tools/generate-all-schemas.go` to the `generate.yml` workflow trigger paths to ensure resources are regenerated when the generator tool is modified.

## Related Issue
Closes #65

## Problem

Commit `a392602` fixed description truncation in the generator (removing the 500-char limit), but resources weren't regenerated because `generate.yml` only triggered on spec changes in `docs/specifications/api/**`.

**Current state of resources:**
```
"Loadbalancer chooses a set o."  ← truncated mid-sentence
```

**Should be after regeneration:**
```
"Loadbalancer chooses a set of random numbers for every new client..."  ← full description
```

## Solution

1. **Workflow trigger update**: Add `tools/generate-all-schemas.go` to `generate.yml` paths
2. **Documentation update**: Added CI/CD integration note to generator file

## Automation Chain After Merge

When this PR merges to main:
1. `generate.yml` triggers (because `tools/generate-all-schemas.go` changed)
2. Resources are regenerated with full descriptions → Creates auto PR
3. When that PR merges, `docs.yml` triggers
4. Documentation is regenerated → Creates auto PR
5. Final docs have full, non-truncated descriptions

## Test Plan
- [ ] CI passes on this PR
- [ ] After merge, verify `Generate Provider Code` workflow runs
- [ ] Verify auto-generated PR contains regenerated resources
- [ ] After full chain completes, verify docs have full descriptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)