### PR TITLE
fix(naming): remove ASN from uppercase acronyms for backward compatibility

### DIFF
--- a/tools/pkg/naming/acronyms.go
+++ b/tools/pkg/naming/acronyms.go
@@ -30,7 +30,9 @@ var UppercaseAcronyms = map[string]bool{
 	"SLA": true, "RPO": true, "RTO": true, "VPC": true, "VNET": true,
 	"TGW": true, "IKE": true, "ID": true, "SLI": true, "S2S": true,
 	// F5/Volterra specific
-	"RE": true, "CE": true, "SPO": true, "SMG": true, "ASN": true,
+	// Note: ASN is intentionally NOT included to maintain backward compatibility
+	// with existing code that uses "Asn" in type names (e.g., BGPAsnSet)
+	"RE": true, "CE": true, "SPO": true, "SMG": true,
 	"APM": true, "PII": true, "OIDC": true, "K8S": true,
 }
 

--- a/tools/pkg/naming/naming_test.go
+++ b/tools/pkg/naming/naming_test.go
@@ -19,7 +19,7 @@ func TestToTitleCase(t *testing.T) {
 		{"mtls_certificate", "mTLS Certificate"},
 		{"oauth_provider", "OAuth Provider"},
 		{"ipv4_address", "IPv4 Address"},
-		{"bgp_asn_set", "BGP ASN Set"},
+		{"bgp_asn_set", "BGP Asn Set"}, // ASN intentionally not uppercased for backward compatibility
 		{"k8s_cluster", "K8S Cluster"},
 	}
 


### PR DESCRIPTION
## Summary

Fix the on-merge workflow failure caused by the naming package treating ASN as an uppercase acronym.

## Related Issue

Closes #337

## Problem

The ASN acronym was added to the `tools/pkg/naming/acronyms.go` uppercase acronyms list. This caused the code generator to produce method names like `GetBGPASNSet` instead of `GetBGPAsnSet`, breaking compatibility with:
- The manually-maintained `internal/acctest/acctest.go` which used the original method names
- The currently committed client types which used the original method names

## Root Cause

When the naming package was added/updated, ASN was included as an uppercase acronym. However, the existing generated files (client types, resource files) were never regenerated in the same PR to use the new convention, creating a mismatch.

## Solution

Remove ASN from the uppercase acronyms list to maintain backward compatibility with existing code. This ensures:
1. The generator continues to produce `BGPAsnSet` (not `BGPASNSet`)
2. No need to update manually-maintained files like acctest.go
3. Future regenerations will be compatible with current code

## Changes Made

- `tools/pkg/naming/acronyms.go`: Remove ASN from uppercase acronyms list, add comment explaining why
- `tools/pkg/naming/naming_test.go`: Update test expectation for `bgp_asn_set`

## Testing

- [x] All naming package tests pass
- [x] All internal tests pass
- [x] Build succeeds
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)