### PR TITLE
fix(docs): remove unsupported template variables from index.md.tmpl

### DIFF
--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -140,4 +140,4 @@ resource "f5xc_http_loadbalancer" "example" {
 
 ## Resources and Data Sources
 
-This provider includes {{ len .Resources }} resources and {{ len .DataSources }} data sources for managing F5 Distributed Cloud infrastructure. Browse the documentation sidebar for the complete list organized by category.
+Browse the documentation sidebar for the complete list of resources and data sources organized by category.


### PR DESCRIPTION
## Summary
Fixes documentation generation failure by removing unsupported `.Resources` and `.DataSources` template variables from index.md.tmpl.

## Related Issue
Fixes #166

## Problem
The tfplugindocs tool doesn't support `.Resources` and `.DataSources` variables, causing the docs workflow to fail with:
```
unable to render provider template "index.md.tmpl": template: providerTemplate:143:30: at <.Resources>: can't evaluate field Resources
```

## Changes Made
- Removed `{{ len .Resources }}` and `{{ len .DataSources }}` from templates/index.md.tmpl
- Replaced with static text: "Browse the documentation sidebar for the complete list"

## Impact
This fix will allow the docs workflow to regenerate documentation with the new P12/PEM authentication attributes from #164.

🤖 Generated with [Claude Code](https://claude.com/claude-code)