### PR TITLE
fix(ci): update golangci-lint to v2.x in pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,16 +53,13 @@ repos:
       - id: destroyed-symlinks
 
   # =============================================================================
-  # Go language checks - golangci-lint (validation only, no --fix)
+  # Go language checks - golangci-lint v2.x (validation only, no --fix)
   # =============================================================================
-  - repo: local
+  - repo: https://github.com/golangci/golangci-lint
+    rev: v2.6.2
     hooks:
       - id: golangci-lint
-        name: golangci-lint
-        entry: golangci-lint run --timeout=5m
-        language: system
-        types: [go]
-        pass_filenames: false
+        args: [--timeout=5m]
 
   # =============================================================================
   # Terraform example files validation


### PR DESCRIPTION
## Summary

Update pre-commit configuration to use the official golangci-lint hook instead of relying on system-installed version.

## Related Issue

Closes #270

## Changes Made

- Replace `language: system` hook with official hook from `https://github.com/golangci/golangci-lint`
- Pin to `rev: v2.6.2` for version consistency with `.golangci.yml` (which requires v2.x)

## Version Consistency

| Environment | Version | Status |
|-------------|---------|--------|
| `.golangci.yml` | v2.x config | ✅ |
| GitHub CI (`_build-test.yml`) | `version: latest` (v2.x) | ✅ |
| Pre-commit | v2.6.2 (official hook) | ✅ |

## Testing

- [x] `pre-commit run golangci-lint --all-files` passes
- [x] Local golangci-lint v2.6.0 installed and verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)