### PR TITLE
fix(tools): add documentation to trigger example regeneration

### DIFF
--- a/tools/generate-examples.go
+++ b/tools/generate-examples.go
@@ -372,6 +372,9 @@ func generateExample(resourceName string, schema *SchemaInfo) string {
 	return sb.String()
 }
 
+// addResourceSpecificConfig adds resource-specific example configurations.
+// OneOf comments are manually curated to exclude deprecated options that are
+// no longer valid in the current API version.
 func addResourceSpecificConfig(sb *strings.Builder, resourceName string, schema *SchemaInfo) {
 	switch resourceName {
 	case "http_loadbalancer":


### PR DESCRIPTION
## Summary
Adds a documentation comment to `addResourceSpecificConfig` function in `generate-examples.go`. This triggers the docs.yml workflow which will now run the example regeneration step to produce examples with corrected OneOf comments.

## Related Issue
Closes #183

## Background
- PR #178 updated `generate-examples.go` to remove deprecated options from OneOf comments
- PR #182 added the `generate-examples.go` step to docs.yml
- But PR #178 merged BEFORE PR #182, so the examples were never regenerated

## Expected Behavior
When this PR merges:
1. docs.yml triggers (change to `tools/`)
2. Workflow runs `go run tools/generate-examples.go`
3. Examples regenerated with corrected OneOf comments
4. Workflow creates auto-PR with regenerated examples

## Testing
- [x] Change triggers docs.yml workflow
- [ ] Workflow regenerates examples correctly (verified after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)