### PR TITLE
fix(docs): restore Azure RM-style blue clickable property names

### DIFF
--- a/tools/transform-docs.go
+++ b/tools/transform-docs.go
@@ -1007,7 +1007,8 @@ func transformDoc(filePath string) error {
 		// Build the first line: bullet + name + Required/Optional + Type + defaults + specified in
 		reqText := strings.Trim(attr.reqStr, "()")
 		var firstLine strings.Builder
-		firstLine.WriteString(fmt.Sprintf("%s`%s` - %s %s", bulletPrefix, attr.name, reqText, typeStr))
+		anchorID := toAnchorName(attr.name)
+		firstLine.WriteString(fmt.Sprintf("%s[`%s`](#%s) - %s %s", bulletPrefix, attr.name, anchorID, reqText, typeStr))
 		if defaultVal != "" {
 			firstLine.WriteString("  " + defaultVal)
 		}
@@ -1274,7 +1275,8 @@ func transformDoc(filePath string) error {
 
 					// Build the first line: bullet + name + Optional + Type + defaults + specified in
 					var firstLine strings.Builder
-					firstLine.WriteString(fmt.Sprintf("&#x2022; `%s` - Optional %s", name, typeStr))
+					nestedAttrAnchor := toAnchorName(name)
+					firstLine.WriteString(fmt.Sprintf("&#x2022; [`%s`](#%s) - Optional %s", name, nestedAttrAnchor, typeStr))
 					if defaultVal != "" {
 						firstLine.WriteString("  " + defaultVal)
 					}


### PR DESCRIPTION
## Summary
Restores the link syntax for property names that was removed in PR #151. After investigation with Playwright, we confirmed that Azure RM provider documentation **does** use clickable property names that scroll to section anchors.

## Related Issue
Closes #153

## Changes Made
- Restore link syntax `[`property`](#anchor)` for main attributes  
- Restore link syntax for nested block attributes
- Property names will now render as blue clickable links that scroll to their anchor (matching Azure RM style)

## Before (PR #151)
```
&#x2022; `name` - Required String<br>...
```

## After (this PR)
```
&#x2022; [`name`](#name) - Required String<br>...
```

## Azure RM Reference
Verified with Playwright that Azure RM renders property names like `location` as clickable links pointing to anchors like `#location-1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)