### PR TITLE
chore: remove stale MkDocs patterns from CI constitution check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,11 +72,6 @@ jobs:
             # Example Terraform files
             "^examples/resources/.*\.tf$"
             "^examples/data-sources/.*\.tf$"
-            # API documentation
-            "^docs/api/.*\.md$"
-            "^docs/nav-api\.yml$"
-            # MkDocs site build output
-            "^site/"
             # Provider Go code
             "^internal/provider/.*_resource\.go$"
             "^internal/provider/.*_data_source\.go$"


### PR DESCRIPTION
## Summary
Remove obsolete patterns from the CI constitution check that referenced MkDocs artifacts removed in PR #217.

## Related Issue
Closes #218

## Changes Made
Removed stale patterns from `.github/workflows/ci.yml`:
- `^docs/api/.*\.md$` - API documentation (removed)
- `^docs/nav-api\.yml$` - MkDocs navigation (removed)
- `^site/` - MkDocs build output (removed)

## Context
These patterns were part of the MkDocs static site generator infrastructure that was fully removed in PR #217. Keeping them in the constitution check serves no purpose and adds confusion.

## Testing
- [x] CI workflow syntax is valid
- [x] Constitution check still validates remaining generated file patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)