### PR TITLE
chore: trigger provider regeneration after bug fixes

### DIFF
--- a/tools/generate-all-schemas.go
+++ b/tools/generate-all-schemas.go
@@ -8,7 +8,7 @@
 //   Changes to this file trigger the generate.yml workflow which regenerates all
 //   provider resources from the latest OpenAPI specifications.
 //
-// Pipeline Verification: 2025-11-25T07:30 - Full regeneration test after workflow fixes #69, #72, #78
+// Pipeline Verification: 2025-11-29T04:40 - Trigger regeneration after bug fixes #272, #273, #274
 //
 // Usage: go run tools/generate-all-schemas.go [--spec-dir=/path/to/specs] [--dry-run]
 //


### PR DESCRIPTION
## Summary

This PR triggers the on-merge workflow's provider regeneration job to apply bug fixes from #272, #273 to all 144+ resource files.

## Related Issue

Relates to #272

## Background

1. PR #273 merged generator bug fixes (`tools/generate-all-schemas.go`)
2. At that time, the on-merge workflow only triggered provider regeneration when OpenAPI specs changed, not when generator tools changed
3. PR #274 fixed the workflow to also trigger on tool changes
4. However, since PR #274 only changed the workflow file (not in `tools/`), it didn't trigger regeneration

This PR updates the pipeline verification timestamp in the generator to trigger the newly-fixed workflow, which will:
- Run `go run tools/generate-all-schemas.go` with the bug fixes
- Regenerate all 144+ resource files with proper nested model structs, ImportState parsing, NOT_FOUND handling, etc.
- Create an auto-regeneration PR with the updated files

## Changes Made

- Updated pipeline verification comment in `tools/generate-all-schemas.go`

## Testing

- [x] CI checks will validate
- [ ] on-merge workflow will regenerate provider code after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)