### PR TITLE
refactor(functions): standardize example naming to follow AzureRM style

### DIFF
--- a/examples/functions/blindfold/function.tf
+++ b/examples/functions/blindfold/function.tf
@@ -7,7 +7,7 @@
 # Example: Encrypt a password for use in origin pool authentication
 locals {
   encrypted_password = provider::f5xc::blindfold(
-    base64encode("my-secret-password"),
+    base64encode("example-secret-password"),
     "production-secrets-policy",
     "shared"
   )

--- a/internal/functions/blindfold.go
+++ b/internal/functions/blindfold.go
@@ -57,7 +57,7 @@ resource "f5xc_http_loadbalancer" "example" {
       blindfold_secret_info {
         location = provider::f5xc::blindfold(
           base64encode(file("${path.module}/private.key")),
-          "my-secret-policy",
+          "example-secret-policy",
           "shared"
         )
       }

--- a/internal/functions/blindfold_file.go
+++ b/internal/functions/blindfold_file.go
@@ -62,7 +62,7 @@ resource "f5xc_http_loadbalancer" "example" {
       blindfold_secret_info {
         location = provider::f5xc::blindfold_file(
           "${path.module}/certs/private.key",
-          "my-secret-policy",
+          "example-secret-policy",
           "shared"
         )
       }


### PR DESCRIPTION
## Summary
- Replace "my-" prefix with "example-" prefix in blindfold function documentation and examples
- Aligns with HashiCorp Terraform Style Guide and AzureRM provider documentation patterns
- Matches existing auto-generated resource examples in this provider

## Related Issue
Closes #246

## Changes Made
| File | Before | After |
|------|--------|-------|
| `internal/functions/blindfold.go` | `"my-secret-policy"` | `"example-secret-policy"` |
| `internal/functions/blindfold_file.go` | `"my-secret-policy"` | `"example-secret-policy"` |
| `examples/functions/blindfold/function.tf` | `"my-secret-password"` | `"example-secret-password"` |

## Testing
- [x] Go build passes
- [x] Changes are limited to documentation/example strings only

## References
- [HashiCorp Terraform Style Guide](https://developer.hashicorp.com/terraform/language/style)
- [AzureRM Provider Documentation Patterns](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_account)

🤖 Generated with [Claude Code](https://claude.com/claude-code)