### PR TITLE
feat(docs): add visual separation between properties in OneOf callouts

### DIFF
--- a/tools/transform-docs.go
+++ b/tools/transform-docs.go
@@ -1063,8 +1063,8 @@ func transformDoc(filePath string) error {
 				// First attribute on next line (continuation of callout) with bullet
 				output.WriteString(fmt.Sprintf("&#x2022; %s\n", formatAttrLine(attr, true)))
 			} else {
-				// Subsequent attributes with <br> prefix and bullet for line breaks inside callout
-				output.WriteString(fmt.Sprintf("<br>&#x2022; %s\n", formatAttrLine(attr, true)))
+				// Subsequent attributes with <br><br> prefix for visual separation between properties
+				output.WriteString(fmt.Sprintf("<br><br>&#x2022; %s\n", formatAttrLine(attr, true)))
 			}
 		}
 		output.WriteString("\n")


### PR DESCRIPTION
## Summary
Adds visual separation between property entries inside "One of the following:" callout sections to improve readability.

## Related Issue
Closes #142

## Changes Made
- Changed `<br>` to `<br><br>` in `writeOneOfGroup` function in `tools/transform-docs.go`
- Properties inside OneOf callouts now have consistent visual spacing matching properties outside callouts

## Testing
- [x] Ran `go run tools/transform-docs.go` successfully
- [x] Verified `<br><br>&#x2022;` pattern appears in generated docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)