### PR TITLE
fix(generator): resolve state drift for nested empty blocks

### DIFF
--- a/tools/generate-all-schemas.go
+++ b/tools/generate-all-schemas.go
@@ -2167,8 +2167,9 @@ func renderSpecUnmarshalCode(attrs []TerraformAttribute, indent string, resource
 				// These should be preserved from prior state during normal Read, and populated on Import
 				if nestedAttr.IsBlock && nestedAttr.NestedBlockType == "single" && len(nestedAttr.NestedAttributes) == 0 {
 					sb.WriteString(fmt.Sprintf("%s\t\t%s: func() *%sEmptyModel {\n", indent, nestedFieldName, resourceTitleCase))
-					sb.WriteString(fmt.Sprintf("%s\t\t\tif !isImport && data.%s != nil && data.%s.%s != nil {\n", indent, fieldName, fieldName, nestedFieldName))
-					sb.WriteString(fmt.Sprintf("%s\t\t\t\t// Normal Read: preserve existing state value\n", indent))
+					sb.WriteString(fmt.Sprintf("%s\t\t\tif !isImport && data.%s != nil {\n", indent, fieldName))
+					sb.WriteString(fmt.Sprintf("%s\t\t\t\t// Normal Read: preserve existing state value (even if nil)\n", indent))
+					sb.WriteString(fmt.Sprintf("%s\t\t\t\t// This prevents API returning empty objects from overwriting user's 'not configured' intent\n", indent))
 					sb.WriteString(fmt.Sprintf("%s\t\t\t\treturn data.%s.%s\n", indent, fieldName, nestedFieldName))
 					sb.WriteString(fmt.Sprintf("%s\t\t\t}\n", indent))
 					sb.WriteString(fmt.Sprintf("%s\t\t\t// Import case: read from API\n", indent))


### PR DESCRIPTION
## Summary

Fixed state drift issues in the generator for nested `SingleNestedBlocks`, particularly empty blocks (presence markers) within other blocks.

## Related Issue

Related to #258 (keeping issue open for continued test development)

## Changes Made

### Commit 1: Handle nested single blocks in Read function
- Fixed compilation errors with unused `nestedBlockData` variable
- Added pre-check for usable attributes before generating variable name

### Commit 2: Preserve nil nested empty blocks during normal Read
- Fixed state drift for empty `SingleNestedBlocks` within other `SingleNestedBlocks`
- Example: `headers {}` inside `http_health_check {}` was causing drift when user didn't specify it
- Changed generator logic to always preserve prior state (even if nil) during normal Read
- API data is only read during Import operations

## Root Cause Analysis

When user config had `http_health_check { path = "/health" }` without specifying `headers {}`:
1. During Create, `Headers` was nil (correct - user didn't specify)
2. During Read, condition checked: `if !isImport && parent != nil && nested != nil`
3. Since nested was nil, it fell through to reading from API
4. API returned `headers: {}` empty object
5. State was set to `&EmptyModel{}`, causing drift with user's "not configured" intent

## Fix Applied

Changed generator condition from:
```go
if !isImport && data.Parent != nil && data.Parent.Nested != nil {
```
to:
```go
if !isImport && data.Parent != nil {
```

This preserves prior state (even if nil) during normal Read, respecting user's intent.

## Testing

All tests pass:
- ✅ Healthcheck tests (13/13)
- ✅ ServicePolicy tests (6/6)
- ✅ AppFirewall tests (6/6)
- ✅ AlertReceiver tests (14/14)
- ✅ OriginPool tests (5/5)
- ✅ NetworkConnector tests (15/15)
- ✅ Comprehensive suite (25/25)

🤖 Generated with [Claude Code](https://claude.com/claude-code)