### PR TITLE
fix(ci): trigger auto-tag on docs PR merge for complete releases

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -6,8 +6,10 @@ on:
   push:
     branches:
       - main
+    # Note: 'docs/**' intentionally NOT ignored - when docs.yml's auto-PR merges,
+    # we want a new release to include the regenerated documentation.
+    # Manual docs commits are blocked by constitution check (CLAUDE.md Rule 1).
     paths-ignore:
-      - 'docs/**'
       - '*.md'
       - '.github/workflows/docs.yml'
 


### PR DESCRIPTION
## Summary
Remove `docs/**` from paths-ignore in auto-tag.yml so that when docs.yml's auto-generated PR merges, a new release is created with the updated documentation.

## Related Issue
Closes #96

## Problem
When generator tools (e.g., `tools/transform-docs.go`) are modified:
1. Code change merges → auto-tag immediately creates a release
2. docs.yml runs → regenerates docs → creates auto-merge PR
3. Docs PR merges → **no new release** because `docs/**` was in paths-ignore

This results in releases published with outdated documentation.

## Solution
Remove `docs/**` from paths-ignore. This is safe because:
- Manual commits to `docs/` are blocked by constitution check (CLAUDE.md Rule 1)
- docs/ changes only come from CI automation via docs.yml workflow

## Expected Behavior After Fix
1. Code change merges → auto-tag creates vX.Y.Z
2. docs.yml regenerates docs → creates PR
3. Docs PR merges → auto-tag creates vX.Y.(Z+1) with updated docs
4. Registry gets the release with correct documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)