### PR TITLE
fix(generator): resolve state drift for nested empty blocks

### DIFF
--- a/internal/provider/geo_location_set_resource_test.go
+++ b/internal/provider/geo_location_set_resource_test.go
@@ -24,7 +24,7 @@ import (
 // Uses "system" namespace to avoid creating test namespaces that can't be deleted
 // =============================================================================
 func TestAccGeoLocationSetResource_basic(t *testing.T) {
-	t.Skip("Skipping: geo_location_set API endpoint not available in staging environment (returns 404)")
+	// Removed outdated skip - API endpoint is now available in staging
 	acctest.SkipIfNotAccTest(t)
 	acctest.PreCheck(t)
 

--- a/tools/generate-all-schemas.go
+++ b/tools/generate-all-schemas.go
@@ -1776,6 +1776,25 @@ func renderSpecMarshalCode(attrs []TerraformAttribute, indent string) string {
 					sb.WriteString(fmt.Sprintf("%s\tif !data.%s.%s.IsNull() && !data.%s.%s.IsUnknown() {\n", indent, fieldName, nestedFieldName, fieldName, nestedFieldName))
 					sb.WriteString(fmt.Sprintf("%s\t\t%sMap[\"%s\"] = data.%s.%s.ValueBool()\n", indent, tfsdkName, nestedTfsdkName, fieldName, nestedFieldName))
 					sb.WriteString(fmt.Sprintf("%s\t}\n", indent))
+				case "list":
+					// Handle list types (e.g., expressions: types.List) inside single nested blocks
+					if nestedAttr.ElementType == "string" {
+						sb.WriteString(fmt.Sprintf("%s\tif !data.%s.%s.IsNull() && !data.%s.%s.IsUnknown() {\n", indent, fieldName, nestedFieldName, fieldName, nestedFieldName))
+						sb.WriteString(fmt.Sprintf("%s\t\tvar %sItems []string\n", indent, nestedTfsdkName))
+						sb.WriteString(fmt.Sprintf("%s\t\tdiags := data.%s.%s.ElementsAs(ctx, &%sItems, false)\n", indent, fieldName, nestedFieldName, nestedTfsdkName))
+						sb.WriteString(fmt.Sprintf("%s\t\tif !diags.HasError() {\n", indent))
+						sb.WriteString(fmt.Sprintf("%s\t\t\t%sMap[\"%s\"] = %sItems\n", indent, tfsdkName, nestedTfsdkName, nestedTfsdkName))
+						sb.WriteString(fmt.Sprintf("%s\t\t}\n", indent))
+						sb.WriteString(fmt.Sprintf("%s\t}\n", indent))
+					} else if nestedAttr.ElementType == "int64" {
+						sb.WriteString(fmt.Sprintf("%s\tif !data.%s.%s.IsNull() && !data.%s.%s.IsUnknown() {\n", indent, fieldName, nestedFieldName, fieldName, nestedFieldName))
+						sb.WriteString(fmt.Sprintf("%s\t\tvar %sItems []int64\n", indent, nestedTfsdkName))
+						sb.WriteString(fmt.Sprintf("%s\t\tdiags := data.%s.%s.ElementsAs(ctx, &%sItems, false)\n", indent, fieldName, nestedFieldName, nestedTfsdkName))
+						sb.WriteString(fmt.Sprintf("%s\t\tif !diags.HasError() {\n", indent))
+						sb.WriteString(fmt.Sprintf("%s\t\t\t%sMap[\"%s\"] = %sItems\n", indent, tfsdkName, nestedTfsdkName, nestedTfsdkName))
+						sb.WriteString(fmt.Sprintf("%s\t\t}\n", indent))
+						sb.WriteString(fmt.Sprintf("%s\t}\n", indent))
+					}
 				}
 			}
 			sb.WriteString(fmt.Sprintf("%s\tapiResource.Spec[\"%s\"] = %sMap\n", indent, jsonName, tfsdkName))


### PR DESCRIPTION
## Summary

Add list type handling for single nested block attributes in `renderSpecMarshalCode` function. This fixes state drift issues where list attributes (e.g., `expressions` in `custom_geo_location_selector`) were not being marshaled to the API during Create/Update operations.

## Related Issue
Related to #258 (keeping issue open for continued work)

## Changes Made

### Generator Enhancement (`tools/generate-all-schemas.go`)
- Added `case "list"` handling in the nested attribute switch statement
- Supports both `string[]` and `int64[]` element types within single nested blocks
- Fix applies to all resources with similar nested block patterns (approximately 30+ resources affected)

### Test Updates (`internal/provider/geo_location_set_resource_test.go`)
- Removed outdated `t.Skip` - API endpoint is now available in staging environment
- All 14 geo_location_set tests now pass

## Testing

### Verified Tests Pass
- All 14 geo_location_set tests ✅
- Namespace tests ✅
- IP Prefix Set tests ✅
- Healthcheck tests ✅
- Data Group tests ✅
- User Identification tests ✅

### Previously Failing Test Now Passes
`TestAccGeoLocationSetResource_customSelector` - This test was failing due to state drift where the `expressions` list in `custom_geo_location_selector` was not being sent to the API.

## Test plan
- [x] Generator compiles successfully
- [x] Provider builds without errors
- [x] All geo_location_set tests pass (14 tests)
- [x] Broader regression tests pass
- [x] CI/CD will regenerate all resources with the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)