### PR TITLE
fix(docs): use full path titles for H4 headers to enable anchor navigation

### DIFF
--- a/tools/transform-docs.go
+++ b/tools/transform-docs.go
@@ -1479,15 +1479,16 @@ func transformDoc(filePath string) error {
 				if m := headerRegex.FindStringSubmatch(line); m != nil {
 					fullPath := m[1] // e.g., "active_service_policies.policies"
 
-					// Extract only the last segment to avoid redundant naming
-					// "active_service_policies.policies" → "Policies"
-					// "active_service_policies" → "Active Service Policies"
+					// Use full path for H4 header title to generate unique anchor on Terraform Registry
+					// e.g., "routes.simple_route.cors_policy" → "#### Routes Simple Route CORS Policy"
+					// This generates anchor "#routes-simple-route-cors-policy" matching the link targets
 					pathParts := strings.Split(fullPath, ".")
 					lastSegment := pathParts[len(pathParts)-1]
-					displayName := toTitleCase(lastSegment)
 
-					// Use H4 header to create proper navigable anchor on Terraform Registry
-					output.WriteString(fmt.Sprintf("#### %s\n\n", displayName))
+					// Build full title from all path parts for unique H4 header
+					// This ensures each nested block has a unique anchor
+					fullTitle := toTitleCase(strings.ReplaceAll(fullPath, ".", " "))
+					output.WriteString(fmt.Sprintf("#### %s\n\n", fullTitle))
 
 					// Add AzureRM-style context line showing parent relationship with clickable links
 					// Example: "A [`policies`](#active-service-policies-policies) block (within [`active_service_policies`](#active-service-policies)) supports the following:"


### PR DESCRIPTION
## Summary
- Uses full path titles for H4 headers in nested block documentation to generate unique anchors
- Fixes anchor navigation links that point to nested block sections

## Related Issue
Closes #205

## Changes Made
Modified `tools/transform-docs.go`:
- Changed H4 header generation in `processNestedBlocks` to use full path title
- Before: `#### CORS Policy` → generates `#cors-policy`
- After: `#### Routes Simple Route Advanced Options CORS Policy` → generates `#routes-simple-route-advanced-options-cors-policy`

## Testing
- [x] Regenerated http_loadbalancer.md from scratch using `tfplugindocs generate`
- [x] Ran `transform-docs.go` to apply transformation
- [x] Verified H4 headers now use full path titles
- [x] Confirmed anchor links in "See...below" text match the generated H4 anchors
- [x] Code compiles without errors

## Example
Before:
```markdown
#### CORS Policy

A [`cors_policy`](#routes-simple-route-advanced-options-cors-policy) block...
```
The link `#routes-simple-route-advanced-options-cors-policy` didn't match `#cors-policy`.

After:
```markdown
#### Routes Simple Route Advanced Options CORS Policy

A [`cors_policy`](#routes-simple-route-advanced-options-cors-policy) block...
```
The link now matches the auto-generated anchor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)