### PR TITLE
fix(ci): trigger provider regeneration when generator tools change

### DIFF
--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -181,16 +181,18 @@ jobs:
       run-lint: true
 
   # ===========================================================================
-  # STEP 3: Regenerate provider code (if OpenAPI specs changed - human commits only)
+  # STEP 3: Regenerate provider code (if OpenAPI specs OR generator tools changed - human commits only)
   # ===========================================================================
   regenerate-provider:
     name: Regenerate Provider
     needs: [detect-changes, build-test]
     # Only run for human commits that need provider regeneration
+    # This includes: OpenAPI spec changes OR generator tool changes (to apply bug fixes)
     if: |
       needs.detect-changes.outputs.should-process == 'true' &&
       needs.detect-changes.outputs.is-bot-commit != 'true' &&
-      needs.detect-changes.outputs.specs-changed == 'true'
+      (needs.detect-changes.outputs.specs-changed == 'true' ||
+       needs.detect-changes.outputs.tools-changed == 'true')
     uses: ./.github/workflows/_generate-provider.yml
 
   # ===========================================================================


### PR DESCRIPTION
## Summary

The on-merge workflow was only regenerating provider code when OpenAPI specs changed, but not when the generator tool (`generate-all-schemas.go`) changed. This meant generator bug fixes wouldn't be applied to resource files until the next OpenAPI spec update.

## Related Issue

Relates to #272

## Changes Made

Updated the `regenerate-provider` job condition in `on-merge.yml` to also trigger when `tools-changed == true`:

```yaml
# Before
needs.detect-changes.outputs.specs-changed == 'true'

# After
(needs.detect-changes.outputs.specs-changed == 'true' ||
 needs.detect-changes.outputs.tools-changed == 'true')
```

## Why This Is Needed

1. PR #273 merged generator bug fixes to `tools/generate-all-schemas.go`
2. The on-merge workflow ran but skipped provider regeneration because `specs-changed == false`
3. The workflow failed at PR creation due to missing `regeneration` label (now fixed)
4. Even if that had succeeded, provider code wouldn't have been regenerated

With this fix, any change to tools (including the generator) will trigger provider regeneration, ensuring bug fixes are applied to all 144+ resource files.

## Testing

- [x] Workflow syntax validated locally
- [ ] CI checks will validate build

🤖 Generated with [Claude Code](https://claude.com/claude-code)