### PR TITLE
fix(ci): remove unsupported negation pattern from paths-ignore

### DIFF
--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -33,8 +33,9 @@ on:
       - main
     paths-ignore:
       - '*.md'
-      - '.github/workflows/*.yml'
-      - '!.github/workflows/on-merge.yml'
+      # Note: Don't ignore workflow files - changes to on-merge.yml itself
+      # should be testable via CI, but won't trigger regeneration anyway
+      # since the detect-changes job filters by actual code changes.
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary
Removes invalid negation pattern from paths-ignore that caused workflow parsing failure.

## Related Issue
Closes #264

## Problem
GitHub Actions `paths-ignore` filter doesn't support negation patterns (`!`).
The pattern `!.github/workflows/on-merge.yml` caused all workflow runs to fail
with "This run likely failed because of a workflow file issue."

## Solution
Removed the invalid negation pattern. Workflow changes will now trigger the
workflow, but the detect-changes job filters by actual code changes so no
unnecessary regeneration will occur.

## Testing
- [x] YAML validates correctly
- [ ] CI passes
- [ ] On Merge workflow runs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)