### PR TITLE
fix(docs): remove raw HTML anchors from processNestedBlocks function

### DIFF
--- a/tools/transform-docs.go
+++ b/tools/transform-docs.go
@@ -1440,8 +1440,8 @@ func transformDoc(filePath string) error {
 					}
 
 					skipCurrentBlock = false
-					// Add blank line before anchor for proper markdown formatting
-					output.WriteString(fmt.Sprintf("\n<a id=\"%s\"></a>\n\n", anchorName))
+					// Skip raw HTML anchor - H4 header will auto-generate anchor on Terraform Registry
+					// The H4 header "#### Title" generates anchor "#title" automatically
 					inNestedBlock = true
 				}
 				continue
@@ -1458,8 +1458,8 @@ func transformDoc(filePath string) error {
 					}
 
 					skipCurrentBlock = false
-					// Write anchor as-is (already in simplified format)
-					output.WriteString(fmt.Sprintf("\n<a id=\"%s\"></a>\n\n", m[1]))
+					// Skip raw HTML anchor - H4 header will auto-generate anchor on Terraform Registry
+					// The H4 header "#### Title" generates anchor "#title" automatically
 					inNestedBlock = true
 				}
 				continue


### PR DESCRIPTION
## Summary
Remove raw HTML anchor tags from `processNestedBlocks` function that don't work on Terraform Registry for navigation.

## Related Issue
Closes #202

## Changes Made
- Modified `tools/transform-docs.go` to skip writing `<a id="..."></a>` tags in `processNestedBlocks`
- H4 headers (`#### CORS Policy`) already auto-generate proper anchors (`#cors-policy`) on Terraform Registry
- This is a follow-up to PR #200 which added H4 headers but didn't remove the redundant HTML anchors

## Testing
- Ran `go run ./tools/transform-docs.go` locally
- Verified raw HTML anchors are removed: `grep -c '<a id=' docs/resources/http_loadbalancer.md` returns 0
- Verified H4 headers remain intact

## Expected Behavior After Merge
- CI workflow will regenerate docs with ~10,000 fewer lines (removing `<a id="..."></a>` tags)
- Clicking "See [CORS Policy](#cors-policy) below" links will navigate to `#### CORS Policy` headers
- Anchor navigation will work on Terraform Registry

🤖 Generated with [Claude Code](https://claude.com/claude-code)