### PR TITLE
fix(ci): remove chromium-browser from pages.yml workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -41,7 +41,6 @@ jobs:
           sudo apt-get install -y \
             build-essential \
             ca-certificates \
-            chromium-browser \
             curl \
             fonts-dejavu \
             fonts-droid-fallback \


### PR DESCRIPTION
## Summary
Removes the `chromium-browser` package from the apt-get install step in the pages.yml workflow to fix failing documentation builds.

## Related Issue
Closes #89

## Problem
The `Publish Documentation` workflow was failing with:
```
Errors were encountered while processing:
 /tmp/apt-dpkg-install-frVYOQ/000-chromium-browser_2%3a1snap1-0ubuntu2_amd64.deb
E: Sub-process /usr/bin/dpkg returned an error code (1)
```

On Ubuntu 22.04+, `chromium-browser` is a transitional package that attempts to install Chromium via snap. This fails in GitHub Actions runners because snap requires systemd integration that isn't available.

## Solution
Remove `chromium-browser` from the apt-get install command. The PDF generation in this workflow uses `weasyprint` which relies on Cairo/Pango for rendering and doesn't require Chromium.

## Testing
- [ ] Workflow runs successfully after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)