### PR TITLE
feat(ci): add retry logic for transient network errors in workflows

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -52,7 +52,28 @@ jobs:
 
       - name: Generate documentation
         run: |
-          tfplugindocs generate
+          # Retry logic with exponential backoff for transient network errors
+          # tfplugindocs downloads Terraform CLI from HashiCorp's checkpoint API
+          # which can occasionally timeout
+          max_attempts=3
+          attempt=1
+          while [ $attempt -le $max_attempts ]; do
+            echo "::group::Attempt $attempt of $max_attempts"
+            if tfplugindocs generate; then
+              echo "Documentation generated successfully"
+              echo "::endgroup::"
+              exit 0
+            fi
+            echo "::endgroup::"
+            attempt=$((attempt + 1))
+            if [ $attempt -le $max_attempts ]; then
+              sleep_time=$((2 ** attempt * 5))  # 10s, 20s exponential backoff
+              echo "::warning::tfplugindocs failed, retrying in ${sleep_time}s..."
+              sleep $sleep_time
+            fi
+          done
+          echo "::error::All $max_attempts attempts failed"
+          exit 1
 
       - name: Transform documentation for markdown compliance
         run: |

--- a/.github/workflows/sync-openapi.yml
+++ b/.github/workflows/sync-openapi.yml
@@ -34,7 +34,28 @@ jobs:
       - name: Download and extract OpenAPI spec
         run: |
           mkdir -p ${{ env.SPEC_DIR }}
-          curl -sL -o openapi.zip "https://docs.cloud.f5.com/docs-v2/downloads/f5-distributed-cloud-open-api.zip"
+          # Retry logic with exponential backoff for transient network errors
+          max_attempts=3
+          attempt=1
+          while [ $attempt -le $max_attempts ]; do
+            echo "::group::Download attempt $attempt of $max_attempts"
+            if curl -sL --fail --retry 2 --retry-delay 5 -o openapi.zip \
+                "https://docs.cloud.f5.com/docs-v2/downloads/f5-distributed-cloud-open-api.zip"; then
+              echo "Download successful"
+              echo "::endgroup::"
+              break
+            fi
+            echo "::endgroup::"
+            attempt=$((attempt + 1))
+            if [ $attempt -le $max_attempts ]; then
+              sleep_time=$((2 ** attempt * 5))
+              echo "::warning::Download failed, retrying in ${sleep_time}s..."
+              sleep $sleep_time
+            else
+              echo "::error::All $max_attempts download attempts failed"
+              exit 1
+            fi
+          done
           unzip -o openapi.zip -d ${{ env.SPEC_DIR }}
           rm openapi.zip
 


### PR DESCRIPTION
## Summary
Add retry logic with exponential backoff to GitHub Actions workflows to handle transient network errors gracefully.

## Related Issue
Closes #148

## Changes Made

### `docs.yml` - Generate documentation step
- Adds retry logic around `tfplugindocs generate`
- 3 attempts with exponential backoff (10s, 20s delays)
- Uses GitHub Actions `::group::` and `::warning::` workflow commands

### `sync-openapi.yml` - Download OpenAPI spec step
- Adds retry logic around curl download from F5 docs
- 3 attempts with exponential backoff
- Also uses curl's built-in `--retry` for additional resilience

## Implementation Pattern
```bash
max_attempts=3
attempt=1
while [ $attempt -le $max_attempts ]; do
  echo "::group::Attempt $attempt of $max_attempts"
  if <command>; then
    exit 0
  fi
  echo "::endgroup::"
  sleep_time=$((2 ** attempt * 5))  # 10s, 20s exponential backoff
  sleep $sleep_time
done
exit 1
```

## Benefits
- Reduces manual intervention for transient network failures
- Improves CI/CD reliability
- No additional action dependencies required
- Clear logging with grouped output

🤖 Generated with [Claude Code](https://claude.com/claude-code)