### PR TITLE
fix(examples): remove deprecated options from OneOf comments

### DIFF
--- a/tools/generate-examples.go
+++ b/tools/generate-examples.go
@@ -377,7 +377,7 @@ func addResourceSpecificConfig(sb *strings.Builder, resourceName string, schema 
 	case "http_loadbalancer":
 		sb.WriteString("\n  // One of the arguments from this list \"advertise_custom advertise_on_public advertise_on_public_default_vip do_not_advertise\" must be set\n\n")
 		sb.WriteString("  advertise_on_public_default_vip = true\n\n")
-		sb.WriteString("  // One of the arguments from this list \"api_definition api_definitions api_specification disable_api_definition\" must be set\n\n")
+		sb.WriteString("  // One of the arguments from this list \"api_specification disable_api_definition\" must be set\n\n")
 		sb.WriteString("  disable_api_definition = true\n\n")
 		sb.WriteString("  // One of the arguments from this list \"disable_api_discovery enable_api_discovery\" must be set\n\n")
 		sb.WriteString("  enable_api_discovery {\n")
@@ -542,7 +542,7 @@ func addResourceSpecificConfig(sb *strings.Builder, resourceName string, schema 
 	case "app_firewall":
 		sb.WriteString("\n  // One of the arguments from this list \"blocking monitoring\" must be set\n\n")
 		sb.WriteString("  blocking {}\n\n")
-		sb.WriteString("  // One of the arguments from this list \"custom_blocking_page use_default_blocking_page\" must be set\n\n")
+		sb.WriteString("  // One of the arguments from this list \"blocking_page use_default_blocking_page\" must be set\n\n")
 		sb.WriteString("  use_default_blocking_page {}\n\n")
 		sb.WriteString("  // One of the arguments from this list \"bot_protection_setting default_bot_setting\" must be set\n\n")
 		sb.WriteString("  bot_protection_setting {\n")
@@ -550,7 +550,7 @@ func addResourceSpecificConfig(sb *strings.Builder, resourceName string, schema 
 		sb.WriteString("    suspicious_bot_action = \"REPORT\"\n")
 		sb.WriteString("    good_bot_action       = \"REPORT\"\n")
 		sb.WriteString("  }\n\n")
-		sb.WriteString("  // One of the arguments from this list \"custom_detection_settings default_detection_settings\" must be set\n\n")
+		sb.WriteString("  // One of the arguments from this list \"ai_risk_based_blocking default_detection_settings detection_settings\" must be set\n\n")
 		sb.WriteString("  default_detection_settings {}\n\n")
 		sb.WriteString("  // One of the arguments from this list \"allow_all_response_codes allowed_response_codes\" must be set\n\n")
 		sb.WriteString("  allow_all_response_codes {}\n")


### PR DESCRIPTION
## Summary
Update hardcoded "One of the arguments from this list" comments in `generate-examples.go` to match current schema `[OneOf:]` markers. Deprecated and renamed options have been removed/updated to ensure example code comments reflect actual available options.

## Related Issue
Closes #177

## Changes Made
### http_loadbalancer
- Removed deprecated `api_definition` and `api_definitions` from OneOf comment
- Now shows only: `api_specification disable_api_definition`

### app_firewall
1. **Blocking page**: Changed `custom_blocking_page` to `blocking_page` (renamed in schema)
2. **Detection settings**: Changed `custom_detection_settings` to `detection_settings` and added new `ai_risk_based_blocking` option

## Testing
- [x] Code compiles without errors
- [x] Changes align with schema `[OneOf:]` markers

## Impact
Example code comments will no longer show deprecated options that don't exist in the current schema, improving documentation accuracy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)