### PR TITLE
chore: trigger provider regeneration after normalizeAPIURL fix

### DIFF
--- a/tools/generate-all-schemas.go
+++ b/tools/generate-all-schemas.go
@@ -8,7 +8,7 @@
 //   Changes to this file trigger the generate.yml workflow which regenerates all
 //   provider resources from the latest OpenAPI specifications.
 //
-// Pipeline Verification: 2025-11-29T04:40 - Trigger regeneration after bug fixes #272, #273, #274
+// Pipeline Verification: 2025-11-29T05:20 - Trigger regeneration after provider_helpers.go fix #277
 //
 // Usage: go run tools/generate-all-schemas.go [--spec-dir=/path/to/specs] [--dry-run]
 //


### PR DESCRIPTION
## Summary
Triggers provider regeneration now that PR #277 added `provider_helpers.go` to preserve the `normalizeAPIURL` function.

## Background
- PR #273: Fixed 6 generator bugs
- PR #274: Fixed workflow to trigger on tool changes  
- PR #275: First attempt to trigger regeneration - **failed** because `normalizeAPIURL` was missing
- PR #277: Added `provider_helpers.go` with `normalizeAPIURL` function
- This PR: Triggers regeneration now that the helper function is preserved

## Expected Behavior
After this PR merges:
1. On-merge workflow runs
2. Detects `tools-changed == 'true'` 
3. Regenerates provider code with all bug fixes from #273
4. Tests pass because `normalizeAPIURL` now lives in `provider_helpers.go`
5. Auto-PR created with regenerated provider code
6. Issue #272 can be closed

## Related Issue
Relates to #272

🤖 Generated with [Claude Code](https://claude.com/claude-code)