### PR TITLE
feat(examples): add Volterra-style OneOf comments to examples

### DIFF
--- a/examples/resources/f5xc_app_firewall/resource.tf
+++ b/examples/resources/f5xc_app_firewall/resource.tf
@@ -15,19 +15,27 @@ resource "f5xc_app_firewall" "example" {
     "owner" = "platform-team"
   }
 
-  # Web Application Firewall configuration
-  # Block malicious requests
+  // One of the arguments from this list "blocking monitoring" must be set
+
   blocking {}
 
-  # Use default detection settings
+  // One of the arguments from this list "custom_blocking_page use_default_blocking_page" must be set
+
   use_default_blocking_page {}
 
-  # Default bot defense configuration
-  default_bot_setting {}
+  // One of the arguments from this list "bot_protection_setting default_bot_setting" must be set
 
-  # Default detection settings
+  bot_protection_setting {
+    malicious_bot_action  = "BLOCK"
+    suspicious_bot_action = "REPORT"
+    good_bot_action       = "REPORT"
+  }
+
+  // One of the arguments from this list "custom_detection_settings default_detection_settings" must be set
+
   default_detection_settings {}
 
-  # Allow all response codes
+  // One of the arguments from this list "allow_all_response_codes allowed_response_codes" must be set
+
   allow_all_response_codes {}
 }

--- a/examples/resources/f5xc_dns_zone/resource.tf
+++ b/examples/resources/f5xc_dns_zone/resource.tf
@@ -1,5 +1,5 @@
 # Dns Zone Resource Example
-# Manages a DNSZone resource in F5 Distributed Cloud.
+# Manages DNS Zone in a given namespace. If one already exist it will give a error. in F5 Distributed Cloud.
 
 # Basic Dns Zone configuration
 resource "f5xc_dns_zone" "example" {

--- a/examples/resources/f5xc_healthcheck/resource.tf
+++ b/examples/resources/f5xc_healthcheck/resource.tf
@@ -15,12 +15,22 @@ resource "f5xc_healthcheck" "example" {
     "owner" = "platform-team"
   }
 
-  # Health Check specific configuration
+  // One of the arguments from this list "http_health_check tcp_health_check udp_icmp_health_check" must be set
+
   http_health_check {
+    // One of the arguments from this list "host_header use_origin_server_name" must be set
+
     use_origin_server_name {}
+
     path                  = "/health"
     use_http2             = false
     expected_status_codes = ["200"]
+
+    // One of the arguments from this list "headers request_headers_to_remove" must be set
+
+    headers = {
+      "x-health-check" = "true"
+    }
   }
 
   healthy_threshold   = 3

--- a/examples/resources/f5xc_http_loadbalancer/resource.tf
+++ b/examples/resources/f5xc_http_loadbalancer/resource.tf
@@ -15,15 +15,141 @@ resource "f5xc_http_loadbalancer" "example" {
     "owner" = "platform-team"
   }
 
-  # HTTP Load Balancer specific configuration
-  domains = ["app.example.com"]
+  // One of the arguments from this list "advertise_custom advertise_on_public advertise_on_public_default_vip do_not_advertise" must be set
 
-  # Advertise on public internet
-  advertise_on_internet {
-    default_vip {}
+  advertise_on_public_default_vip = true
+
+  // One of the arguments from this list "api_definition api_definitions api_specification disable_api_definition" must be set
+
+  disable_api_definition = true
+
+  // One of the arguments from this list "disable_api_discovery enable_api_discovery" must be set
+
+  enable_api_discovery {
+    // One of the arguments from this list "api_discovery_from_code_scan api_discovery_from_discovered_schema api_discovery_from_live_traffic" must be set
+
+    api_discovery_from_live_traffic {}
+
+    discovered_api_settings {
+      purge_duration_for_inactive_discovered_apis = "30"
+    }
+
+    // One of the arguments from this list "disable_learn_from_redirect_traffic enable_learn_from_redirect_traffic" must be set
+
+    disable_learn_from_redirect_traffic = true
   }
 
-  # Default origin server
+  // One of the arguments from this list "api_testing disable_api_testing" must be set
+
+  disable_api_testing = true
+
+  // One of the arguments from this list "captcha_challenge enable_challenge js_challenge no_challenge policy_based_challenge" must be set
+
+  js_challenge {
+    cookie_expiry   = 3600
+    custom_page     = ""
+    js_script_delay = 5000
+  }
+
+  domains = ["app.example.com", "www.example.com"]
+
+  // One of the arguments from this list "cookie_stickiness least_active random ring_hash round_robin source_ip_stickiness" must be set
+
+  round_robin = true
+
+  // One of the arguments from this list "http https https_auto_cert" must be set
+
+  https_auto_cert {
+    http_redirect = true
+    add_hsts      = true
+
+    // One of the arguments from this list "default_header no_headers server_name" must be set
+
+    default_header {}
+
+    tls_config {
+      // One of the arguments from this list "custom_security default_security low_security medium_security" must be set
+
+      default_security {}
+    }
+
+    // One of the arguments from this list "no_mtls use_mtls" must be set
+
+    no_mtls {}
+  }
+
+  // One of the arguments from this list "disable_malicious_user_detection enable_malicious_user_detection" must be set
+
+  enable_malicious_user_detection = true
+
+  // One of the arguments from this list "disable_malware_protection malware_protection_settings" must be set
+
+  disable_malware_protection = true
+
+  // One of the arguments from this list "api_rate_limit disable_rate_limit rate_limit" must be set
+
+  rate_limit {
+    rate_limiter {
+      name      = "example-rate-limiter"
+      namespace = "system"
+    }
+    no_ip_allowed_list {}
+  }
+
+  // One of the arguments from this list "default_sensitive_data_policy sensitive_data_policy" must be set
+
+  default_sensitive_data_policy = true
+
+  // One of the arguments from this list "active_service_policies no_service_policies service_policies_from_namespace" must be set
+
+  active_service_policies {
+    policies {
+      name      = "example-service-policy"
+      namespace = "system"
+    }
+  }
+
+  // One of the arguments from this list "disable_threat_mesh enable_threat_mesh" must be set
+
+  enable_threat_mesh = true
+
+  // One of the arguments from this list "disable_trust_client_ip_headers enable_trust_client_ip_headers" must be set
+
+  disable_trust_client_ip_headers = true
+
+  // One of the arguments from this list "user_id_client_ip user_identification" must be set
+
+  user_identification {
+    name      = "example-user-identification"
+    namespace = "system"
+  }
+
+  // One of the arguments from this list "app_firewall disable_waf" must be set
+
+  app_firewall {
+    name      = "example-app-firewall"
+    namespace = "shared"
+  }
+
+  // One of the arguments from this list "bot_defense bot_defense_advanced disable_bot_defense" must be set
+
+  bot_defense {
+    policy {
+      // One of the arguments from this list "js_download_path js_insert_all_pages js_insert_all_pages_except" must be set
+
+      js_insert_all_pages {
+        javascript_location = "AFTER_HEAD"
+      }
+
+      // One of the arguments from this list "disable_mobile_sdk enable_mobile_sdk" must be set
+
+      disable_mobile_sdk {}
+    }
+    regional_endpoint = "US"
+    timeout           = 1000
+  }
+
+  // Default route pools configuration
   default_route_pools {
     pool {
       name      = "example-origin-pool"
@@ -32,15 +158,4 @@ resource "f5xc_http_loadbalancer" "example" {
     weight   = 1
     priority = 1
   }
-
-  # Enable HTTP to HTTPS redirect
-  http {
-    dns_volterra_managed = true
-  }
-
-  # Disable rate limiting by default
-  disable_rate_limit {}
-
-  # No WAF by default
-  disable_waf {}
 }

--- a/examples/resources/f5xc_origin_pool/resource.tf
+++ b/examples/resources/f5xc_origin_pool/resource.tf
@@ -15,25 +15,72 @@ resource "f5xc_origin_pool" "example" {
     "owner" = "platform-team"
   }
 
-  # Origin Pool specific configuration
+  // Origin servers configuration
   origin_servers {
-    public_ip {
-      ip = "203.0.113.10"
+    // One of the arguments from this list "consul_service custom_endpoint_object k8s_service private_ip private_name public_ip public_name vn_private_ip vn_private_name" must be set
+
+    public_name {
+      dns_name         = "origin.example.com"
+      refresh_interval = 60
+    }
+
+    labels = {
+      "app" = "backend"
+    }
+  }
+
+  origin_servers {
+    // One of the arguments from this list "consul_service custom_endpoint_object k8s_service private_ip private_name public_ip public_name vn_private_ip vn_private_name" must be set
+
+    k8s_service {
+      service_name = "backend-svc"
+
+      // One of the arguments from this list "inside_network outside_network vk8s_networks" must be set
+
+      vk8s_networks {}
+
+      site_locator {
+        // One of the arguments from this list "site virtual_site" must be set
+
+        site {
+          name      = "example-site"
+          namespace = "system"
+        }
+      }
     }
   }
 
   port = 443
 
-  # Use TLS to origin
+  // One of the arguments from this list "no_tls use_tls" must be set
+
   use_tls {
-    use_host_header_as_sni {}
+    // One of the arguments from this list "disable_sni sni use_host_header_as_sni" must be set
+
+    sni = "backend.example.com"
+
     tls_config {
+      // One of the arguments from this list "custom_security default_security low_security medium_security" must be set
+
       default_security {}
     }
-    skip_server_verification {}
+
+    // One of the arguments from this list "no_mtls use_mtls use_mtls_obj" must be set
+
+    no_mtls {}
+
+    // One of the arguments from this list "skip_server_verification use_server_verification volterra_trusted_ca" must be set
+
+    volterra_trusted_ca {}
   }
 
-  # Endpoint selection
+  // Health check configuration
+  healthcheck {
+    name      = "example-healthcheck"
+    namespace = "system"
+  }
+
+  // Load balancing configuration
   endpoint_selection     = "LOCAL_PREFERRED"
-  loadbalancer_algorithm = "LB_OVERRIDE"
+  loadbalancer_algorithm = "ROUND_ROBIN"
 }

--- a/examples/resources/f5xc_virtual_k8s/resource.tf
+++ b/examples/resources/f5xc_virtual_k8s/resource.tf
@@ -15,13 +15,19 @@ resource "f5xc_virtual_k8s" "example" {
     "owner" = "platform-team"
   }
 
-  # Virtual Kubernetes configuration
-  # Virtual site selection
+  // Virtual site selection for workload deployment
   vsite_refs {
     name      = "example-virtual-site"
     namespace = "system"
   }
 
-  # Disable cluster global access
-  disabled {}
+  // One of the arguments from this list "disabled isolated" must be set
+
+  isolated {}
+
+  // Default workload flavor reference
+  default_flavor_ref {
+    name      = "example-workload-flavor"
+    namespace = "system"
+  }
 }

--- a/examples/resources/f5xc_virtual_network/resource.tf
+++ b/examples/resources/f5xc_virtual_network/resource.tf
@@ -15,15 +15,18 @@ resource "f5xc_virtual_network" "example" {
     "owner" = "platform-team"
   }
 
-  # Virtual Network configuration
+  // One of the arguments from this list "global_network legacy_type site_local_inside_network site_local_network srv6_network" must be set
+
   site_local_network {}
 
-  # DHCP range for the network
-  srv6_network {
-    enterprise_network {
-      srv6_network_ns_params {
-        namespace = "system"
-      }
-    }
+  // Static routes configuration (optional)
+  static_routes {
+    ip_prefixes = ["10.0.0.0/8"]
+
+    // One of the arguments from this list "default_gateway ip_address node_interface" must be set
+
+    default_gateway {}
+
+    attrs = ["ROUTE_ATTR_INSTALL_FORWARDING"]
   }
 }


### PR DESCRIPTION
## Summary

Updates the example generator to produce comprehensive Volterra-style examples with inline OneOf comments showing mutually exclusive options.

## Related Issue

Closes #129

## Changes Made

### Generator Updates (`tools/generate-examples.go`)
- Added `OneOfGroup` type and `parseOneOfGroups()` function to parse `[OneOf: ...]` markers
- Added `formatOneOfComment()` for generating Volterra-style comments
- Added `getOneOfGroupForBlock()` helper function

### Updated Resource Examples
| Resource | Changes |
|----------|---------|
| `http_loadbalancer` | Comprehensive example with 15+ OneOf comments, shows WAF enabled, rate limiting, bot defense |
| `origin_pool` | Multiple origin server types (public_name, k8s_service), TLS configuration options |
| `healthcheck` | HTTP health check with OneOf options for host header and headers |
| `app_firewall` | WAF configuration showing blocking mode, bot protection settings |
| `virtual_k8s` | Shows isolated mode instead of disabled, with flavor reference |
| `virtual_network` | Site local network with static routes showing OneOf options |

### Example Format (Before vs After)

**Before:**
```hcl
# Disable rate limiting by default
disable_rate_limit {}

# No WAF by default
disable_waf {}
```

**After:**
```hcl
// One of the arguments from this list "api_rate_limit disable_rate_limit rate_limit" must be set

rate_limit {
  rate_limiter {
    name      = "example-rate-limiter"
    namespace = "system"
  }
  no_ip_allowed_list {}
}

// One of the arguments from this list "app_firewall disable_waf" must be set

app_firewall {
  name      = "example-app-firewall"
  namespace = "shared"
}
```

## References
- Volterra http_loadbalancer example: https://registry.terraform.io/providers/volterraedge/volterra/latest/docs/resources/volterra_http_loadbalancer
- F5XC http_loadbalancer (current): https://registry.terraform.io/providers/robinmordasiewicz/f5xc/latest/docs/resources/http_loadbalancer

## Testing
- [x] Generator runs successfully
- [x] All examples have valid Terraform syntax (terraform fmt passes)
- [x] OneOf comments match schema definitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)