### PR TITLE
fix(docs): use full path anchors for nested property links

### DIFF
--- a/tools/transform-docs.go
+++ b/tools/transform-docs.go
@@ -1615,7 +1615,12 @@ func transformDoc(filePath string) error {
 
 					// Build the first line: bullet + name + Optional + Type + defaults + specified in
 					var firstLine strings.Builder
-					nestedAttrAnchor := toAnchorName(name)
+					// FIX: Use full path anchor for nested attributes to match section headers
+					// currentBlockName is like "routes.simple_route.advanced_options"
+					// name is like "cors_policy"
+					// Result: "routes-simple-route-advanced-options-cors-policy"
+					fullAttrPath := currentBlockName + "." + name
+					nestedAttrAnchor := toAnchorName(strings.ReplaceAll(fullAttrPath, ".", "-"))
 					firstLine.WriteString(fmt.Sprintf("&#x2022; [`%s`](#%s) - Optional %s", name, nestedAttrAnchor, typeStr))
 					if defaultVal != "" {
 						firstLine.WriteString("  " + defaultVal)


### PR DESCRIPTION
## Summary

Fixed broken anchor links in nested property documentation. Property name links (e.g., `cors_policy`) in nested blocks were incorrectly using short anchors (`#cors-policy`) instead of full path anchors (`#routes-simple-route-advanced-options-cors-policy`) that match the H4 section headers.

## Related Issue

Closes #241

## Changes Made

- Modified `tools/transform-docs.go` to build full path anchors from `currentBlockName + "." + name`
- Nested property links now correctly navigate to their corresponding section headers

## Before/After

**Before** (line 6179 in http_loadbalancer.md):
```markdown
&#x2022; [`cors_policy`](#cors-policy) - Optional Block<br>...See [CORS Policy](#routes-simple-route-advanced-options-cors-policy) below.
```
- Property name link: `#cors-policy` ❌ (wrong section)
- "See below" link: `#routes-simple-route-advanced-options-cors-policy` ✅

**After**:
```markdown
&#x2022; [`cors_policy`](#routes-simple-route-advanced-options-cors-policy) - Optional Block<br>...
```
- Both links now point to the correct section ✅

## Testing

- [x] Verified fix with local regeneration
- [x] Confirmed multiple nested properties use correct anchors (cors_policy, csrf_policy, buffer_policy)
- [x] CI/CD will regenerate docs on merge (per CLAUDE.md workflow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)