### PR TITLE
fix(docs): use cleaner OneOf callout format

### DIFF
--- a/tools/transform-docs.go
+++ b/tools/transform-docs.go
@@ -1012,17 +1012,22 @@ func transformDoc(filePath string) error {
 		output.WriteString("\n\n")
 	}
 
-	// Helper function to write a OneOf group with info callout and bullet list
+	// Helper function to write a OneOf group with all content inside callout
 	writeOneOfGroup := func(attrs []attrInfo) {
 		if len(attrs) == 0 {
 			return
 		}
-		// Write generic info callout title (no attribute names to avoid redundancy)
-		// -> creates light blue informational style callout
-		output.WriteString("-> **Note:** Only one of the following may be set:\n\n")
-		// Write attributes as a bullet list (no indentation to avoid code block rendering)
-		for _, attr := range attrs {
-			output.WriteString(fmt.Sprintf("- %s\n", formatAttrLine(attr, "")))
+		// Write callout with bold title (no redundant "Note:" label - icon indicates it)
+		// All content stays inside the callout box using <br> for line breaks
+		output.WriteString("-> **Only one of the following may be set:**\n")
+		for i, attr := range attrs {
+			if i == 0 {
+				// First attribute on next line (continuation of callout)
+				output.WriteString(fmt.Sprintf("%s\n", formatAttrLine(attr, "")))
+			} else {
+				// Subsequent attributes with <br> prefix for line breaks inside callout
+				output.WriteString(fmt.Sprintf("<br>%s\n", formatAttrLine(attr, "")))
+			}
 		}
 		output.WriteString("\n")
 	}


### PR DESCRIPTION
## Summary
Updates the OneOf callout format to be cleaner and more contained within the callout box.

## Related Issue
Closes #116

## Changes Made
- Remove redundant "Note:" label (the ℹ️ icon already indicates it's a note)
- Keep all content inside the blue callout box using `<br>` tags for line breaks
- Bold title: `**Only one of the following may be set:**`
- First attribute on continuation line, subsequent with `<br>` prefix

## Before
```markdown
-> **Note:** Only one of the following may be set:

- `attr1` - (Optional) Description.
- `attr2` - (Optional) Description.
```
List appears outside the callout box.

## After
```markdown
-> **Only one of the following may be set:**
`attr1` - (Optional) Description.
<br>`attr2` - (Optional) Description.
```
All content stays inside the blue callout box.

## Testing
- [x] Verified on Terraform Registry Doc Preview Tool
- [x] Build compiles successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)