### PR TITLE
fix: move normalizeAPIURL to provider_helpers.go

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -6,7 +6,6 @@ package provider
 import (
 	"context"
 	"os"
-	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -18,26 +17,6 @@ import (
 
 	"github.com/f5xc/terraform-provider-f5xc/internal/client"
 )
-
-// normalizeAPIURL cleans up the API URL to ensure consistent formatting.
-// It removes trailing slashes and the /api suffix if present, since API paths
-// already include the /api prefix (e.g., /api/web/namespaces).
-func normalizeAPIURL(url string) (string, bool) {
-	original := url
-
-	// Remove trailing slashes
-	url = strings.TrimRight(url, "/")
-
-	// Remove /api suffix (case-insensitive check, preserve original case in removal)
-	if strings.HasSuffix(strings.ToLower(url), "/api") {
-		url = url[:len(url)-4]
-	}
-
-	// Remove any trailing slashes that might have been before /api
-	url = strings.TrimRight(url, "/")
-
-	return url, url != original
-}
 
 // Ensure F5XCProvider satisfies various provider interfaces.
 var _ provider.Provider = &F5XCProvider{}

--- a/internal/provider/provider_helpers.go
+++ b/internal/provider/provider_helpers.go
@@ -1,0 +1,32 @@
+// Copyright (c) F5XC Community
+// SPDX-License-Identifier: MPL-2.0
+
+// provider_helpers.go - Manually maintained helper functions for the provider.
+// This file is NOT auto-generated and contains utility functions used by
+// the provider implementation.
+
+package provider
+
+import (
+	"strings"
+)
+
+// normalizeAPIURL cleans up the API URL to ensure consistent formatting.
+// It removes trailing slashes and the /api suffix if present, since API paths
+// already include the /api prefix (e.g., /api/web/namespaces).
+func normalizeAPIURL(url string) (string, bool) {
+	original := url
+
+	// Remove trailing slashes
+	url = strings.TrimRight(url, "/")
+
+	// Remove /api suffix (case-insensitive check, preserve original case in removal)
+	if strings.HasSuffix(strings.ToLower(url), "/api") {
+		url = url[:len(url)-4]
+	}
+
+	// Remove any trailing slashes that might have been before /api
+	url = strings.TrimRight(url, "/")
+
+	return url, url != original
+}


### PR DESCRIPTION
## Summary
Moves the `normalizeAPIURL` helper function to a separate manually-maintained file to prevent it from being overwritten when the generator regenerates `provider.go`.

## Related Issue
Addresses part of #272 - the CI test failures due to missing `normalizeAPIURL` function after provider regeneration.

## Changes Made
- Created `internal/provider/provider_helpers.go` with the `normalizeAPIURL` function
- Removed `normalizeAPIURL` and the `strings` import from `provider.go` (which is auto-generated)
- The helper file is NOT auto-generated and will be preserved during regeneration

## Why This Fix
When `on-merge.yml` regenerates `provider.go` using `generate-all-schemas.go`, the generator doesn't include the `normalizeAPIURL` function. This caused test failures because `provider_test.go` references this function.

By moving the function to a separate helper file that is NOT auto-generated, it will persist across regeneration cycles.

## Testing
- [x] Build succeeds: `go build -o terraform-provider-f5xc`
- [x] All `TestNormalizeAPIURL` tests pass (10/10 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)