### PR TITLE
test: add HTML tag rendering test guides for Registry investigation

### DIFF
--- a/templates/guides/test_control.md.tmpl
+++ b/templates/guides/test_control.md.tmpl
@@ -1,0 +1,45 @@
+---
+page_title: "Test: Control (No HTML Tags)"
+description: |-
+  Control test guide with no HTML tags to establish baseline Registry markdown parsing behavior.
+---
+
+# Test: Control (No HTML Tags)
+
+This guide serves as a control test with no HTML tags to establish baseline rendering behavior.
+
+## Section Before Test Content
+
+This section appears before the test content and should render correctly.
+
+### Argument Reference
+
+- `name` - Required String. Name of the resource
+- `description` - Optional String. Description of the resource
+
+## Section With Plain Text
+
+This section contains only plain text descriptions without any HTML-like content.
+
+### JavaScript Location Settings
+
+The JavaScript can be inserted at different locations:
+
+- Insert JavaScript after the opening head element
+- Insert JavaScript after the closing title element
+- Insert JavaScript before the first script element
+
+These descriptions above use plain English without any HTML tag syntax.
+
+## Section After Test Content
+
+If this section renders on the Terraform Registry, then the document structure is valid.
+
+### Additional Arguments
+
+- `enabled` - Optional Bool. Enable the feature
+- `timeout` - Optional Number. Timeout in seconds
+
+## Final Section
+
+This is the final section of the control test guide. If you can see this on the Registry, the entire document rendered successfully.

--- a/templates/guides/test_html_escaped.md.tmpl
+++ b/templates/guides/test_html_escaped.md.tmpl
@@ -1,0 +1,45 @@
+---
+page_title: "Test: Escaped HTML Tags"
+description: |-
+  Test guide with escaped HTML tags (using backticks) to verify Registry markdown parsing behavior.
+---
+
+# Test: Escaped HTML Tags
+
+This guide tests whether escaped HTML tags (using backticks) render correctly on Terraform Registry.
+
+## Section Before HTML Tags
+
+This section appears before any HTML tags and should render correctly.
+
+### Argument Reference
+
+- `name` - Required String. Name of the resource
+- `description` - Optional String. Description of the resource
+
+## Section With Escaped HTML Tags
+
+This section contains HTML tags escaped with backticks, which should render safely.
+
+### JavaScript Location Settings
+
+The JavaScript can be inserted at different locations:
+
+- Insert JavaScript after `<head>` tag
+- Insert JavaScript after `</title>` tag
+- Insert JavaScript before first `<script>` tag
+
+These HTML-like tags above are escaped with backticks and should render as code.
+
+## Section After HTML Tags
+
+If this section renders on the Terraform Registry, then escaped HTML tags are handled correctly.
+
+### Additional Arguments
+
+- `enabled` - Optional Bool. Enable the feature
+- `timeout` - Optional Number. Timeout in seconds
+
+## Final Section
+
+This is the final section of the test guide. If you can see this on the Registry, the entire document rendered successfully.

--- a/templates/guides/test_html_unescaped.md.tmpl
+++ b/templates/guides/test_html_unescaped.md.tmpl
@@ -1,0 +1,45 @@
+---
+page_title: "Test: Unescaped HTML Tags"
+description: |-
+  Test guide with unescaped HTML tags to verify Registry markdown parsing behavior.
+---
+
+# Test: Unescaped HTML Tags
+
+This guide tests whether unescaped HTML tags break Terraform Registry markdown parsing.
+
+## Section Before HTML Tags
+
+This section appears before any HTML tags and should render correctly.
+
+### Argument Reference
+
+- `name` - Required String. Name of the resource
+- `description` - Optional String. Description of the resource
+
+## Section With Unescaped HTML Tags
+
+This section contains unescaped HTML tags that may break the markdown parser.
+
+### JavaScript Location Settings
+
+The JavaScript can be inserted at different locations:
+
+- Insert JavaScript after <head> tag
+- Insert JavaScript after </title> tag
+- Insert JavaScript before first <script> tag
+
+These HTML-like tags above are unescaped and may cause parsing issues.
+
+## Section After HTML Tags
+
+If this section renders on the Terraform Registry, then unescaped HTML tags do NOT break parsing.
+
+### Additional Arguments
+
+- `enabled` - Optional Bool. Enable the feature
+- `timeout` - Optional Number. Timeout in seconds
+
+## Final Section
+
+This is the final section of the test guide. If you can see this on the Registry, the entire document rendered successfully.


### PR DESCRIPTION
## Summary

Creates systematic test files to verify whether unescaped HTML tags break Terraform Registry markdown parsing.

## Related Issue

Related to #226

## Test Files Created

| File | Content | Purpose |
|------|---------|---------|
| `test_html_unescaped.md.tmpl` | `<head>`, `</title>`, `<script>` as plain text | Test if unescaped HTML breaks parsing |
| `test_html_escaped.md.tmpl` | Same tags wrapped in backticks | Test if escaped HTML renders correctly |
| `test_control.md.tmpl` | No HTML-like content | Baseline comparison |

## Expected Behavior After Merge

Once merged and published to Terraform Registry:
- **Control**: Should render completely (baseline)
- **Escaped**: Should render completely with HTML tags shown as code
- **Unescaped**: If hypothesis is correct, content after HTML tags may not render

## Verification Steps

1. Merge this PR
2. Wait for Registry to update
3. Visit:
   - https://registry.terraform.io/providers/robinmordasiewicz/f5xc/latest/docs/guides/test_control
   - https://registry.terraform.io/providers/robinmordasiewicz/f5xc/latest/docs/guides/test_html_escaped  
   - https://registry.terraform.io/providers/robinmordasiewicz/f5xc/latest/docs/guides/test_html_unescaped
4. Compare "Final Section" visibility across all three guides

🤖 Generated with [Claude Code](https://claude.com/claude-code)