### PR TITLE
docs: add HashiCorp documentation and reference provider links

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,22 @@ See [ROADMAP.md](docs/ROADMAP.md) for detailed development timeline and feature 
 
 This project is licensed under the Mozilla Public License 2.0 - see the [LICENSE](LICENSE) file for details.
 
+## 📖 References
+
+### HashiCorp Documentation
+
+- [Provider Documentation Style and Structure](https://developer.hashicorp.com/terraform/registry/providers/docs)
+- [Publishing Providers to the Registry](https://developer.hashicorp.com/terraform/registry/providers/publishing)
+
+### Reference Providers
+
+This provider follows patterns established by HashiCorp's official providers:
+
+| Provider | Registry | Source Code |
+|----------|----------|-------------|
+| AzureRM | [Registry](https://registry.terraform.io/providers/hashicorp/azurerm/latest) | [GitHub](https://github.com/hashicorp/terraform-provider-azurerm) |
+| AWS | [Registry](https://registry.terraform.io/providers/hashicorp/aws/latest) | [GitHub](https://github.com/hashicorp/terraform-provider-aws) |
+
 ## 🙏 Acknowledgments
 
 - **HashiCorp**: For the excellent Terraform Plugin Framework


### PR DESCRIPTION
## Summary
Adds a References section to README.md with links to HashiCorp documentation and reference providers.

## Related Issue
Closes #119

## Changes Made
- Added "References" section with:
  - [Provider Documentation Style and Structure](https://developer.hashicorp.com/terraform/registry/providers/docs)
  - [Publishing Providers to the Registry](https://developer.hashicorp.com/terraform/registry/providers/publishing)
  - Reference providers table (AzureRM, AWS) with Registry and GitHub links

## Value
Helps contributors understand the documentation standards and patterns this provider follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)