### PR TITLE
fix(pre-commit): align golangci-lint scope with CI workflow

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,12 +54,14 @@ repos:
 
   # =============================================================================
   # Go language checks - golangci-lint v2.x (validation only, no --fix)
+  # Runs on SAME paths as CI to ensure consistency: ./internal/... .
   # =============================================================================
   - repo: https://github.com/golangci/golangci-lint
     rev: v2.6.2
     hooks:
       - id: golangci-lint
-        args: [--timeout=5m]
+        args: [--timeout=5m, ./internal/..., .]
+        pass_filenames: false
 
   # =============================================================================
   # Terraform example files validation

--- a/scripts/lint-generated-preview.sh
+++ b/scripts/lint-generated-preview.sh
@@ -335,7 +335,8 @@ if [ "$LINT_GO" = true ]; then
     echo "🔍 Running golangci-lint on generated Go files..."
     echo ""
 
-    if ! GO_LINT_OUTPUT=$(golangci-lint run --timeout=5m ./internal/provider/... 2>&1); then
+    # Lint same paths as CI: ./internal/... .
+    if ! GO_LINT_OUTPUT=$(golangci-lint run --timeout=5m ./internal/... . 2>&1); then
         GO_LINT_SUCCESS=false
     fi
 


### PR DESCRIPTION
## Summary

Pre-commit hooks were running golangci-lint with different scope than CI, allowing lint errors to slip through locally but fail in GitHub Actions.

## Related Issue

Closes #319

## Root Cause

| Component | Before (inconsistent) | After (consistent) |
|-----------|----------------------|-------------------|
| Pre-commit golangci-lint | Staged files only | `./internal/... .` |
| lint-generated-preview.sh | `./internal/provider/...` | `./internal/... .` |
| CI workflow | `./internal/... .` | `./internal/... .` ✓ |

The golangci-lint pre-commit hook by default only lints staged files, while CI runs on the entire codebase. This meant errors in `internal/acctest/certificates.go` were caught by CI but not locally.

## Changes Made

1. **`.pre-commit-config.yaml`**: Added explicit paths `./internal/... .` and `pass_filenames: false`
2. **`scripts/lint-generated-preview.sh`**: Updated to lint `./internal/... .` instead of just `./internal/provider/...`

## Testing

- [x] `pre-commit run golangci-lint --all-files` passes
- [x] Verified scope matches CI workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)