### PR TITLE
fix(ci): use PAT for auto-merge to enable workflow triggers

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -131,9 +131,12 @@ jobs:
             api-update
 
       - name: Enable auto-merge on PR
+        # IMPORTANT: Must use AUTO_MERGE_TOKEN (PAT) instead of GITHUB_TOKEN
+        # because PRs merged with GITHUB_TOKEN do NOT trigger downstream workflows.
+        # This ensures docs.yml runs after the regenerated code is merged.
         if: steps.create-pr.outputs.pull-request-operation == 'created'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.AUTO_MERGE_TOKEN }}
         run: |
           gh pr merge ${{ steps.create-pr.outputs.pull-request-number }} \
             --auto --squash


### PR DESCRIPTION
## Summary

Fixes the root cause of why `docs.yml` was not automatically triggered after `generate.yml` merged regenerated provider code.

## Related Issue

Closes #71

## Root Cause

The `generate.yml` workflow was using `GITHUB_TOKEN` for the auto-merge step:

```yaml
- name: Enable auto-merge on PR
  env:
    GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # ❌ Problem
```

When GitHub Actions merges a PR using `GITHUB_TOKEN`, the resulting push to main **does NOT trigger workflows**. This is GitHub's built-in anti-loop protection.

## Fix

Changed to use `AUTO_MERGE_TOKEN` (PAT) which **does** trigger downstream workflows:

```yaml
- name: Enable auto-merge on PR
  env:
    GH_TOKEN: ${{ secrets.AUTO_MERGE_TOKEN }}  # ✅ Fix
```

## Impact

After this fix, when `generate.yml` regenerates provider resources and merges the PR:
1. PR is merged using PAT
2. Push to main triggers `docs.yml`
3. `docs.yml` regenerates documentation with full (non-truncated) descriptions
4. Documentation stays in sync automatically

## Testing

- [x] Syntax is valid YAML
- [x] Token usage follows established pattern (same as other workflows)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)