### PR TITLE
fix(ci): skip docs out-of-date check for auto-generate branches

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -86,15 +86,20 @@ jobs:
           labels: documentation,automated
 
       - name: Enable auto-merge on PR
+        # IMPORTANT: Must use AUTO_MERGE_TOKEN (PAT) instead of GITHUB_TOKEN
+        # because PRs merged with GITHUB_TOKEN do NOT trigger downstream workflows.
         if: steps.create-pr.outputs.pull-request-operation == 'created'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.AUTO_MERGE_TOKEN }}
         run: |
           gh pr merge ${{ steps.create-pr.outputs.pull-request-number }} \
             --auto --squash
 
       - name: Fail if docs are out of date on PR
-        if: steps.changes.outputs.changed == 'true' && github.event_name == 'pull_request'
+        # Skip for auto-generate/* branches - docs are expected to be out of date
+        # because resources were just regenerated. Docs will be updated when the
+        # auto-generate PR merges and triggers this workflow on push to main.
+        if: steps.changes.outputs.changed == 'true' && github.event_name == 'pull_request' && !startsWith(github.head_ref, 'auto-generate/')
         run: |
           echo "::error::Provider documentation is out of date. Please run 'tfplugindocs generate && go run tools/transform-docs.go' locally and commit the changes."
           git diff docs/


### PR DESCRIPTION
## Summary

Two fixes to `docs.yml` workflow to improve automation reliability:

1. **Skip 'Fail if docs are out of date' check for `auto-generate/*` branches**
   - When `generate.yml` creates PR #75 from regenerated code, docs.yml runs on that PR
   - The docs ARE out of date at that point (resources just changed)
   - This check fails unnecessarily - the docs will be updated after PR merges

2. **Use `AUTO_MERGE_TOKEN` instead of `GITHUB_TOKEN` for auto-merge**
   - PRs merged with `GITHUB_TOKEN` do NOT trigger downstream workflows (GitHub security feature)
   - This is consistent with the fix applied to `generate.yml` in PR #72

## Related Issue

Closes #77

## Changes Made

- Added `!startsWith(github.head_ref, 'auto-generate/')` to skip condition
- Changed `secrets.GITHUB_TOKEN` to `secrets.AUTO_MERGE_TOKEN` in auto-merge step
- Added explanatory comments for both changes

## Testing

This fix was identified during end-to-end pipeline testing:
- PR #74 merged → triggered generate.yml
- PR #75 created from auto-generate/api-update
- docs.yml "Fail if docs are out of date" **failed** on PR #75 (expected with this bug)
- This fix prevents that unnecessary failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)