### PR TITLE
fix: add proper logging to Create Regeneration PR workflow step

### DIFF
--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -279,16 +279,36 @@ jobs:
       - name: Regenerate provider (if needed)
         if: needs.regenerate-provider.outputs.changed == 'true'
         run: |
+          echo "::group::Generate provider code"
           go run tools/generate-all-schemas.go --spec-dir=docs/specifications/api
-          # Retry go mod tidy
+          echo "::endgroup::"
+
+          # Retry logic for go mod operations (network-dependent)
           max_attempts=3
           attempt=1
           while [ $attempt -le $max_attempts ]; do
-            if go mod tidy; then break; fi
+            echo "::group::go mod tidy - Attempt $attempt of $max_attempts"
+            if go mod tidy; then
+              echo "::endgroup::"
+              break
+            fi
+            echo "::endgroup::"
             attempt=$((attempt + 1))
-            [ $attempt -le $max_attempts ] && sleep $((2 ** attempt * 5))
+            if [ $attempt -le $max_attempts ]; then
+              sleep_time=$((2 ** attempt * 5))
+              echo "::warning::go mod tidy failed, retrying in ${sleep_time}s..."
+              sleep $sleep_time
+            fi
           done
-          [ $attempt -gt $max_attempts ] && exit 1
+          if [ $attempt -gt $max_attempts ]; then
+            echo "::error::go mod tidy failed after $max_attempts attempts"
+            exit 1
+          fi
+
+          # Verify build succeeds
+          echo "::group::Verify build"
+          go build -v .
+          echo "::endgroup::"
 
       - name: Regenerate documentation (if needed)
         if: needs.regenerate-docs.outputs.changed == 'true'

--- a/tools/generate-all-schemas.go
+++ b/tools/generate-all-schemas.go
@@ -8,7 +8,7 @@
 //   Changes to this file trigger the generate.yml workflow which regenerates all
 //   provider resources from the latest OpenAPI specifications.
 //
-// Pipeline Verification: 2025-11-29T07:20 - Trigger regeneration after sweep_test.go removal #279
+// Pipeline Verification: 2025-11-29T08:15 - Add logging to Create Regeneration PR workflow #281
 //
 // Usage: go run tools/generate-all-schemas.go [--spec-dir=/path/to/specs] [--dry-run]
 //


### PR DESCRIPTION
## Summary
Add proper logging to the "Create Regeneration PR" job in on-merge.yml to debug silent failures at the go mod tidy step.

## Related Issue
Closes #281

## Changes Made
- Add `::group::` logging for generator execution
- Add proper retry logging for `go mod tidy` to match `_generate-provider.yml` pattern
- Add build verification step after generation to catch compile errors early
- Update generator timestamp to trigger regeneration

## Testing
- [x] Workflow syntax validated
- [ ] Waiting for CI to run on this PR
- [ ] Manual testing of workflow changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)