### PR TITLE
fix(docs): add missing post-processing functions to main transform path

### DIFF
--- a/tools/transform-docs.go
+++ b/tools/transform-docs.go
@@ -1618,6 +1618,12 @@ func transformDoc(filePath string) error {
 	// Normalize multiple consecutive blank lines to single blank lines
 	result := normalizeBlankLines(output.String())
 
+	// Convert plain backticked context lines to clickable links
+	result = convertContextLinesToLinks(result)
+
+	// Add "See below" links for nested blocks that have their own sections
+	result = addSeeBelowLinksForNestedBlocks(result)
+
 	// Final pass: fix any remaining bare URLs not in backticks (MD034 compliance)
 	result = fixBareURLs(result)
 


### PR DESCRIPTION
## Summary

The main transform path (for fresh docs with `## Schema`) was missing calls to two critical post-processing functions:
- `convertContextLinesToLinks` - Converts plain backticked context lines to clickable links
- `addSeeBelowLinksForNestedBlocks` - Adds "See below" links for nested blocks

These functions were only being called in `transformAnchorsOnly` (for already-transformed files with `## Argument Reference`). This caused "See below" links for nested blocks like `cors_policy` to be missing when CI regenerates docs from scratch via tfplugindocs.

## Related Issue

Closes #196

## Root Cause Analysis

When CI runs the docs workflow:
1. `tfplugindocs generate` creates fresh docs with `## Schema`
2. `transform-docs.go` detects `## Schema` → goes to main transform path (line 960+)
3. Main transform was NOT calling `convertContextLinesToLinks` or `addSeeBelowLinksForNestedBlocks`
4. Result: Fresh docs were missing "See below" links for nested blocks

The `transformAnchorsOnly` path (for already-transformed files) DID have these calls, which is why running the transform locally on existing docs worked correctly.

## Changes Made

Added calls to both functions in the main transform path at `tools/transform-docs.go:1621-1625`

## Testing

- [x] Build succeeds: `go build ./tools/transform-docs.go`
- [x] Local test: `go run tools/transform-docs.go` adds "See below" links to `cors_policy` on line 261

🤖 Generated with [Claude Code](https://claude.com/claude-code)