### PR TITLE
fix(docs): remove redundant Functions subcategory from template

### DIFF
--- a/templates/functions.md.tmpl
+++ b/templates/functions.md.tmpl
@@ -1,6 +1,5 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: "Functions"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---


### PR DESCRIPTION
## Summary

Remove the redundant `subcategory: "Functions"` from the function documentation template to eliminate the nested "Functions → Functions" menu structure in the Terraform Registry.

## Related Issue

Closes #256

## Problem

Currently the Registry sidebar shows:
```
├── Functions              ← Auto-created category for function type
│   └── Functions          ← Redundant subcategory from template
│       ├── blindfold
│       └── blindfold_file
```

## Solution

Remove the `subcategory` field from `templates/functions.md.tmpl`. The Terraform Registry automatically creates a "Functions" category for provider-defined functions, so specifying it explicitly was redundant.

## Expected Result

```
├── Functions
│   ├── blindfold
│   └── blindfold_file
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)