### PR TITLE
fix(docs): add subcategory to test guide templates

### DIFF
--- a/templates/guides/test_control.md.tmpl
+++ b/templates/guides/test_control.md.tmpl
@@ -1,5 +1,6 @@
 ---
 page_title: "Test: Control (No HTML Tags)"
+subcategory: "Testing"
 description: |-
   Control test guide with no HTML tags to establish baseline Registry markdown parsing behavior.
 ---

--- a/templates/guides/test_html_escaped.md.tmpl
+++ b/templates/guides/test_html_escaped.md.tmpl
@@ -1,5 +1,6 @@
 ---
 page_title: "Test: Escaped HTML Tags"
+subcategory: "Testing"
 description: |-
   Test guide with escaped HTML tags (using backticks) to verify Registry markdown parsing behavior.
 ---

--- a/templates/guides/test_html_unescaped.md.tmpl
+++ b/templates/guides/test_html_unescaped.md.tmpl
@@ -1,5 +1,6 @@
 ---
 page_title: "Test: Unescaped HTML Tags"
+subcategory: "Testing"
 description: |-
   Test guide with unescaped HTML tags to verify Registry markdown parsing behavior.
 ---


### PR DESCRIPTION
## Summary
Adds the required `subcategory: "Testing"` field to all three test guide templates so they appear correctly on the Terraform Registry.

## Related Issue
Related to #226

## Problem
The test guides (control, escaped HTML, unescaped HTML) were not appearing on the Terraform Registry because they were missing the `subcategory` field in their frontmatter. This field is required for the Registry to properly index and display guides.

## Changes Made
- Added `subcategory: "Testing"` to `templates/guides/test_control.md.tmpl`
- Added `subcategory: "Testing"` to `templates/guides/test_html_escaped.md.tmpl`
- Added `subcategory: "Testing"` to `templates/guides/test_html_unescaped.md.tmpl`

## Testing
- [ ] Verify test guides appear on Registry after merge and release
- [ ] Compare rendering of all three test guides

🤖 Generated with [Claude Code](https://claude.com/claude-code)