### PR TITLE
chore: trigger provider regeneration after sweep_test removal

### DIFF
--- a/tools/generate-all-schemas.go
+++ b/tools/generate-all-schemas.go
@@ -8,7 +8,7 @@
 //   Changes to this file trigger the generate.yml workflow which regenerates all
 //   provider resources from the latest OpenAPI specifications.
 //
-// Pipeline Verification: 2025-11-29T05:20 - Trigger regeneration after provider_helpers.go fix #277
+// Pipeline Verification: 2025-11-29T07:20 - Trigger regeneration after sweep_test.go removal #279
 //
 // Usage: go run tools/generate-all-schemas.go [--spec-dir=/path/to/specs] [--dry-run]
 //


### PR DESCRIPTION
## Summary
Triggers provider regeneration now that `sweep_test.go` has been removed (#279).

## Background
The previous regeneration attempt (PR #278) failed because `sweep_test.go` referenced `ListNamespaces` and `ListHealthchecks` methods that don't exist in the generated client code.

Now that `sweep_test.go` is removed, regeneration should succeed.

## Expected Behavior
After this PR merges:
1. On-merge workflow runs
2. Detects `tools-changed == 'true'`
3. Regenerates provider code with all bug fixes from #273
4. Tests pass (no more sweep_test.go to cause failures)
5. Auto-PR created with regenerated provider code
6. Issue #272 can be closed

## Related Issue
Relates to #272

🤖 Generated with [Claude Code](https://claude.com/claude-code)