### PR TITLE
feat(examples): implement F5XC namespace best practices

### DIFF
--- a/examples/resources/f5xc_addon_subscription/resource.tf
+++ b/examples/resources/f5xc_addon_subscription/resource.tf
@@ -4,7 +4,7 @@
 # Basic Addon Subscription configuration
 resource "f5xc_addon_subscription" "example" {
   name      = "example-addon-subscription"
-  namespace = "system"
+  namespace = "staging"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_address_allocator/resource.tf
+++ b/examples/resources/f5xc_address_allocator/resource.tf
@@ -4,7 +4,7 @@
 # Basic Address Allocator configuration
 resource "f5xc_address_allocator" "example" {
   name      = "example-address-allocator"
-  namespace = "system"
+  namespace = "staging"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_advertise_policy/resource.tf
+++ b/examples/resources/f5xc_advertise_policy/resource.tf
@@ -4,7 +4,7 @@
 # Basic Advertise Policy configuration
 resource "f5xc_advertise_policy" "example" {
   name      = "example-advertise-policy"
-  namespace = "system"
+  namespace = "staging"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_alert_policy/resource.tf
+++ b/examples/resources/f5xc_alert_policy/resource.tf
@@ -4,7 +4,7 @@
 # Basic Alert Policy configuration
 resource "f5xc_alert_policy" "example" {
   name      = "example-alert-policy"
-  namespace = "system"
+  namespace = "shared"
 
   labels = {
     environment = "production"
@@ -19,7 +19,7 @@ resource "f5xc_alert_policy" "example" {
   # Alert receivers
   receivers {
     name      = "slack-receiver"
-    namespace = "system"
+    namespace = "shared"
   }
 
   # Alert routes

--- a/examples/resources/f5xc_alert_receiver/resource.tf
+++ b/examples/resources/f5xc_alert_receiver/resource.tf
@@ -4,7 +4,7 @@
 # Basic Alert Receiver configuration
 resource "f5xc_alert_receiver" "example" {
   name      = "example-alert-receiver"
-  namespace = "system"
+  namespace = "shared"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_allowed_tenant/resource.tf
+++ b/examples/resources/f5xc_allowed_tenant/resource.tf
@@ -4,7 +4,7 @@
 # Basic Allowed Tenant configuration
 resource "f5xc_allowed_tenant" "example" {
   name      = "example-allowed-tenant"
-  namespace = "system"
+  namespace = "staging"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_api_crawler/resource.tf
+++ b/examples/resources/f5xc_api_crawler/resource.tf
@@ -4,7 +4,7 @@
 # Basic Api Crawler configuration
 resource "f5xc_api_crawler" "example" {
   name      = "example-api-crawler"
-  namespace = "system"
+  namespace = "staging"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_api_credential/resource.tf
+++ b/examples/resources/f5xc_api_credential/resource.tf
@@ -4,7 +4,7 @@
 # Basic Api Credential configuration
 resource "f5xc_api_credential" "example" {
   name      = "example-api-credential"
-  namespace = "system"
+  namespace = "staging"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_api_definition/resource.tf
+++ b/examples/resources/f5xc_api_definition/resource.tf
@@ -4,7 +4,7 @@
 # Basic Api Definition configuration
 resource "f5xc_api_definition" "example" {
   name      = "example-api-definition"
-  namespace = "system"
+  namespace = "shared"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_api_discovery/resource.tf
+++ b/examples/resources/f5xc_api_discovery/resource.tf
@@ -4,7 +4,7 @@
 # Basic Api Discovery configuration
 resource "f5xc_api_discovery" "example" {
   name      = "example-api-discovery"
-  namespace = "system"
+  namespace = "staging"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_api_testing/resource.tf
+++ b/examples/resources/f5xc_api_testing/resource.tf
@@ -4,7 +4,7 @@
 # Basic Api Testing configuration
 resource "f5xc_api_testing" "example" {
   name      = "example-api-testing"
-  namespace = "system"
+  namespace = "staging"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_apm/resource.tf
+++ b/examples/resources/f5xc_apm/resource.tf
@@ -4,7 +4,7 @@
 # Basic Apm configuration
 resource "f5xc_apm" "example" {
   name      = "example-apm"
-  namespace = "system"
+  namespace = "staging"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_app_api_group/resource.tf
+++ b/examples/resources/f5xc_app_api_group/resource.tf
@@ -4,7 +4,7 @@
 # Basic App Api Group configuration
 resource "f5xc_app_api_group" "example" {
   name      = "example-app-api-group"
-  namespace = "system"
+  namespace = "staging"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_app_firewall/resource.tf
+++ b/examples/resources/f5xc_app_firewall/resource.tf
@@ -4,7 +4,7 @@
 # Basic App Firewall configuration
 resource "f5xc_app_firewall" "example" {
   name      = "example-app-firewall"
-  namespace = "system"
+  namespace = "shared"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_app_setting/resource.tf
+++ b/examples/resources/f5xc_app_setting/resource.tf
@@ -4,7 +4,7 @@
 # Basic App Setting configuration
 resource "f5xc_app_setting" "example" {
   name      = "example-app-setting"
-  namespace = "system"
+  namespace = "staging"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_app_type/resource.tf
+++ b/examples/resources/f5xc_app_type/resource.tf
@@ -4,7 +4,7 @@
 # Basic App Type configuration
 resource "f5xc_app_type" "example" {
   name      = "example-app-type"
-  namespace = "system"
+  namespace = "staging"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_authentication/resource.tf
+++ b/examples/resources/f5xc_authentication/resource.tf
@@ -4,7 +4,7 @@
 # Basic Authentication configuration
 resource "f5xc_authentication" "example" {
   name      = "example-authentication"
-  namespace = "system"
+  namespace = "staging"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_bigip_irule/resource.tf
+++ b/examples/resources/f5xc_bigip_irule/resource.tf
@@ -4,7 +4,7 @@
 # Basic Bigip Irule configuration
 resource "f5xc_bigip_irule" "example" {
   name      = "example-bigip-irule"
-  namespace = "system"
+  namespace = "staging"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_bot_defense_app_infrastructure/resource.tf
+++ b/examples/resources/f5xc_bot_defense_app_infrastructure/resource.tf
@@ -4,7 +4,7 @@
 # Basic Bot Defense App Infrastructure configuration
 resource "f5xc_bot_defense_app_infrastructure" "example" {
   name      = "example-bot-defense-app-infrastructure"
-  namespace = "system"
+  namespace = "shared"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_cdn_cache_rule/resource.tf
+++ b/examples/resources/f5xc_cdn_cache_rule/resource.tf
@@ -4,7 +4,7 @@
 # Basic Cdn Cache Rule configuration
 resource "f5xc_cdn_cache_rule" "example" {
   name      = "example-cdn-cache-rule"
-  namespace = "system"
+  namespace = "staging"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_cdn_loadbalancer/resource.tf
+++ b/examples/resources/f5xc_cdn_loadbalancer/resource.tf
@@ -4,7 +4,7 @@
 # Basic Cdn Loadbalancer configuration
 resource "f5xc_cdn_loadbalancer" "example" {
   name      = "example-cdn-loadbalancer"
-  namespace = "system"
+  namespace = "staging"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_certificate/resource.tf
+++ b/examples/resources/f5xc_certificate/resource.tf
@@ -4,7 +4,7 @@
 # Basic Certificate configuration
 resource "f5xc_certificate" "example" {
   name      = "example-certificate"
-  namespace = "system"
+  namespace = "shared"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_certificate_chain/resource.tf
+++ b/examples/resources/f5xc_certificate_chain/resource.tf
@@ -4,7 +4,7 @@
 # Basic Certificate Chain configuration
 resource "f5xc_certificate_chain" "example" {
   name      = "example-certificate-chain"
-  namespace = "system"
+  namespace = "shared"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_child_tenant/resource.tf
+++ b/examples/resources/f5xc_child_tenant/resource.tf
@@ -4,7 +4,7 @@
 # Basic Child Tenant configuration
 resource "f5xc_child_tenant" "example" {
   name      = "example-child-tenant"
-  namespace = "system"
+  namespace = "staging"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_child_tenant_manager/resource.tf
+++ b/examples/resources/f5xc_child_tenant_manager/resource.tf
@@ -4,7 +4,7 @@
 # Basic Child Tenant Manager configuration
 resource "f5xc_child_tenant_manager" "example" {
   name      = "example-child-tenant-manager"
-  namespace = "system"
+  namespace = "staging"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_cminstance/resource.tf
+++ b/examples/resources/f5xc_cminstance/resource.tf
@@ -4,7 +4,7 @@
 # Basic Cminstance configuration
 resource "f5xc_cminstance" "example" {
   name      = "example-cminstance"
-  namespace = "system"
+  namespace = "staging"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_code_base_integration/resource.tf
+++ b/examples/resources/f5xc_code_base_integration/resource.tf
@@ -4,7 +4,7 @@
 # Basic Code Base Integration configuration
 resource "f5xc_code_base_integration" "example" {
   name      = "example-code-base-integration"
-  namespace = "system"
+  namespace = "staging"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_contact/resource.tf
+++ b/examples/resources/f5xc_contact/resource.tf
@@ -4,7 +4,7 @@
 # Basic Contact configuration
 resource "f5xc_contact" "example" {
   name      = "example-contact"
-  namespace = "system"
+  namespace = "staging"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_container_registry/resource.tf
+++ b/examples/resources/f5xc_container_registry/resource.tf
@@ -4,7 +4,7 @@
 # Basic Container Registry configuration
 resource "f5xc_container_registry" "example" {
   name      = "example-container-registry"
-  namespace = "system"
+  namespace = "staging"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_crl/resource.tf
+++ b/examples/resources/f5xc_crl/resource.tf
@@ -4,7 +4,7 @@
 # Basic Crl configuration
 resource "f5xc_crl" "example" {
   name      = "example-crl"
-  namespace = "system"
+  namespace = "shared"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_customer_support/resource.tf
+++ b/examples/resources/f5xc_customer_support/resource.tf
@@ -4,7 +4,7 @@
 # Basic Customer Support configuration
 resource "f5xc_customer_support" "example" {
   name      = "example-customer-support"
-  namespace = "system"
+  namespace = "staging"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_data_group/resource.tf
+++ b/examples/resources/f5xc_data_group/resource.tf
@@ -4,7 +4,7 @@
 # Basic Data Group configuration
 resource "f5xc_data_group" "example" {
   name      = "example-data-group"
-  namespace = "system"
+  namespace = "staging"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_data_type/resource.tf
+++ b/examples/resources/f5xc_data_type/resource.tf
@@ -4,7 +4,7 @@
 # Basic Data Type configuration
 resource "f5xc_data_type" "example" {
   name      = "example-data-type"
-  namespace = "system"
+  namespace = "shared"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_discovery/resource.tf
+++ b/examples/resources/f5xc_discovery/resource.tf
@@ -4,7 +4,7 @@
 # Basic Discovery configuration
 resource "f5xc_discovery" "example" {
   name      = "example-discovery"
-  namespace = "system"
+  namespace = "staging"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_dns_compliance_checks/resource.tf
+++ b/examples/resources/f5xc_dns_compliance_checks/resource.tf
@@ -4,7 +4,7 @@
 # Basic Dns Compliance Checks configuration
 resource "f5xc_dns_compliance_checks" "example" {
   name      = "example-dns-compliance-checks"
-  namespace = "system"
+  namespace = "staging"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_dns_domain/resource.tf
+++ b/examples/resources/f5xc_dns_domain/resource.tf
@@ -4,7 +4,7 @@
 # Basic Dns Domain configuration
 resource "f5xc_dns_domain" "example" {
   name      = "example-dns-domain"
-  namespace = "system"
+  namespace = "staging"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_dns_lb_health_check/resource.tf
+++ b/examples/resources/f5xc_dns_lb_health_check/resource.tf
@@ -4,7 +4,7 @@
 # Basic Dns Lb Health Check configuration
 resource "f5xc_dns_lb_health_check" "example" {
   name      = "example-dns-lb-health-check"
-  namespace = "system"
+  namespace = "staging"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_dns_lb_pool/resource.tf
+++ b/examples/resources/f5xc_dns_lb_pool/resource.tf
@@ -4,7 +4,7 @@
 # Basic Dns Lb Pool configuration
 resource "f5xc_dns_lb_pool" "example" {
   name      = "example-dns-lb-pool"
-  namespace = "system"
+  namespace = "staging"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_dns_load_balancer/resource.tf
+++ b/examples/resources/f5xc_dns_load_balancer/resource.tf
@@ -4,7 +4,7 @@
 # Basic Dns Load Balancer configuration
 resource "f5xc_dns_load_balancer" "example" {
   name      = "example-dns-load-balancer"
-  namespace = "system"
+  namespace = "staging"
 
   labels = {
     environment = "production"
@@ -21,7 +21,7 @@ resource "f5xc_dns_load_balancer" "example" {
   # DNS zone reference
   dns_zone {
     name      = "example-dns-zone"
-    namespace = "system"
+    namespace = "staging"
   }
 
   # Rule-based load balancing
@@ -29,11 +29,11 @@ resource "f5xc_dns_load_balancer" "example" {
     rules {
       geo_location_set {
         name      = "us-geo"
-        namespace = "system"
+        namespace = "shared"
       }
       pool {
         name      = "us-pool"
-        namespace = "system"
+        namespace = "staging"
       }
       score = 100
     }

--- a/examples/resources/f5xc_dns_zone/resource.tf
+++ b/examples/resources/f5xc_dns_zone/resource.tf
@@ -4,7 +4,7 @@
 # Basic Dns Zone configuration
 resource "f5xc_dns_zone" "example" {
   name      = "example-dns-zone"
-  namespace = "system"
+  namespace = "staging"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_endpoint/resource.tf
+++ b/examples/resources/f5xc_endpoint/resource.tf
@@ -4,7 +4,7 @@
 # Basic Endpoint configuration
 resource "f5xc_endpoint" "example" {
   name      = "example-endpoint"
-  namespace = "system"
+  namespace = "staging"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_enhanced_firewall_policy/resource.tf
+++ b/examples/resources/f5xc_enhanced_firewall_policy/resource.tf
@@ -4,7 +4,7 @@
 # Basic Enhanced Firewall Policy configuration
 resource "f5xc_enhanced_firewall_policy" "example" {
   name      = "example-enhanced-firewall-policy"
-  namespace = "system"
+  namespace = "staging"
 
   labels = {
     environment = "production"
@@ -28,7 +28,7 @@ resource "f5xc_enhanced_firewall_policy" "example" {
       source_prefix_list {
         ip_prefix_set {
           name      = "trusted-ips"
-          namespace = "system"
+          namespace = "shared"
         }
       }
       all_traffic {}

--- a/examples/resources/f5xc_external_connector/resource.tf
+++ b/examples/resources/f5xc_external_connector/resource.tf
@@ -4,7 +4,7 @@
 # Basic External Connector configuration
 resource "f5xc_external_connector" "example" {
   name      = "example-external-connector"
-  namespace = "system"
+  namespace = "staging"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_fast_acl/resource.tf
+++ b/examples/resources/f5xc_fast_acl/resource.tf
@@ -4,7 +4,7 @@
 # Basic Fast Acl configuration
 resource "f5xc_fast_acl" "example" {
   name      = "example-fast-acl"
-  namespace = "system"
+  namespace = "staging"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_fast_acl_rule/resource.tf
+++ b/examples/resources/f5xc_fast_acl_rule/resource.tf
@@ -4,7 +4,7 @@
 # Basic Fast Acl Rule configuration
 resource "f5xc_fast_acl_rule" "example" {
   name      = "example-fast-acl-rule"
-  namespace = "system"
+  namespace = "staging"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_filter_set/resource.tf
+++ b/examples/resources/f5xc_filter_set/resource.tf
@@ -4,7 +4,7 @@
 # Basic Filter Set configuration
 resource "f5xc_filter_set" "example" {
   name      = "example-filter-set"
-  namespace = "system"
+  namespace = "staging"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_forward_proxy_policy/resource.tf
+++ b/examples/resources/f5xc_forward_proxy_policy/resource.tf
@@ -4,7 +4,7 @@
 # Basic Forward Proxy Policy configuration
 resource "f5xc_forward_proxy_policy" "example" {
   name      = "example-forward-proxy-policy"
-  namespace = "system"
+  namespace = "shared"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_forwarding_class/resource.tf
+++ b/examples/resources/f5xc_forwarding_class/resource.tf
@@ -4,7 +4,7 @@
 # Basic Forwarding Class configuration
 resource "f5xc_forwarding_class" "example" {
   name      = "example-forwarding-class"
-  namespace = "system"
+  namespace = "staging"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_geo_location_set/resource.tf
+++ b/examples/resources/f5xc_geo_location_set/resource.tf
@@ -4,7 +4,7 @@
 # Basic Geo Location Set configuration
 resource "f5xc_geo_location_set" "example" {
   name      = "example-geo-location-set"
-  namespace = "system"
+  namespace = "shared"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_healthcheck/resource.tf
+++ b/examples/resources/f5xc_healthcheck/resource.tf
@@ -4,7 +4,7 @@
 # Basic Healthcheck configuration
 resource "f5xc_healthcheck" "example" {
   name      = "example-healthcheck"
-  namespace = "system"
+  namespace = "staging"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_http_loadbalancer/resource.tf
+++ b/examples/resources/f5xc_http_loadbalancer/resource.tf
@@ -4,7 +4,7 @@
 # Basic Http Loadbalancer configuration
 resource "f5xc_http_loadbalancer" "example" {
   name      = "example-http-loadbalancer"
-  namespace = "system"
+  namespace = "staging"
 
   labels = {
     environment = "production"
@@ -91,7 +91,7 @@ resource "f5xc_http_loadbalancer" "example" {
   rate_limit {
     rate_limiter {
       name      = "example-rate-limiter"
-      namespace = "system"
+      namespace = "shared"
     }
     no_ip_allowed_list {}
   }
@@ -105,7 +105,7 @@ resource "f5xc_http_loadbalancer" "example" {
   active_service_policies {
     policies {
       name      = "example-service-policy"
-      namespace = "system"
+      namespace = "shared"
     }
   }
 
@@ -121,7 +121,7 @@ resource "f5xc_http_loadbalancer" "example" {
 
   user_identification {
     name      = "example-user-identification"
-    namespace = "system"
+    namespace = "shared"
   }
 
   // One of the arguments from this list "app_firewall disable_waf" must be set
@@ -153,7 +153,7 @@ resource "f5xc_http_loadbalancer" "example" {
   default_route_pools {
     pool {
       name      = "example-origin-pool"
-      namespace = "system"
+      namespace = "staging"
     }
     weight   = 1
     priority = 1

--- a/examples/resources/f5xc_ike1/resource.tf
+++ b/examples/resources/f5xc_ike1/resource.tf
@@ -4,7 +4,7 @@
 # Basic Ike1 configuration
 resource "f5xc_ike1" "example" {
   name      = "example-ike1"
-  namespace = "system"
+  namespace = "staging"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_ike2/resource.tf
+++ b/examples/resources/f5xc_ike2/resource.tf
@@ -4,7 +4,7 @@
 # Basic Ike2 configuration
 resource "f5xc_ike2" "example" {
   name      = "example-ike2"
-  namespace = "system"
+  namespace = "staging"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_ike_phase1_profile/resource.tf
+++ b/examples/resources/f5xc_ike_phase1_profile/resource.tf
@@ -4,7 +4,7 @@
 # Basic Ike Phase1 Profile configuration
 resource "f5xc_ike_phase1_profile" "example" {
   name      = "example-ike-phase1-profile"
-  namespace = "system"
+  namespace = "staging"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_ike_phase2_profile/resource.tf
+++ b/examples/resources/f5xc_ike_phase2_profile/resource.tf
@@ -4,7 +4,7 @@
 # Basic Ike Phase2 Profile configuration
 resource "f5xc_ike_phase2_profile" "example" {
   name      = "example-ike-phase2-profile"
-  namespace = "system"
+  namespace = "staging"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_infraprotect_asn/resource.tf
+++ b/examples/resources/f5xc_infraprotect_asn/resource.tf
@@ -4,7 +4,7 @@
 # Basic Infraprotect Asn configuration
 resource "f5xc_infraprotect_asn" "example" {
   name      = "example-infraprotect-asn"
-  namespace = "system"
+  namespace = "staging"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_infraprotect_asn_prefix/resource.tf
+++ b/examples/resources/f5xc_infraprotect_asn_prefix/resource.tf
@@ -4,7 +4,7 @@
 # Basic Infraprotect Asn Prefix configuration
 resource "f5xc_infraprotect_asn_prefix" "example" {
   name      = "example-infraprotect-asn-prefix"
-  namespace = "system"
+  namespace = "staging"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_infraprotect_deny_list_rule/resource.tf
+++ b/examples/resources/f5xc_infraprotect_deny_list_rule/resource.tf
@@ -4,7 +4,7 @@
 # Basic Infraprotect Deny List Rule configuration
 resource "f5xc_infraprotect_deny_list_rule" "example" {
   name      = "example-infraprotect-deny-list-rule"
-  namespace = "system"
+  namespace = "staging"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_infraprotect_firewall_rule/resource.tf
+++ b/examples/resources/f5xc_infraprotect_firewall_rule/resource.tf
@@ -4,7 +4,7 @@
 # Basic Infraprotect Firewall Rule configuration
 resource "f5xc_infraprotect_firewall_rule" "example" {
   name      = "example-infraprotect-firewall-rule"
-  namespace = "system"
+  namespace = "staging"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_infraprotect_firewall_rule_group/resource.tf
+++ b/examples/resources/f5xc_infraprotect_firewall_rule_group/resource.tf
@@ -4,7 +4,7 @@
 # Basic Infraprotect Firewall Rule Group configuration
 resource "f5xc_infraprotect_firewall_rule_group" "example" {
   name      = "example-infraprotect-firewall-rule-group"
-  namespace = "system"
+  namespace = "staging"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_infraprotect_internet_prefix_advertisement/resource.tf
+++ b/examples/resources/f5xc_infraprotect_internet_prefix_advertisement/resource.tf
@@ -4,7 +4,7 @@
 # Basic Infraprotect Internet Prefix Advertisement configuration
 resource "f5xc_infraprotect_internet_prefix_advertisement" "example" {
   name      = "example-infraprotect-internet-prefix-advertisement"
-  namespace = "system"
+  namespace = "staging"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_infraprotect_tunnel/resource.tf
+++ b/examples/resources/f5xc_infraprotect_tunnel/resource.tf
@@ -4,7 +4,7 @@
 # Basic Infraprotect Tunnel configuration
 resource "f5xc_infraprotect_tunnel" "example" {
   name      = "example-infraprotect-tunnel"
-  namespace = "system"
+  namespace = "staging"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_ip_prefix_set/resource.tf
+++ b/examples/resources/f5xc_ip_prefix_set/resource.tf
@@ -4,7 +4,7 @@
 # Basic Ip Prefix Set configuration
 resource "f5xc_ip_prefix_set" "example" {
   name      = "example-ip-prefix-set"
-  namespace = "system"
+  namespace = "shared"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_irule/resource.tf
+++ b/examples/resources/f5xc_irule/resource.tf
@@ -4,7 +4,7 @@
 # Basic Irule configuration
 resource "f5xc_irule" "example" {
   name      = "example-irule"
-  namespace = "system"
+  namespace = "staging"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_k8s_pod_security_admission/resource.tf
+++ b/examples/resources/f5xc_k8s_pod_security_admission/resource.tf
@@ -4,7 +4,7 @@
 # Basic K8s Pod Security Admission configuration
 resource "f5xc_k8s_pod_security_admission" "example" {
   name      = "example-k8s-pod-security-admission"
-  namespace = "system"
+  namespace = "staging"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_k8s_pod_security_policy/resource.tf
+++ b/examples/resources/f5xc_k8s_pod_security_policy/resource.tf
@@ -4,7 +4,7 @@
 # Basic K8s Pod Security Policy configuration
 resource "f5xc_k8s_pod_security_policy" "example" {
   name      = "example-k8s-pod-security-policy"
-  namespace = "system"
+  namespace = "staging"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_log_receiver/resource.tf
+++ b/examples/resources/f5xc_log_receiver/resource.tf
@@ -4,7 +4,7 @@
 # Basic Log Receiver configuration
 resource "f5xc_log_receiver" "example" {
   name      = "example-log-receiver"
-  namespace = "system"
+  namespace = "staging"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_malicious_user_mitigation/resource.tf
+++ b/examples/resources/f5xc_malicious_user_mitigation/resource.tf
@@ -4,7 +4,7 @@
 # Basic Malicious User Mitigation configuration
 resource "f5xc_malicious_user_mitigation" "example" {
   name      = "example-malicious-user-mitigation"
-  namespace = "system"
+  namespace = "shared"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_managed_tenant/resource.tf
+++ b/examples/resources/f5xc_managed_tenant/resource.tf
@@ -4,7 +4,7 @@
 # Basic Managed Tenant configuration
 resource "f5xc_managed_tenant" "example" {
   name      = "example-managed-tenant"
-  namespace = "system"
+  namespace = "staging"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_nat_policy/resource.tf
+++ b/examples/resources/f5xc_nat_policy/resource.tf
@@ -4,7 +4,7 @@
 # Basic Nat Policy configuration
 resource "f5xc_nat_policy" "example" {
   name      = "example-nat-policy"
-  namespace = "system"
+  namespace = "staging"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_network_policy/resource.tf
+++ b/examples/resources/f5xc_network_policy/resource.tf
@@ -4,7 +4,7 @@
 # Basic Network Policy configuration
 resource "f5xc_network_policy" "example" {
   name      = "example-network-policy"
-  namespace = "system"
+  namespace = "staging"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_network_policy_rule/resource.tf
+++ b/examples/resources/f5xc_network_policy_rule/resource.tf
@@ -4,7 +4,7 @@
 # Basic Network Policy Rule configuration
 resource "f5xc_network_policy_rule" "example" {
   name      = "example-network-policy-rule"
-  namespace = "system"
+  namespace = "staging"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_network_policy_view/resource.tf
+++ b/examples/resources/f5xc_network_policy_view/resource.tf
@@ -4,7 +4,7 @@
 # Basic Network Policy View configuration
 resource "f5xc_network_policy_view" "example" {
   name      = "example-network-policy-view"
-  namespace = "system"
+  namespace = "staging"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_nfv_service/resource.tf
+++ b/examples/resources/f5xc_nfv_service/resource.tf
@@ -4,7 +4,7 @@
 # Basic Nfv Service configuration
 resource "f5xc_nfv_service" "example" {
   name      = "example-nfv-service"
-  namespace = "system"
+  namespace = "staging"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_oidc_provider/resource.tf
+++ b/examples/resources/f5xc_oidc_provider/resource.tf
@@ -4,7 +4,7 @@
 # Basic Oidc Provider configuration
 resource "f5xc_oidc_provider" "example" {
   name      = "example-oidc-provider"
-  namespace = "system"
+  namespace = "staging"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_origin_pool/resource.tf
+++ b/examples/resources/f5xc_origin_pool/resource.tf
@@ -4,7 +4,7 @@
 # Basic Origin Pool configuration
 resource "f5xc_origin_pool" "example" {
   name      = "example-origin-pool"
-  namespace = "system"
+  namespace = "staging"
 
   labels = {
     environment = "production"
@@ -77,7 +77,7 @@ resource "f5xc_origin_pool" "example" {
   // Health check configuration
   healthcheck {
     name      = "example-healthcheck"
-    namespace = "system"
+    namespace = "staging"
   }
 
   // Load balancing configuration

--- a/examples/resources/f5xc_policer/resource.tf
+++ b/examples/resources/f5xc_policer/resource.tf
@@ -4,7 +4,7 @@
 # Basic Policer configuration
 resource "f5xc_policer" "example" {
   name      = "example-policer"
-  namespace = "system"
+  namespace = "staging"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_policy_based_routing/resource.tf
+++ b/examples/resources/f5xc_policy_based_routing/resource.tf
@@ -4,7 +4,7 @@
 # Basic Policy Based Routing configuration
 resource "f5xc_policy_based_routing" "example" {
   name      = "example-policy-based-routing"
-  namespace = "system"
+  namespace = "staging"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_protocol_inspection/resource.tf
+++ b/examples/resources/f5xc_protocol_inspection/resource.tf
@@ -4,7 +4,7 @@
 # Basic Protocol Inspection configuration
 resource "f5xc_protocol_inspection" "example" {
   name      = "example-protocol-inspection"
-  namespace = "system"
+  namespace = "shared"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_protocol_policer/resource.tf
+++ b/examples/resources/f5xc_protocol_policer/resource.tf
@@ -4,7 +4,7 @@
 # Basic Protocol Policer configuration
 resource "f5xc_protocol_policer" "example" {
   name      = "example-protocol-policer"
-  namespace = "system"
+  namespace = "shared"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_proxy/resource.tf
+++ b/examples/resources/f5xc_proxy/resource.tf
@@ -4,7 +4,7 @@
 # Basic Proxy configuration
 resource "f5xc_proxy" "example" {
   name      = "example-proxy"
-  namespace = "system"
+  namespace = "staging"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_quota/resource.tf
+++ b/examples/resources/f5xc_quota/resource.tf
@@ -4,7 +4,7 @@
 # Basic Quota configuration
 resource "f5xc_quota" "example" {
   name      = "example-quota"
-  namespace = "system"
+  namespace = "staging"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_rate_limiter/resource.tf
+++ b/examples/resources/f5xc_rate_limiter/resource.tf
@@ -4,7 +4,7 @@
 # Basic Rate Limiter configuration
 resource "f5xc_rate_limiter" "example" {
   name      = "example-rate-limiter"
-  namespace = "system"
+  namespace = "shared"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_rate_limiter_policy/resource.tf
+++ b/examples/resources/f5xc_rate_limiter_policy/resource.tf
@@ -4,7 +4,7 @@
 # Basic Rate Limiter Policy configuration
 resource "f5xc_rate_limiter_policy" "example" {
   name      = "example-rate-limiter-policy"
-  namespace = "system"
+  namespace = "shared"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_registration/resource.tf
+++ b/examples/resources/f5xc_registration/resource.tf
@@ -4,7 +4,7 @@
 # Basic Registration configuration
 resource "f5xc_registration" "example" {
   name      = "example-registration"
-  namespace = "system"
+  namespace = "staging"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_report_config/resource.tf
+++ b/examples/resources/f5xc_report_config/resource.tf
@@ -4,7 +4,7 @@
 # Basic Report Config configuration
 resource "f5xc_report_config" "example" {
   name      = "example-report-config"
-  namespace = "system"
+  namespace = "staging"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_secret_management_access/resource.tf
+++ b/examples/resources/f5xc_secret_management_access/resource.tf
@@ -4,7 +4,7 @@
 # Basic Secret Management Access configuration
 resource "f5xc_secret_management_access" "example" {
   name      = "example-secret-management-access"
-  namespace = "system"
+  namespace = "staging"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_secret_policy/resource.tf
+++ b/examples/resources/f5xc_secret_policy/resource.tf
@@ -4,7 +4,7 @@
 # Basic Secret Policy configuration
 resource "f5xc_secret_policy" "example" {
   name      = "example-secret-policy"
-  namespace = "system"
+  namespace = "shared"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_secret_policy_rule/resource.tf
+++ b/examples/resources/f5xc_secret_policy_rule/resource.tf
@@ -4,7 +4,7 @@
 # Basic Secret Policy Rule configuration
 resource "f5xc_secret_policy_rule" "example" {
   name      = "example-secret-policy-rule"
-  namespace = "system"
+  namespace = "shared"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_segment/resource.tf
+++ b/examples/resources/f5xc_segment/resource.tf
@@ -4,7 +4,7 @@
 # Basic Segment configuration
 resource "f5xc_segment" "example" {
   name      = "example-segment"
-  namespace = "system"
+  namespace = "staging"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_sensitive_data_policy/resource.tf
+++ b/examples/resources/f5xc_sensitive_data_policy/resource.tf
@@ -4,7 +4,7 @@
 # Basic Sensitive Data Policy configuration
 resource "f5xc_sensitive_data_policy" "example" {
   name      = "example-sensitive-data-policy"
-  namespace = "system"
+  namespace = "shared"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_service_policy/resource.tf
+++ b/examples/resources/f5xc_service_policy/resource.tf
@@ -4,7 +4,7 @@
 # Basic Service Policy configuration
 resource "f5xc_service_policy" "example" {
   name      = "example-service-policy"
-  namespace = "system"
+  namespace = "shared"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_service_policy_rule/resource.tf
+++ b/examples/resources/f5xc_service_policy_rule/resource.tf
@@ -4,7 +4,7 @@
 # Basic Service Policy Rule configuration
 resource "f5xc_service_policy_rule" "example" {
   name      = "example-service-policy-rule"
-  namespace = "system"
+  namespace = "shared"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_srv6_network_slice/resource.tf
+++ b/examples/resources/f5xc_srv6_network_slice/resource.tf
@@ -4,7 +4,7 @@
 # Basic Srv6 Network Slice configuration
 resource "f5xc_srv6_network_slice" "example" {
   name      = "example-srv6-network-slice"
-  namespace = "system"
+  namespace = "staging"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_tcp_loadbalancer/resource.tf
+++ b/examples/resources/f5xc_tcp_loadbalancer/resource.tf
@@ -4,7 +4,7 @@
 # Basic Tcp Loadbalancer configuration
 resource "f5xc_tcp_loadbalancer" "example" {
   name      = "example-tcp-loadbalancer"
-  namespace = "system"
+  namespace = "staging"
 
   labels = {
     environment = "production"
@@ -27,7 +27,7 @@ resource "f5xc_tcp_loadbalancer" "example" {
   origin_pools_weights {
     pool {
       name      = "example-tcp-pool"
-      namespace = "system"
+      namespace = "staging"
     }
     weight = 1
   }

--- a/examples/resources/f5xc_ticket_tracking_system/resource.tf
+++ b/examples/resources/f5xc_ticket_tracking_system/resource.tf
@@ -4,7 +4,7 @@
 # Basic Ticket Tracking System configuration
 resource "f5xc_ticket_tracking_system" "example" {
   name      = "example-ticket-tracking-system"
-  namespace = "system"
+  namespace = "staging"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_token/resource.tf
+++ b/examples/resources/f5xc_token/resource.tf
@@ -4,7 +4,7 @@
 # Basic Token configuration
 resource "f5xc_token" "example" {
   name      = "example-token"
-  namespace = "system"
+  namespace = "staging"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_tpm_api_key/resource.tf
+++ b/examples/resources/f5xc_tpm_api_key/resource.tf
@@ -4,7 +4,7 @@
 # Basic Tpm Api Key configuration
 resource "f5xc_tpm_api_key" "example" {
   name      = "example-tpm-api-key"
-  namespace = "system"
+  namespace = "staging"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_tpm_category/resource.tf
+++ b/examples/resources/f5xc_tpm_category/resource.tf
@@ -4,7 +4,7 @@
 # Basic Tpm Category configuration
 resource "f5xc_tpm_category" "example" {
   name      = "example-tpm-category"
-  namespace = "system"
+  namespace = "staging"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_tpm_manager/resource.tf
+++ b/examples/resources/f5xc_tpm_manager/resource.tf
@@ -4,7 +4,7 @@
 # Basic Tpm Manager configuration
 resource "f5xc_tpm_manager" "example" {
   name      = "example-tpm-manager"
-  namespace = "system"
+  namespace = "staging"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_trusted_ca_list/resource.tf
+++ b/examples/resources/f5xc_trusted_ca_list/resource.tf
@@ -4,7 +4,7 @@
 # Basic Trusted Ca List configuration
 resource "f5xc_trusted_ca_list" "example" {
   name      = "example-trusted-ca-list"
-  namespace = "system"
+  namespace = "shared"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_udp_loadbalancer/resource.tf
+++ b/examples/resources/f5xc_udp_loadbalancer/resource.tf
@@ -4,7 +4,7 @@
 # Basic Udp Loadbalancer configuration
 resource "f5xc_udp_loadbalancer" "example" {
   name      = "example-udp-loadbalancer"
-  namespace = "system"
+  namespace = "staging"
 
   labels = {
     environment = "production"
@@ -27,7 +27,7 @@ resource "f5xc_udp_loadbalancer" "example" {
   origin_pools_weights {
     pool {
       name      = "dns-pool"
-      namespace = "system"
+      namespace = "staging"
     }
     weight = 1
   }

--- a/examples/resources/f5xc_usb_policy/resource.tf
+++ b/examples/resources/f5xc_usb_policy/resource.tf
@@ -4,7 +4,7 @@
 # Basic Usb Policy configuration
 resource "f5xc_usb_policy" "example" {
   name      = "example-usb-policy"
-  namespace = "system"
+  namespace = "staging"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_user_identification/resource.tf
+++ b/examples/resources/f5xc_user_identification/resource.tf
@@ -4,7 +4,7 @@
 # Basic User Identification configuration
 resource "f5xc_user_identification" "example" {
   name      = "example-user-identification"
-  namespace = "system"
+  namespace = "shared"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_virtual_host/resource.tf
+++ b/examples/resources/f5xc_virtual_host/resource.tf
@@ -4,7 +4,7 @@
 # Basic Virtual Host configuration
 resource "f5xc_virtual_host" "example" {
   name      = "example-virtual-host"
-  namespace = "system"
+  namespace = "staging"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_virtual_k8s/resource.tf
+++ b/examples/resources/f5xc_virtual_k8s/resource.tf
@@ -4,7 +4,7 @@
 # Basic Virtual K8s configuration
 resource "f5xc_virtual_k8s" "example" {
   name      = "example-virtual-k8s"
-  namespace = "system"
+  namespace = "staging"
 
   labels = {
     environment = "production"
@@ -28,6 +28,6 @@ resource "f5xc_virtual_k8s" "example" {
   // Default workload flavor reference
   default_flavor_ref {
     name      = "example-workload-flavor"
-    namespace = "system"
+    namespace = "staging"
   }
 }

--- a/examples/resources/f5xc_voltshare_admin_policy/resource.tf
+++ b/examples/resources/f5xc_voltshare_admin_policy/resource.tf
@@ -4,7 +4,7 @@
 # Basic Voltshare Admin Policy configuration
 resource "f5xc_voltshare_admin_policy" "example" {
   name      = "example-voltshare-admin-policy"
-  namespace = "system"
+  namespace = "staging"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_waf_exclusion_policy/resource.tf
+++ b/examples/resources/f5xc_waf_exclusion_policy/resource.tf
@@ -4,7 +4,7 @@
 # Basic Waf Exclusion Policy configuration
 resource "f5xc_waf_exclusion_policy" "example" {
   name      = "example-waf-exclusion-policy"
-  namespace = "system"
+  namespace = "shared"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_workload/resource.tf
+++ b/examples/resources/f5xc_workload/resource.tf
@@ -4,7 +4,7 @@
 # Basic Workload configuration
 resource "f5xc_workload" "example" {
   name      = "example-workload"
-  namespace = "system"
+  namespace = "staging"
 
   labels = {
     environment = "production"

--- a/examples/resources/f5xc_workload_flavor/resource.tf
+++ b/examples/resources/f5xc_workload_flavor/resource.tf
@@ -4,7 +4,7 @@
 # Basic Workload Flavor configuration
 resource "f5xc_workload_flavor" "example" {
   name      = "example-workload-flavor"
-  namespace = "system"
+  namespace = "staging"
 
   labels = {
     environment = "production"


### PR DESCRIPTION
## Summary

Implements intelligent namespace assignment in the example generator following F5XC best practices, aligning with Volterra provider documentation patterns.

### Namespace Categories

| Category | Namespace | Resources |
|----------|-----------|-----------|
| Infrastructure | `system` | Sites, networks, fleet, cluster, cloud credentials, BGP, routing, k8s resources |
| Security | `shared` | app_firewall, service_policy, certificates, rate_limiters, user_identification, ip_prefix_set |
| Application | `staging` | http_loadbalancer, origin_pool, tcp/udp_loadbalancer, healthcheck, virtual_k8s, workload |

### Changes

- Added `getNamespaceForResource()` with comprehensive categorization of all 144 resources
- Added `getNamespaceForReference()` for cross-resource references (e.g., origin_pool referencing app_firewall)
- Updated `generateExample()` and `generateAdvancedExample()` to use dynamic namespace
- Updated all resource-specific configs with proper namespace references
- Regenerated all 144 resource examples with correct namespaces

### Example Before/After

**Before:**
```hcl
resource "f5xc_http_loadbalancer" "example" {
  namespace = "system"  # Wrong - app resources should use app namespace
  
  app_firewall {
    namespace = "system"  # Wrong - security resources should use shared
  }
}
```

**After:**
```hcl
resource "f5xc_http_loadbalancer" "example" {
  namespace = "staging"  # Correct - application workload
  
  app_firewall {
    namespace = "shared"  # Correct - shared security policy
  }
}
```

## Related Issue

Closes #132

## Testing

- [x] Generator compiles successfully
- [x] All 144 examples regenerated
- [x] Verified namespace assignments across resource categories
- [x] Cross-resource references use correct namespaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)