### PR TITLE
fix(tools): add acronym handling to toHumanName in example generators

### DIFF
--- a/tools/generate-datasource-examples.go
+++ b/tools/generate-datasource-examples.go
@@ -11,6 +11,27 @@ import (
 	"strings"
 )
 
+// uppercaseAcronyms defines acronyms that should be fully uppercase
+var uppercaseAcronyms = map[string]bool{
+	"http": true, "https": true, "dns": true, "tcp": true, "udp": true,
+	"tls": true, "ssl": true, "api": true, "url": true, "uri": true,
+	"ip": true, "bgp": true, "jwt": true, "acl": true, "waf": true,
+	"cdn": true, "aws": true, "gcp": true, "vpc": true, "tgw": true,
+	"vnet": true, "ce": true, "re": true, "lb": true, "vip": true,
+	"sni": true, "cors": true, "xss": true, "csrf": true, "oidc": true,
+	"saml": true, "ssh": true, "nfs": true, "ntp": true, "pem": true,
+	"rsa": true, "ecdsa": true, "id": true, "apm": true, "irule": true,
+}
+
+// mixedCaseAcronyms defines acronyms with specific mixed case
+var mixedCaseAcronyms = map[string]string{
+	"mtls": "mTLS", "oauth": "OAuth", "graphql": "GraphQL",
+	"websocket": "WebSocket", "javascript": "JavaScript", "typescript": "TypeScript",
+	"github": "GitHub", "gitlab": "GitLab", "devops": "DevOps",
+	"fastcgi": "FastCGI", "modsecurity": "ModSecurity", "hashicorp": "HashiCorp",
+	"bigip": "BigIP",
+}
+
 func main() {
 	providerDir := "internal/provider"
 	examplesDir := "examples/data-sources"
@@ -262,7 +283,14 @@ func addDataSourceSpecificExample(sb *strings.Builder, dataSourceName string) {
 func toHumanName(name string) string {
 	words := strings.Split(name, "_")
 	for i, word := range words {
-		words[i] = strings.Title(word)
+		lower := strings.ToLower(word)
+		if uppercaseAcronyms[lower] {
+			words[i] = strings.ToUpper(word)
+		} else if replacement, ok := mixedCaseAcronyms[lower]; ok {
+			words[i] = replacement
+		} else {
+			words[i] = strings.Title(word)
+		}
 	}
 	return strings.Join(words, " ")
 }

--- a/tools/generate-examples.go
+++ b/tools/generate-examples.go
@@ -16,6 +16,27 @@ import (
 	"strings"
 )
 
+// uppercaseAcronyms defines acronyms that should be fully uppercase
+var uppercaseAcronyms = map[string]bool{
+	"http": true, "https": true, "dns": true, "tcp": true, "udp": true,
+	"tls": true, "ssl": true, "api": true, "url": true, "uri": true,
+	"ip": true, "bgp": true, "jwt": true, "acl": true, "waf": true,
+	"cdn": true, "aws": true, "gcp": true, "vpc": true, "tgw": true,
+	"vnet": true, "ce": true, "re": true, "lb": true, "vip": true,
+	"sni": true, "cors": true, "xss": true, "csrf": true, "oidc": true,
+	"saml": true, "ssh": true, "nfs": true, "ntp": true, "pem": true,
+	"rsa": true, "ecdsa": true, "id": true, "apm": true, "irule": true,
+}
+
+// mixedCaseAcronyms defines acronyms with specific mixed case
+var mixedCaseAcronyms = map[string]string{
+	"mtls": "mTLS", "oauth": "OAuth", "graphql": "GraphQL",
+	"websocket": "WebSocket", "javascript": "JavaScript", "typescript": "TypeScript",
+	"github": "GitHub", "gitlab": "GitLab", "devops": "DevOps",
+	"fastcgi": "FastCGI", "modsecurity": "ModSecurity", "hashicorp": "HashiCorp",
+	"bigip": "BigIP",
+}
+
 type SchemaInfo struct {
 	ResourceName string
 	TypeName     string
@@ -1517,7 +1538,14 @@ func truncateDescription(desc string, maxLen int) string {
 func toHumanName(resourceName string) string {
 	words := strings.Split(resourceName, "_")
 	for i, word := range words {
-		words[i] = strings.Title(word)
+		lower := strings.ToLower(word)
+		if uppercaseAcronyms[lower] {
+			words[i] = strings.ToUpper(word)
+		} else if replacement, ok := mixedCaseAcronyms[lower]; ok {
+			words[i] = replacement
+		} else {
+			words[i] = strings.Title(word)
+		}
 	}
 	return strings.Join(words, " ")
 }


### PR DESCRIPTION
## Summary

Add proper acronym handling to `toHumanName()` functions in example generators to produce correctly capitalized human-readable names.

## Related Issue

Closes #171

## Changes Made

Added acronym maps and updated `toHumanName()` in:
- `tools/generate-examples.go`
- `tools/generate-datasource-examples.go`

### Before
```
http_loadbalancer → "Http Loadbalancer"
dns_zone → "Dns Zone"
tcp_loadbalancer → "Tcp Loadbalancer"
```

### After
```
http_loadbalancer → "HTTP Loadbalancer"
dns_zone → "DNS Zone"
tcp_loadbalancer → "TCP Loadbalancer"
```

### Acronyms Handled
- **Uppercase**: HTTP, HTTPS, DNS, TCP, UDP, TLS, SSL, API, URL, URI, IP, BGP, JWT, ACL, WAF, CDN, AWS, GCP, VPC, TGW, VNET, CE, RE, LB, VIP, SNI, CORS, XSS, CSRF, OIDC, SAML, SSH, NFS, NTP, PEM, RSA, ECDSA, ID, APM, IRULE
- **Mixed case**: mTLS, OAuth, GraphQL, WebSocket, JavaScript, TypeScript, GitHub, GitLab, DevOps, FastCGI, ModSecurity, HashiCorp, BigIP

## Testing

- [x] Both tools compile successfully
- [x] Follows same pattern as `transform-docs.go` acronym handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)