### PR TITLE
fix(ci): skip Constitution Check for auto-generate branches

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -78,8 +78,10 @@ jobs:
   check-constitution:
     name: Constitution Check
     runs-on: ubuntu-latest
-    # Run on all PRs to enforce rules, except automated documentation PRs
-    if: github.event_name == 'pull_request' && github.head_ref != 'docs/auto-update'
+    # Run on all PRs to enforce rules, except automated PRs from CI/CD workflows
+    # - docs/auto-update: Documentation regeneration (docs.yml)
+    # - auto-generate/*: Provider code regeneration (generate.yml)
+    if: github.event_name == 'pull_request' && github.head_ref != 'docs/auto-update' && !startsWith(github.head_ref, 'auto-generate/')
     steps:
       - name: Checkout
         uses: actions/checkout@v5


### PR DESCRIPTION
## Summary

Fixes the Constitution Check in `lint.yml` to skip auto-generated PRs from the `generate.yml` workflow.

## Related Issue

Closes #68

## Problem

The Constitution Check was blocking PRs from the `auto-generate/api-update` branch created by `generate.yml` workflow. The check only skipped `docs/auto-update` but not the `auto-generate/*` branches.

## Changes Made

- Updated the `if` condition in `check-constitution` job to also skip branches starting with `auto-generate/`
- Added documentation comments explaining which workflows use each branch pattern:
  - `docs/auto-update`: Documentation regeneration (docs.yml)
  - `auto-generate/*`: Provider code regeneration (generate.yml)

## Testing

- [x] Syntax is valid YAML
- [x] Condition uses correct GitHub Actions expression syntax

## Context

This is part of the fix for truncated descriptions in provider resources. The workflow chain is:

1. `generate.yml` creates PR from `auto-generate/api-update` branch
2. `lint.yml` runs Constitution Check on that PR
3. ❌ Constitution Check was failing because it wasn't skipped
4. ✅ After this fix, Constitution Check will be skipped for auto-generate PRs

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)