### PR TITLE
docs(guides): add Blindfold Secret Management guide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,17 @@ claudedocs/
 
 # Local temporary files
 tmp/
+
+# Certificates and secrets (never commit real credentials)
+# The .gitkeep placeholders in certs/ directories are allowed
+*.pem
+*.key
+!.gitkeep
+*.p12
+*.pfx
+*.crt
+*.cer
+*.csr
+terraform.tfvars
+*-secret.txt
+*-credentials.json

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -134,6 +134,24 @@
     }
   ],
   "results": {
+    "docs/index.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/index.md",
+        "hashed_secret": "ce96fff993090da7bf7842fdecba16e112c336f9",
+        "is_verified": false,
+        "line_number": 60
+      }
+    ],
+    "docs/resources/cdn_loadbalancer.md": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/resources/cdn_loadbalancer.md",
+        "hashed_secret": "0c5aa2932d2cec0a3f054674b7124b6b6af51cf5",
+        "is_verified": false,
+        "line_number": 1817
+      }
+    ],
     "docs/resources/cloud_credentials.md": [
       {
         "type": "AWS Access Key",
@@ -141,6 +159,33 @@
         "hashed_secret": "25910f981e85ca04baf359199dd0bd4a3ae738b6",
         "is_verified": false,
         "line_number": 37
+      }
+    ],
+    "docs/resources/http_loadbalancer.md": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/resources/http_loadbalancer.md",
+        "hashed_secret": "0c5aa2932d2cec0a3f054674b7124b6b6af51cf5",
+        "is_verified": false,
+        "line_number": 2839
+      }
+    ],
+    "docs/resources/virtual_host.md": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/resources/virtual_host.md",
+        "hashed_secret": "b63a1e8efe59d9dfa139cdcee1c397b176d181de",
+        "is_verified": false,
+        "line_number": 100
+      }
+    ],
+    "examples/provider/provider.tf": [
+      {
+        "type": "Secret Keyword",
+        "filename": "examples/provider/provider.tf",
+        "hashed_secret": "ce96fff993090da7bf7842fdecba16e112c336f9",
+        "is_verified": false,
+        "line_number": 27
       }
     ],
     "examples/resources/f5xc_cloud_credentials/resource.tf": [
@@ -152,15 +197,539 @@
         "line_number": 21
       }
     ],
+    "internal/acctest/acctest.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/acctest/acctest.go",
+        "hashed_secret": "a5b0613ec0f3047c546641acfbb384d35561ebf7",
+        "is_verified": false,
+        "line_number": 46
+      }
+    ],
+    "internal/client/client_test.go": [
+      {
+        "type": "Private Key",
+        "filename": "internal/client/client_test.go",
+        "hashed_secret": "be4fc4886bd949b369d5e092eb87494f12e57e5b",
+        "is_verified": false,
+        "line_number": 538
+      }
+    ],
+    "internal/mocks/fixtures.go": [
+      {
+        "type": "AWS Access Key",
+        "filename": "internal/mocks/fixtures.go",
+        "hashed_secret": "25910f981e85ca04baf359199dd0bd4a3ae738b6",
+        "is_verified": false,
+        "line_number": 261
+      }
+    ],
+    "internal/provider/alert_receiver_resource.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/alert_receiver_resource.go",
+        "hashed_secret": "44e17306b837162269a410204daaa5ecee4ec22c",
+        "is_verified": false,
+        "line_number": 916
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/alert_receiver_resource.go",
+        "hashed_secret": "810dde83fa912ef604289c8c8295cbb34a91146e",
+        "is_verified": false,
+        "line_number": 918
+      }
+    ],
+    "internal/provider/api_crawler_resource.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/api_crawler_resource.go",
+        "hashed_secret": "44e17306b837162269a410204daaa5ecee4ec22c",
+        "is_verified": false,
+        "line_number": 374
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/api_crawler_resource.go",
+        "hashed_secret": "f42cc677325ae1dc04d0769b926dd555c068202e",
+        "is_verified": false,
+        "line_number": 376
+      }
+    ],
+    "internal/provider/authentication_resource.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/authentication_resource.go",
+        "hashed_secret": "44e17306b837162269a410204daaa5ecee4ec22c",
+        "is_verified": false,
+        "line_number": 569
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/authentication_resource.go",
+        "hashed_secret": "f5a1ce4a170ef6b8fa88e87844068fb390975e58",
+        "is_verified": false,
+        "line_number": 571
+      }
+    ],
+    "internal/provider/aws_tgw_site_resource.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/aws_tgw_site_resource.go",
+        "hashed_secret": "44e17306b837162269a410204daaa5ecee4ec22c",
+        "is_verified": false,
+        "line_number": 1956
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/aws_tgw_site_resource.go",
+        "hashed_secret": "c6b6b2f434bbaf26904ac693b214d9ac7431275b",
+        "is_verified": false,
+        "line_number": 1958
+      }
+    ],
+    "internal/provider/aws_vpc_site_resource.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/aws_vpc_site_resource.go",
+        "hashed_secret": "44e17306b837162269a410204daaa5ecee4ec22c",
+        "is_verified": false,
+        "line_number": 2662
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/aws_vpc_site_resource.go",
+        "hashed_secret": "73a593129139937dfc5f0aa05ff34e7485392e68",
+        "is_verified": false,
+        "line_number": 2675
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/aws_vpc_site_resource.go",
+        "hashed_secret": "78ad2b7dc424aa4c8c55ff71314194dddc4bfdd5",
+        "is_verified": false,
+        "line_number": 2685
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/aws_vpc_site_resource.go",
+        "hashed_secret": "9a12fa7df86d3f41ee92120df1d038004f0408e4",
+        "is_verified": false,
+        "line_number": 2687
+      }
+    ],
+    "internal/provider/azure_vnet_site_resource.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/azure_vnet_site_resource.go",
+        "hashed_secret": "44e17306b837162269a410204daaa5ecee4ec22c",
+        "is_verified": false,
+        "line_number": 4862
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/azure_vnet_site_resource.go",
+        "hashed_secret": "73a593129139937dfc5f0aa05ff34e7485392e68",
+        "is_verified": false,
+        "line_number": 4875
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/azure_vnet_site_resource.go",
+        "hashed_secret": "78ad2b7dc424aa4c8c55ff71314194dddc4bfdd5",
+        "is_verified": false,
+        "line_number": 4885
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/azure_vnet_site_resource.go",
+        "hashed_secret": "9a12fa7df86d3f41ee92120df1d038004f0408e4",
+        "is_verified": false,
+        "line_number": 4887
+      }
+    ],
+    "internal/provider/cdn_loadbalancer_resource.go": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "internal/provider/cdn_loadbalancer_resource.go",
+        "hashed_secret": "0c5aa2932d2cec0a3f054674b7124b6b6af51cf5",
+        "is_verified": false,
+        "line_number": 5016
+      }
+    ],
+    "internal/provider/certificate_resource.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/certificate_resource.go",
+        "hashed_secret": "44e17306b837162269a410204daaa5ecee4ec22c",
+        "is_verified": false,
+        "line_number": 416
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/certificate_resource.go",
+        "hashed_secret": "73a593129139937dfc5f0aa05ff34e7485392e68",
+        "is_verified": false,
+        "line_number": 429
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/certificate_resource.go",
+        "hashed_secret": "78ad2b7dc424aa4c8c55ff71314194dddc4bfdd5",
+        "is_verified": false,
+        "line_number": 439
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/certificate_resource.go",
+        "hashed_secret": "349cb608cf7819b58f593d76831138248a53e692",
+        "is_verified": false,
+        "line_number": 441
+      }
+    ],
+    "internal/provider/cloud_credentials_resource.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/cloud_credentials_resource.go",
+        "hashed_secret": "44e17306b837162269a410204daaa5ecee4ec22c",
+        "is_verified": false,
+        "line_number": 653
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/cloud_credentials_resource.go",
+        "hashed_secret": "c7d97602c6d816d8b4d1a46cb8f15f8db37c6113",
+        "is_verified": false,
+        "line_number": 660
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/cloud_credentials_resource.go",
+        "hashed_secret": "89af4295942e05c18cb9c53626672fcae9f2d25c",
+        "is_verified": false,
+        "line_number": 662
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/cloud_credentials_resource.go",
+        "hashed_secret": "f5a1ce4a170ef6b8fa88e87844068fb390975e58",
+        "is_verified": false,
+        "line_number": 671
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/cloud_credentials_resource.go",
+        "hashed_secret": "a12e3075ad2723519dc300eb5ac034245422c886",
+        "is_verified": false,
+        "line_number": 679
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/cloud_credentials_resource.go",
+        "hashed_secret": "e9421639eb11c95931528f95c7d51f5272c740a3",
+        "is_verified": false,
+        "line_number": 691
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/cloud_credentials_resource.go",
+        "hashed_secret": "893c5bdd17654597e159a83132ad0a9361cc8f1b",
+        "is_verified": false,
+        "line_number": 795
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/cloud_credentials_resource.go",
+        "hashed_secret": "43259ee56c70a675a49ad20df106e0429ba3e79f",
+        "is_verified": false,
+        "line_number": 816
+      }
+    ],
+    "internal/provider/cminstance_resource.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/cminstance_resource.go",
+        "hashed_secret": "44e17306b837162269a410204daaa5ecee4ec22c",
+        "is_verified": false,
+        "line_number": 421
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/cminstance_resource.go",
+        "hashed_secret": "73a593129139937dfc5f0aa05ff34e7485392e68",
+        "is_verified": false,
+        "line_number": 432
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/cminstance_resource.go",
+        "hashed_secret": "78ad2b7dc424aa4c8c55ff71314194dddc4bfdd5",
+        "is_verified": false,
+        "line_number": 442
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/cminstance_resource.go",
+        "hashed_secret": "40667c963954878f32e63b0d9f28d5c92fe25edf",
+        "is_verified": false,
+        "line_number": 478
+      }
+    ],
+    "internal/provider/container_registry_resource.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/container_registry_resource.go",
+        "hashed_secret": "44e17306b837162269a410204daaa5ecee4ec22c",
+        "is_verified": false,
+        "line_number": 356
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/container_registry_resource.go",
+        "hashed_secret": "73a593129139937dfc5f0aa05ff34e7485392e68",
+        "is_verified": false,
+        "line_number": 369
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/container_registry_resource.go",
+        "hashed_secret": "78ad2b7dc424aa4c8c55ff71314194dddc4bfdd5",
+        "is_verified": false,
+        "line_number": 379
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/container_registry_resource.go",
+        "hashed_secret": "40667c963954878f32e63b0d9f28d5c92fe25edf",
+        "is_verified": false,
+        "line_number": 381
+      }
+    ],
+    "internal/provider/dns_zone_resource.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/dns_zone_resource.go",
+        "hashed_secret": "44e17306b837162269a410204daaa5ecee4ec22c",
+        "is_verified": false,
+        "line_number": 362
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/dns_zone_resource.go",
+        "hashed_secret": "73a593129139937dfc5f0aa05ff34e7485392e68",
+        "is_verified": false,
+        "line_number": 373
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/dns_zone_resource.go",
+        "hashed_secret": "78ad2b7dc424aa4c8c55ff71314194dddc4bfdd5",
+        "is_verified": false,
+        "line_number": 383
+      }
+    ],
+    "internal/provider/gcp_vpc_site_resource.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/gcp_vpc_site_resource.go",
+        "hashed_secret": "44e17306b837162269a410204daaa5ecee4ec22c",
+        "is_verified": false,
+        "line_number": 2448
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/gcp_vpc_site_resource.go",
+        "hashed_secret": "73a593129139937dfc5f0aa05ff34e7485392e68",
+        "is_verified": false,
+        "line_number": 2461
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/gcp_vpc_site_resource.go",
+        "hashed_secret": "78ad2b7dc424aa4c8c55ff71314194dddc4bfdd5",
+        "is_verified": false,
+        "line_number": 2471
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/gcp_vpc_site_resource.go",
+        "hashed_secret": "9a12fa7df86d3f41ee92120df1d038004f0408e4",
+        "is_verified": false,
+        "line_number": 2473
+      }
+    ],
+    "internal/provider/global_log_receiver_resource.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/global_log_receiver_resource.go",
+        "hashed_secret": "44e17306b837162269a410204daaa5ecee4ec22c",
+        "is_verified": false,
+        "line_number": 2440
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/global_log_receiver_resource.go",
+        "hashed_secret": "f9ff1133ff9fd4f62bc6572e01e0acb75a6be1bc",
+        "is_verified": false,
+        "line_number": 2442
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/global_log_receiver_resource.go",
+        "hashed_secret": "810dde83fa912ef604289c8c8295cbb34a91146e",
+        "is_verified": false,
+        "line_number": 2603
+      }
+    ],
+    "internal/provider/http_loadbalancer_resource.go": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "internal/provider/http_loadbalancer_resource.go",
+        "hashed_secret": "0c5aa2932d2cec0a3f054674b7124b6b6af51cf5",
+        "is_verified": false,
+        "line_number": 8456
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/http_loadbalancer_resource.go",
+        "hashed_secret": "44e17306b837162269a410204daaa5ecee4ec22c",
+        "is_verified": false,
+        "line_number": 16674
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/http_loadbalancer_resource.go",
+        "hashed_secret": "064b2503403a6a36ab3f02c9d12471a90531ec58",
+        "is_verified": false,
+        "line_number": 16676
+      }
+    ],
+    "internal/provider/infraprotect_tunnel_resource.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/infraprotect_tunnel_resource.go",
+        "hashed_secret": "44e17306b837162269a410204daaa5ecee4ec22c",
+        "is_verified": false,
+        "line_number": 567
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/infraprotect_tunnel_resource.go",
+        "hashed_secret": "d55ebadb21cb0a7523e3e52585262e0ecd0038e6",
+        "is_verified": false,
+        "line_number": 572
+      }
+    ],
+    "internal/provider/nfv_service_resource.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/nfv_service_resource.go",
+        "hashed_secret": "44e17306b837162269a410204daaa5ecee4ec22c",
+        "is_verified": false,
+        "line_number": 2164
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/nfv_service_resource.go",
+        "hashed_secret": "c6b6b2f434bbaf26904ac693b214d9ac7431275b",
+        "is_verified": false,
+        "line_number": 2166
+      }
+    ],
+    "internal/provider/securemesh_site_v2_resource.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/securemesh_site_v2_resource.go",
+        "hashed_secret": "44e17306b837162269a410204daaa5ecee4ec22c",
+        "is_verified": false,
+        "line_number": 6240
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/securemesh_site_v2_resource.go",
+        "hashed_secret": "c6b6b2f434bbaf26904ac693b214d9ac7431275b",
+        "is_verified": false,
+        "line_number": 6242
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/securemesh_site_v2_resource.go",
+        "hashed_secret": "e9421639eb11c95931528f95c7d51f5272c740a3",
+        "is_verified": false,
+        "line_number": 6311
+      }
+    ],
+    "internal/provider/tenant_configuration_resource.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/tenant_configuration_resource.go",
+        "hashed_secret": "44e17306b837162269a410204daaa5ecee4ec22c",
+        "is_verified": false,
+        "line_number": 367
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/tenant_configuration_resource.go",
+        "hashed_secret": "bd8ef007b37592ab4aa99488242cb787ac27402a",
+        "is_verified": false,
+        "line_number": 393
+      }
+    ],
+    "internal/provider/virtual_host_resource.go": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "internal/provider/virtual_host_resource.go",
+        "hashed_secret": "b63a1e8efe59d9dfa139cdcee1c397b176d181de",
+        "is_verified": false,
+        "line_number": 1079
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/virtual_host_resource.go",
+        "hashed_secret": "44e17306b837162269a410204daaa5ecee4ec22c",
+        "is_verified": false,
+        "line_number": 2465
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/virtual_host_resource.go",
+        "hashed_secret": "0b53e5f72acb76f13bd31cad7118195e9a238c9c",
+        "is_verified": false,
+        "line_number": 2478
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/virtual_host_resource.go",
+        "hashed_secret": "0879e308bea9b00ca8b94423cac4385d22887479",
+        "is_verified": false,
+        "line_number": 2488
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/virtual_host_resource.go",
+        "hashed_secret": "1c433ad60d60a9d70e6d59fc15830fd0495b4afd",
+        "is_verified": false,
+        "line_number": 2490
+      }
+    ],
+    "templates/index.md.tmpl": [
+      {
+        "type": "Secret Keyword",
+        "filename": "templates/index.md.tmpl",
+        "hashed_secret": "ce96fff993090da7bf7842fdecba16e112c336f9",
+        "is_verified": false,
+        "line_number": 94
+      }
+    ],
     "tools/generate-examples.go": [
       {
         "type": "AWS Access Key",
         "filename": "tools/generate-examples.go",
         "hashed_secret": "25910f981e85ca04baf359199dd0bd4a3ae738b6",
         "is_verified": false,
-        "line_number": 445
+        "line_number": 682
       }
     ]
   },
-  "generated_at": "2025-11-23T05:47:09Z"
+  "generated_at": "2025-12-02T19:42:30Z"
 }

--- a/examples/guides/blindfold/README.md
+++ b/examples/guides/blindfold/README.md
@@ -1,0 +1,62 @@
+# Blindfold Secret Management Guide
+
+This example demonstrates how to use F5XC Blindfold functions to securely encrypt secrets for use with F5 Distributed Cloud resources.
+
+## Quick Start
+
+### Prerequisites
+
+- Terraform >= 1.8
+- F5 Distributed Cloud account
+- API credentials (token or P12 certificate)
+
+### Setup
+
+1. **Clone the repository:**
+   ```bash
+   git clone https://github.com/robinmordasiewicz/terraform-provider-f5xc.git
+   cd terraform-provider-f5xc/examples/guides/blindfold
+   ```
+
+2. **Configure authentication:**
+   ```bash
+   export F5XC_API_URL="https://your-tenant.console.ves.volterra.io/api"
+   export F5XC_API_TOKEN="your-api-token"
+   ```
+
+3. **Copy and edit the configuration:**
+   ```bash
+   cp terraform.tfvars.example terraform.tfvars
+   # Edit terraform.tfvars with your values
+   ```
+
+4. **Deploy:**
+   ```bash
+   terraform init
+   terraform plan
+   terraform apply
+   ```
+
+## Use Cases
+
+| Example | Description | Enable Flag |
+|---------|-------------|-------------|
+| TLS Certificate | Encrypt private keys for certificates | `enable_certificate_example` |
+| AWS Credentials | Encrypt AWS secret access keys | `enable_aws_credentials_example` |
+| Azure Credentials | Encrypt Azure client secrets | `enable_azure_credentials_example` |
+| GCP Credentials | Encrypt GCP service account files | `enable_gcp_credentials_example` |
+| Container Registry | Encrypt registry passwords | `enable_container_registry_example` |
+
+## Security
+
+All secrets are encrypted locally using RSA-OAEP with SHA-256. The plaintext never leaves your machine unencrypted.
+
+## Clean Up
+
+```bash
+terraform destroy
+```
+
+## More Information
+
+See the full [Blindfold Secret Management Guide](../../../docs/guides/blindfold.md) for detailed documentation.

--- a/examples/guides/blindfold/certs/.gitkeep
+++ b/examples/guides/blindfold/certs/.gitkeep
@@ -1,0 +1,8 @@
+# Placeholder for certificate files
+# Place your server.crt and server.key files here for the certificate example.
+#
+# Generate self-signed certificates for testing:
+#   openssl req -x509 -newkey rsa:2048 -keyout server.key -out server.crt \
+#     -days 365 -nodes -subj "/CN=example.com"
+#
+# IMPORTANT: Do not commit actual certificate/key files to version control!

--- a/examples/guides/blindfold/main.tf
+++ b/examples/guides/blindfold/main.tf
@@ -1,0 +1,192 @@
+# Blindfold Secret Management Guide Examples
+# This file demonstrates all common use cases for F5XC blindfold encryption.
+#
+# IMPORTANT: These examples use toggle variables to enable/disable each use case.
+# Set the appropriate enable_* variable to true for the use case you want to test.
+
+terraform {
+  required_version = ">= 1.8"
+  required_providers {
+    f5xc = {
+      source = "robinmordasiewicz/f5xc"
+    }
+  }
+}
+
+provider "f5xc" {
+  # Authentication configured via environment variables:
+  # - F5XC_API_URL (required)
+  # - F5XC_API_TOKEN (token auth) OR
+  # - F5XC_API_P12_FILE + F5XC_P12_PASSWORD (P12 cert auth)
+}
+
+# -----------------------------------------------------------------------------
+# Common Configuration
+# -----------------------------------------------------------------------------
+
+locals {
+  # Use created namespace or existing one based on configuration
+  namespace = var.create_namespace ? f5xc_namespace.this[0].name : var.namespace_name
+
+  # Built-in SecretPolicy that allows Volterra services to decrypt
+  # This policy exists in every F5XC tenant by default
+  policy_name = "ves-io-allow-volterra"
+  policy_ns   = "shared"
+}
+
+# Optional: Create a dedicated namespace for testing
+resource "f5xc_namespace" "this" {
+  count = var.create_namespace ? 1 : 0
+  name  = var.namespace_name
+}
+
+# -----------------------------------------------------------------------------
+# Example 1: TLS Certificate with Private Key
+# -----------------------------------------------------------------------------
+# Use Case: TLS certificate storage for load balancers and other F5XC services.
+#
+# NOTE: TLS private keys are typically too large (>1000 bytes) for direct
+# blindfold encryption, which is limited to ~190 bytes. For TLS certificates,
+# use clear_secret_info which transmits the key securely over HTTPS.
+#
+# For secrets that fit within the size limit (API keys, passwords, tokens),
+# use blindfold() or blindfold_file() as shown in the other examples.
+
+resource "f5xc_certificate" "example" {
+  count     = var.enable_certificate_example ? 1 : 0
+  name      = "${var.resource_prefix}-cert"
+  namespace = local.namespace
+
+  # Certificate chain in PEM format (base64 encoded)
+  certificate_url = "string:///${base64encode(file("${path.module}/certs/server.crt"))}"
+
+  # Private key using clear_secret_info (appropriate for TLS keys)
+  # The key is transmitted securely over HTTPS to F5XC
+  private_key {
+    clear_secret_info {
+      url = "string:///${base64encode(file("${path.module}/certs/server.key"))}"
+    }
+  }
+
+  # Use system defaults for OCSP stapling
+  use_system_defaults {}
+
+  labels = var.labels
+}
+
+# -----------------------------------------------------------------------------
+# Example 2: AWS Cloud Credentials
+# -----------------------------------------------------------------------------
+# Use Case: Store AWS credentials for F5XC to access AWS services (VPC sites,
+# cloud connectors, etc.). The secret access key is encrypted with blindfold.
+#
+# The blindfold() function takes base64-encoded plaintext and encrypts it.
+
+resource "f5xc_cloud_credentials" "aws" {
+  count     = var.enable_aws_credentials_example ? 1 : 0
+  name      = "${var.resource_prefix}-aws-creds"
+  namespace = "system" # Cloud credentials must be in system namespace
+
+  aws_secret_key {
+    access_key = var.aws_access_key_id
+
+    secret_key {
+      blindfold_secret_info {
+        location = provider::f5xc::blindfold(
+          base64encode(var.aws_secret_access_key),
+          local.policy_name,
+          local.policy_ns
+        )
+      }
+    }
+  }
+
+  labels = var.labels
+}
+
+# -----------------------------------------------------------------------------
+# Example 3: Azure Cloud Credentials
+# -----------------------------------------------------------------------------
+# Use Case: Store Azure service principal credentials for F5XC to manage
+# Azure resources. The client secret is encrypted with blindfold.
+
+resource "f5xc_cloud_credentials" "azure" {
+  count     = var.enable_azure_credentials_example ? 1 : 0
+  name      = "${var.resource_prefix}-azure-creds"
+  namespace = "system" # Cloud credentials must be in system namespace
+
+  azure_client_secret {
+    subscription_id = var.azure_subscription_id
+    tenant_id       = var.azure_tenant_id
+    client_id       = var.azure_client_id
+
+    client_secret {
+      blindfold_secret_info {
+        location = provider::f5xc::blindfold(
+          base64encode(var.azure_client_secret),
+          local.policy_name,
+          local.policy_ns
+        )
+      }
+    }
+  }
+
+  labels = var.labels
+}
+
+# -----------------------------------------------------------------------------
+# Example 4: GCP Cloud Credentials
+# -----------------------------------------------------------------------------
+# Use Case: Store GCP service account credentials for F5XC to manage GCP
+# resources. The entire service account JSON key file is encrypted.
+#
+# Note: GCP service account JSON files can be large. Ensure the file is under
+# the RSA-OAEP size limit (~190 bytes for 2048-bit keys).
+
+resource "f5xc_cloud_credentials" "gcp" {
+  count     = var.enable_gcp_credentials_example ? 1 : 0
+  name      = "${var.resource_prefix}-gcp-creds"
+  namespace = "system" # Cloud credentials must be in system namespace
+
+  gcp_cred_file {
+    credential_file {
+      blindfold_secret_info {
+        location = provider::f5xc::blindfold_file(
+          var.gcp_credentials_file,
+          local.policy_name,
+          local.policy_ns
+        )
+      }
+    }
+  }
+
+  labels = var.labels
+}
+
+# -----------------------------------------------------------------------------
+# Example 5: Container Registry Credentials
+# -----------------------------------------------------------------------------
+# Use Case: Store container registry authentication for pulling private images
+# in F5XC app deployments. The password/token is encrypted with blindfold.
+
+resource "f5xc_container_registry" "example" {
+  count     = var.enable_container_registry_example ? 1 : 0
+  name      = "${var.resource_prefix}-registry"
+  namespace = local.namespace
+
+  registry = var.container_registry_server
+
+  password {
+    blindfold_secret_info {
+      location = provider::f5xc::blindfold(
+        base64encode(var.container_registry_password),
+        local.policy_name,
+        local.policy_ns
+      )
+    }
+  }
+
+  user_name = var.container_registry_username
+
+  labels = var.labels
+}

--- a/examples/guides/blindfold/outputs.tf
+++ b/examples/guides/blindfold/outputs.tf
@@ -1,0 +1,98 @@
+# Blindfold Secret Management Guide - Outputs
+# These outputs provide useful information and next steps after deployment.
+
+# -----------------------------------------------------------------------------
+# Namespace Information
+# -----------------------------------------------------------------------------
+
+output "namespace" {
+  description = "The namespace where resources were created"
+  value       = local.namespace
+}
+
+# -----------------------------------------------------------------------------
+# Certificate Outputs
+# -----------------------------------------------------------------------------
+
+output "certificate_name" {
+  description = "Name of the created certificate (if enabled)"
+  value       = var.enable_certificate_example ? f5xc_certificate.example[0].name : null
+}
+
+# -----------------------------------------------------------------------------
+# Cloud Credentials Outputs
+# -----------------------------------------------------------------------------
+
+output "aws_credentials_name" {
+  description = "Name of the AWS cloud credentials (if enabled)"
+  value       = var.enable_aws_credentials_example ? f5xc_cloud_credentials.aws[0].name : null
+}
+
+output "azure_credentials_name" {
+  description = "Name of the Azure cloud credentials (if enabled)"
+  value       = var.enable_azure_credentials_example ? f5xc_cloud_credentials.azure[0].name : null
+}
+
+output "gcp_credentials_name" {
+  description = "Name of the GCP cloud credentials (if enabled)"
+  value       = var.enable_gcp_credentials_example ? f5xc_cloud_credentials.gcp[0].name : null
+}
+
+# -----------------------------------------------------------------------------
+# Container Registry Outputs
+# -----------------------------------------------------------------------------
+
+output "container_registry_name" {
+  description = "Name of the container registry (if enabled)"
+  value       = var.enable_container_registry_example ? f5xc_container_registry.example[0].name : null
+}
+
+# -----------------------------------------------------------------------------
+# Next Steps
+# -----------------------------------------------------------------------------
+
+output "next_steps" {
+  description = "Helpful next steps after deployment"
+  value       = <<-EOT
+
+    ============================================================================
+    BLINDFOLD SECRET MANAGEMENT - DEPLOYMENT COMPLETE
+    ============================================================================
+
+    Resources Created:
+    %{if var.enable_certificate_example~}
+    - Certificate: ${f5xc_certificate.example[0].name}
+    %{endif~}
+    %{if var.enable_aws_credentials_example~}
+    - AWS Credentials: ${f5xc_cloud_credentials.aws[0].name}
+    %{endif~}
+    %{if var.enable_azure_credentials_example~}
+    - Azure Credentials: ${f5xc_cloud_credentials.azure[0].name}
+    %{endif~}
+    %{if var.enable_gcp_credentials_example~}
+    - GCP Credentials: ${f5xc_cloud_credentials.gcp[0].name}
+    %{endif~}
+    %{if var.enable_container_registry_example~}
+    - Container Registry: ${f5xc_container_registry.example[0].name}
+    %{endif~}
+
+    Verify in F5XC Console:
+    1. Navigate to your F5 Distributed Cloud Console
+    2. Go to the appropriate section:
+       - Certificates: Multi-Cloud Network Connect > Manage > Load Balancers > Certificates
+       - Cloud Credentials: Cloud and Edge Sites > Manage > Site Management > Cloud Credentials
+       - Container Registries: Distributed Apps > Manage > Service Discovery > Container Registries
+    3. Verify your resources show encrypted secrets (not plaintext)
+
+    Security Notes:
+    - All secrets were encrypted locally before transmission
+    - F5XC stores only the encrypted ciphertext
+    - Only authorized F5XC services can decrypt using the SecretPolicy
+
+    Clean Up:
+    To remove all resources: terraform destroy
+
+    ============================================================================
+
+  EOT
+}

--- a/examples/guides/blindfold/terraform.tfvars.example
+++ b/examples/guides/blindfold/terraform.tfvars.example
@@ -1,0 +1,116 @@
+# Blindfold Secret Management Guide - Example Configuration
+#
+# INSTRUCTIONS:
+# 1. Copy this file to terraform.tfvars:
+#    cp terraform.tfvars.example terraform.tfvars
+#
+# 2. Edit terraform.tfvars with your values
+#
+# 3. Set F5XC authentication environment variables:
+#    export F5XC_API_URL="https://your-tenant.console.ves.volterra.io/api"
+#    export F5XC_API_TOKEN="your-api-token"
+#
+#    OR for P12 certificate authentication:
+#    export F5XC_API_URL="https://your-tenant.console.ves.volterra.io/api"
+#    export F5XC_API_P12_FILE="/path/to/your-credentials.p12"
+#    export F5XC_P12_PASSWORD="your-p12-password"  # pragma: allowlist secret
+#
+# 4. Run terraform:
+#    terraform init
+#    terraform plan
+#    terraform apply
+#
+# IMPORTANT: Never commit terraform.tfvars with real credentials!
+#            The .gitignore should exclude *.tfvars files.
+
+# -----------------------------------------------------------------------------
+# General Configuration
+# -----------------------------------------------------------------------------
+
+namespace_name   = "blindfold-guide"
+create_namespace = true
+resource_prefix  = "blindfold-example"
+
+labels = {
+  managed_by  = "terraform"
+  guide       = "blindfold"
+  environment = "testing"
+}
+
+# -----------------------------------------------------------------------------
+# Example Toggle Flags
+# -----------------------------------------------------------------------------
+# Enable ONLY the examples you want to test.
+# Each requires its own credentials/files to be provided below.
+
+enable_certificate_example        = false  # Requires certs/server.crt and certs/server.key
+enable_aws_credentials_example    = false  # Requires AWS credentials below
+enable_azure_credentials_example  = false  # Requires Azure credentials below
+enable_gcp_credentials_example    = false  # Requires GCP credentials file path below
+enable_container_registry_example = false  # Requires registry credentials below
+
+# -----------------------------------------------------------------------------
+# Example 1: TLS Certificate
+# -----------------------------------------------------------------------------
+# To test this example:
+# 1. Generate a self-signed certificate:
+#    openssl req -x509 -newkey rsa:2048 -keyout certs/server.key -out certs/server.crt \
+#      -days 365 -nodes -subj "/CN=example.com"
+# 2. Set enable_certificate_example = true above
+#
+# NOTE: The private key file must be under ~190 bytes for RSA-OAEP encryption.
+# For production, consider using smaller keys or key derivation techniques.
+
+# -----------------------------------------------------------------------------
+# Example 2: AWS Credentials
+# -----------------------------------------------------------------------------
+# To test this example:
+# 1. Get your AWS access key and secret from AWS IAM
+# 2. Set enable_aws_credentials_example = true above
+# 3. Fill in the values below
+
+aws_access_key_id     = ""  # e.g., "AKIAIOSFODNN7EXAMPLE"  # pragma: allowlist secret
+aws_secret_access_key = ""  # Your AWS secret access key (will be encrypted)
+
+# -----------------------------------------------------------------------------
+# Example 3: Azure Credentials
+# -----------------------------------------------------------------------------
+# To test this example:
+# 1. Create an Azure service principal:
+#    az ad sp create-for-rbac --name "f5xc-terraform"
+# 2. Set enable_azure_credentials_example = true above
+# 3. Fill in the values below
+
+azure_subscription_id = ""  # e.g., "12345678-1234-1234-1234-123456789012"
+azure_tenant_id       = ""  # e.g., "12345678-1234-1234-1234-123456789012"
+azure_client_id       = ""  # e.g., "12345678-1234-1234-1234-123456789012"
+azure_client_secret   = ""  # Your Azure client secret (will be encrypted)
+
+# -----------------------------------------------------------------------------
+# Example 4: GCP Credentials
+# -----------------------------------------------------------------------------
+# To test this example:
+# 1. Create a GCP service account and download the JSON key:
+#    gcloud iam service-accounts create f5xc-terraform
+#    gcloud iam service-accounts keys create gcp-credentials.json \
+#      --iam-account=f5xc-terraform@PROJECT_ID.iam.gserviceaccount.com
+# 2. Set enable_gcp_credentials_example = true above
+# 3. Set the path to your JSON key file below
+#
+# IMPORTANT: GCP credential files can be large. Ensure the file is under
+# ~190 bytes or the encryption will fail. Consider extracting only the
+# private key portion if the full JSON exceeds this limit.
+
+gcp_credentials_file = ""  # e.g., "/path/to/gcp-credentials.json"
+
+# -----------------------------------------------------------------------------
+# Example 5: Container Registry
+# -----------------------------------------------------------------------------
+# To test this example:
+# 1. Get your container registry credentials
+# 2. Set enable_container_registry_example = true above
+# 3. Fill in the values below
+
+container_registry_server   = "docker.io"  # or "gcr.io", "ghcr.io", etc.
+container_registry_username = ""           # Your registry username
+container_registry_password = ""           # Your registry password/token (will be encrypted)

--- a/examples/guides/blindfold/variables.tf
+++ b/examples/guides/blindfold/variables.tf
@@ -1,0 +1,149 @@
+# Blindfold Secret Management Guide - Variables
+# Configure these variables to test different blindfold use cases.
+
+# -----------------------------------------------------------------------------
+# General Configuration
+# -----------------------------------------------------------------------------
+
+variable "namespace_name" {
+  description = "Name of the namespace to use or create for resources"
+  type        = string
+  default     = "blindfold-guide"
+}
+
+variable "create_namespace" {
+  description = "Set to true to create the namespace, false to use an existing one"
+  type        = bool
+  default     = true
+}
+
+variable "resource_prefix" {
+  description = "Prefix for all resource names to ensure uniqueness"
+  type        = string
+  default     = "blindfold-example"
+}
+
+variable "labels" {
+  description = "Labels to apply to all resources"
+  type        = map(string)
+  default = {
+    managed_by = "terraform"
+    guide      = "blindfold"
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Example Toggle Flags
+# -----------------------------------------------------------------------------
+# Enable only the examples you want to test. Each example requires its own
+# set of credentials or files to be provided.
+
+variable "enable_certificate_example" {
+  description = "Enable the TLS certificate example (requires server.crt and server.key in certs/)"
+  type        = bool
+  default     = false
+}
+
+variable "enable_aws_credentials_example" {
+  description = "Enable the AWS credentials example (requires AWS access key and secret)"
+  type        = bool
+  default     = false
+}
+
+variable "enable_azure_credentials_example" {
+  description = "Enable the Azure credentials example (requires Azure service principal)"
+  type        = bool
+  default     = false
+}
+
+variable "enable_gcp_credentials_example" {
+  description = "Enable the GCP credentials example (requires GCP service account JSON file)"
+  type        = bool
+  default     = false
+}
+
+variable "enable_container_registry_example" {
+  description = "Enable the container registry example (requires registry credentials)"
+  type        = bool
+  default     = false
+}
+
+# -----------------------------------------------------------------------------
+# AWS Credentials (Example 2)
+# -----------------------------------------------------------------------------
+
+variable "aws_access_key_id" {
+  description = "AWS access key ID for cloud credentials"
+  type        = string
+  default     = ""
+  sensitive   = false # Access key ID is not secret
+}
+
+variable "aws_secret_access_key" {
+  description = "AWS secret access key (will be encrypted with blindfold)"
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+# -----------------------------------------------------------------------------
+# Azure Credentials (Example 3)
+# -----------------------------------------------------------------------------
+
+variable "azure_subscription_id" {
+  description = "Azure subscription ID"
+  type        = string
+  default     = ""
+}
+
+variable "azure_tenant_id" {
+  description = "Azure Active Directory tenant ID"
+  type        = string
+  default     = ""
+}
+
+variable "azure_client_id" {
+  description = "Azure service principal client (application) ID"
+  type        = string
+  default     = ""
+}
+
+variable "azure_client_secret" {
+  description = "Azure service principal client secret (will be encrypted with blindfold)"
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+# -----------------------------------------------------------------------------
+# GCP Credentials (Example 4)
+# -----------------------------------------------------------------------------
+
+variable "gcp_credentials_file" {
+  description = "Path to GCP service account JSON key file (will be encrypted with blindfold)"
+  type        = string
+  default     = ""
+}
+
+# -----------------------------------------------------------------------------
+# Container Registry Credentials (Example 5)
+# -----------------------------------------------------------------------------
+
+variable "container_registry_server" {
+  description = "Container registry server URL (e.g., docker.io, gcr.io, ghcr.io)"
+  type        = string
+  default     = "docker.io"
+}
+
+variable "container_registry_username" {
+  description = "Container registry username"
+  type        = string
+  default     = ""
+}
+
+variable "container_registry_password" {
+  description = "Container registry password or access token (will be encrypted with blindfold)"
+  type        = string
+  default     = ""
+  sensitive   = true
+}

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,6 @@ require (
 	github.com/hashicorp/terraform-plugin-testing v1.13.3
 	golang.org/x/crypto v0.45.0
 	golang.org/x/text v0.31.0
-	software.sslmate.com/src/go-pkcs12 v0.6.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -241,5 +241,3 @@ gopkg.in/warnings.v0 v0.1.2 h1:wFXVbFY8DY5/xOe1ECiWdKCzZlxgshcYVNkBHstARME=
 gopkg.in/warnings.v0 v0.1.2/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRNI=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-software.sslmate.com/src/go-pkcs12 v0.6.0 h1:f3sQittAeF+pao32Vb+mkli+ZyT+VwKaD014qFGq6oU=
-software.sslmate.com/src/go-pkcs12 v0.6.0/go.mod h1:Qiz0EyvDRJjjxGyUQa2cCNZn/wMyzrRJ/qcDXOQazLI=

--- a/templates/guides/blindfold.md
+++ b/templates/guides/blindfold.md
@@ -1,0 +1,498 @@
+---
+page_title: "Guide: Blindfold Secret Management Functions"
+subcategory: "Guides"
+description: |-
+  Learn how to securely encrypt secrets using F5XC Blindfold functions.
+  Covers TLS certificates, cloud credentials, and container registry authentication.
+---
+
+# Blindfold Secret Management Functions
+
+This guide walks you through using F5XC Blindfold functions to securely encrypt sensitive data. By the end, you'll understand how to:
+
+- **Encrypt TLS private keys** - Secure certificate key storage
+- **Protect cloud credentials** - AWS, Azure, and GCP secrets
+- **Secure container registries** - Private image pull authentication
+- **Understand the security model** - Local encryption, never transmitted unencrypted
+
+## Overview
+
+F5 Distributed Cloud Secret Management ("blindfold") provides client-side encryption for sensitive data. The blindfold functions encrypt your secrets locally using RSA-OAEP with SHA-256, meaning **your plaintext secrets never leave your machine unencrypted**.
+
+### How It Works
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                     Your Local Machine                              │
+│                                                                     │
+│  ┌──────────────┐    ┌──────────────────┐    ┌─────────────────┐   │
+│  │ Secret       │───►│ Blindfold        │───►│ Encrypted       │   │
+│  │ (plaintext)  │    │ Function         │    │ Ciphertext      │   │
+│  └──────────────┘    │ (RSA-OAEP)       │    └────────┬────────┘   │
+│                      └────────┬─────────┘             │            │
+│                               │                       │            │
+│                      ┌────────▼─────────┐             │            │
+│                      │ F5XC Public Key  │             │            │
+│                      │ (fetched once)   │             │            │
+│                      └──────────────────┘             │            │
+└──────────────────────────────────────────────────────│────────────┘
+                                                        │
+                                                        ▼
+                                          ┌─────────────────────────┐
+                                          │   F5 Distributed Cloud  │
+                                          │   (stores ciphertext    │
+                                          │    only)                │
+                                          └─────────────────────────┘
+```
+
+### Security Properties
+
+- **Local encryption**: Secrets encrypted on your machine before transmission
+- **RSA-OAEP with SHA-256**: Industry-standard encryption algorithm
+- **Policy-controlled decryption**: Only authorized F5XC services can decrypt
+- **No plaintext storage**: F5XC never receives or stores plaintext secrets
+
+## Prerequisites
+
+Before you begin, ensure you have:
+
+- **Terraform >= 1.8** - Provider-defined functions require Terraform 1.8 or later
+- **F5 Distributed Cloud Account** - Sign up at <https://www.f5.com/cloud/products/distributed-cloud-console>
+- **API Credentials** - Token or P12 certificate authentication configured
+
+### Authentication Setup
+
+Configure one of these authentication methods via environment variables:
+
+**Option 1: API Token (Recommended for development)**
+```bash
+export F5XC_API_URL="https://your-tenant.console.ves.volterra.io/api"
+export F5XC_API_TOKEN="your-api-token"
+```
+
+**Option 2: P12 Certificate (Recommended for production)**
+```bash
+export F5XC_API_URL="https://your-tenant.console.ves.volterra.io/api"
+export F5XC_API_P12_FILE="/path/to/your-credentials.p12"
+export F5XC_P12_PASSWORD="your-p12-password"  # pragma: allowlist secret
+```
+
+-> **Tip:** Add these to your shell profile (`~/.bashrc` or `~/.zshrc`) for persistence across terminal sessions.
+
+## Quick Start
+
+### Step 1: Clone the Repository
+
+```bash
+git clone https://github.com/robinmordasiewicz/terraform-provider-f5xc.git
+cd terraform-provider-f5xc/examples/guides/blindfold
+```
+
+### Step 2: Configure Your Deployment
+
+```bash
+cp terraform.tfvars.example terraform.tfvars
+```
+
+Edit `terraform.tfvars` to enable the examples you want to test:
+
+```hcl
+# Enable the TLS certificate example
+enable_certificate_example = true
+
+# Namespace configuration
+namespace_name   = "my-blindfold-test"
+create_namespace = true
+```
+
+### Step 3: Generate Test Certificates (for certificate example)
+
+```bash
+openssl req -x509 -newkey rsa:2048 \
+  -keyout certs/server.key \
+  -out certs/server.crt \
+  -days 365 -nodes \
+  -subj "/CN=example.com"
+```
+
+### Step 4: Deploy
+
+```bash
+terraform init
+terraform plan
+terraform apply
+```
+
+Review the plan output, then type `yes` to confirm deployment.
+
+### Step 5: Verify
+
+1. Check the Terraform outputs for created resource names
+2. Navigate to the F5XC Console
+3. Verify the certificate shows encrypted private key (not plaintext)
+
+## Understanding Blindfold Functions
+
+The provider includes two blindfold functions:
+
+### blindfold()
+
+Encrypts base64-encoded plaintext:
+
+```hcl
+provider::f5xc::blindfold(plaintext, policy_name, namespace)
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `plaintext` | string | Base64-encoded secret to encrypt |
+| `policy_name` | string | Name of the SecretPolicy |
+| `namespace` | string | Namespace containing the policy |
+
+**Example:**
+```hcl
+location = provider::f5xc::blindfold(
+  base64encode(var.my_secret),
+  "ves-io-allow-volterra",
+  "shared"
+)
+```
+
+### blindfold_file()
+
+Reads a file and encrypts its contents:
+
+```hcl
+provider::f5xc::blindfold_file(path, policy_name, namespace)
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `path` | string | Path to the file to encrypt |
+| `policy_name` | string | Name of the SecretPolicy |
+| `namespace` | string | Namespace containing the policy |
+
+**Example:**
+```hcl
+location = provider::f5xc::blindfold_file(
+  "${path.module}/certs/server.key",
+  "ves-io-allow-volterra",
+  "shared"
+)
+```
+
+### Built-in SecretPolicy
+
+Every F5XC tenant includes a default policy: `ves-io-allow-volterra` in the `shared` namespace. This policy allows Volterra (F5XC) services to decrypt secrets.
+
+## Use Cases
+
+### TLS Certificate Private Key
+
+Store TLS certificates for load balancers. Note that TLS private keys are typically too large (>1000 bytes) for direct blindfold encryption (~190 byte limit). Use `clear_secret_info` for TLS keys:
+
+```hcl
+resource "f5xc_certificate" "example" {
+  name      = "my-certificate"
+  namespace = "shared"
+
+  certificate_url = "string:///${base64encode(file("${path.module}/certs/server.crt"))}"
+
+  # TLS private keys are too large for blindfold encryption
+  # Use clear_secret_info - the key is transmitted securely over HTTPS
+  private_key {
+    clear_secret_info {
+      url = "string:///${base64encode(file("${path.module}/certs/server.key"))}"
+    }
+  }
+
+  use_system_defaults {}
+}
+```
+
+~> **Size Limitation:** Blindfold encryption uses RSA-OAEP which limits plaintext to ~190 bytes. TLS private keys exceed this limit. Use `clear_secret_info` for certificates - the data is transmitted securely over HTTPS. For secrets under 190 bytes (API keys, passwords), use blindfold functions as shown below.
+
+### AWS Cloud Credentials
+
+Protect AWS secret access keys for VPC site deployments:
+
+```hcl
+resource "f5xc_cloud_credentials" "aws" {
+  name      = "aws-credentials"
+  namespace = "system"
+
+  aws_secret_key {
+    access_key = var.aws_access_key_id
+
+    secret_key {
+      blindfold_secret_info {
+        location = provider::f5xc::blindfold(
+          base64encode(var.aws_secret_access_key),
+          "ves-io-allow-volterra",
+          "shared"
+        )
+      }
+    }
+  }
+}
+```
+
+### Azure Cloud Credentials
+
+Secure Azure service principal client secrets:
+
+```hcl
+resource "f5xc_cloud_credentials" "azure" {
+  name      = "azure-credentials"
+  namespace = "system"
+
+  azure_client_secret {
+    subscription_id = var.azure_subscription_id
+    tenant_id       = var.azure_tenant_id
+    client_id       = var.azure_client_id
+
+    client_secret {
+      blindfold_secret_info {
+        location = provider::f5xc::blindfold(
+          base64encode(var.azure_client_secret),
+          "ves-io-allow-volterra",
+          "shared"
+        )
+      }
+    }
+  }
+}
+```
+
+### GCP Cloud Credentials
+
+Encrypt GCP service account JSON key files:
+
+```hcl
+resource "f5xc_cloud_credentials" "gcp" {
+  name      = "gcp-credentials"
+  namespace = "system"
+
+  gcp_cred_file {
+    credential_file {
+      blindfold_secret_info {
+        location = provider::f5xc::blindfold_file(
+          var.gcp_credentials_file,
+          "ves-io-allow-volterra",
+          "shared"
+        )
+      }
+    }
+  }
+}
+```
+
+### Container Registry Authentication
+
+Protect container registry passwords for private image pulls:
+
+```hcl
+resource "f5xc_container_registry" "example" {
+  name      = "docker-registry"
+  namespace = "shared"
+
+  registry  = "docker.io"
+  user_name = var.registry_username
+
+  password {
+    blindfold_secret_info {
+      location = provider::f5xc::blindfold(
+        base64encode(var.registry_password),
+        "ves-io-allow-volterra",
+        "shared"
+      )
+    }
+  }
+}
+```
+
+## Configuration Options
+
+### Using Custom SecretPolicies
+
+While the built-in `ves-io-allow-volterra` policy works for most cases, you can create custom policies for fine-grained access control:
+
+```hcl
+locals {
+  policy_name = "my-custom-policy"
+  policy_ns   = "my-namespace"
+}
+
+# Reference your custom policy
+location = provider::f5xc::blindfold(
+  base64encode(var.secret),
+  local.policy_name,
+  local.policy_ns
+)
+```
+
+### Encrypting Multiple Secrets with for_each
+
+```hcl
+variable "secrets" {
+  type = map(string)
+  default = {
+    "api-key"    = "secret1"
+    "auth-token" = "secret2"
+  }
+}
+
+locals {
+  encrypted_secrets = {
+    for name, value in var.secrets :
+    name => provider::f5xc::blindfold(
+      base64encode(value),
+      "ves-io-allow-volterra",
+      "shared"
+    )
+  }
+}
+```
+
+## Technical Details
+
+### Size Limitations
+
+RSA-OAEP encryption has a maximum plaintext size based on the key size:
+
+| Key Size | Maximum Plaintext |
+|----------|-------------------|
+| 2048-bit | ~190 bytes |
+| 4096-bit | ~446 bytes |
+
+~> **Note:** If your secret exceeds the size limit, consider splitting it or using a different approach. The function will return a clear error message if the plaintext is too large.
+
+### Output Format
+
+The blindfold functions return a sealed secret string in this format:
+
+```
+string:///<base64-encoded-sealed-json>
+```
+
+The sealed JSON contains:
+- `key_version`: Public key version used for encryption
+- `policy_id`: Reference to the SecretPolicy
+- `tenant`: Your F5XC tenant identifier
+- `data`: The encrypted ciphertext
+
+### Function Behavior
+
+- **Idempotent**: Same input produces different output (due to random padding)
+- **Network required**: Functions fetch the public key from F5XC API
+- **Caching**: Public keys are cached for the Terraform run
+
+## Troubleshooting
+
+### Authentication Configuration Error
+
+**Symptom:** Error message about missing authentication configuration.
+
+**Solution:**
+```bash
+# Verify environment variables are set
+echo $F5XC_API_URL
+echo $F5XC_API_TOKEN  # or F5XC_API_P12_FILE
+
+# Set them if missing
+export F5XC_API_URL="https://your-tenant.console.ves.volterra.io/api"
+export F5XC_API_TOKEN="your-api-token"
+```
+
+### Policy Not Found
+
+**Symptom:** Error about secret policy not found.
+
+**Solutions:**
+
+1. Use the built-in policy:
+   ```hcl
+   policy_name = "ves-io-allow-volterra"
+   namespace   = "shared"
+   ```
+
+2. Verify your custom policy exists in F5XC Console
+
+### Plaintext Too Large
+
+**Symptom:** Error indicating plaintext exceeds maximum size.
+
+**Solutions:**
+
+1. Verify your secret size:
+   ```bash
+   wc -c < your-secret-file
+   ```
+
+2. For large files (like some GCP credentials), consider:
+   - Extracting only the private key portion
+   - Using F5XC's external secret management integration
+
+### File Not Found
+
+**Symptom:** Error about file not found when using `blindfold_file()`.
+
+**Solutions:**
+
+1. Use `${path.module}` for relative paths:
+   ```hcl
+   location = provider::f5xc::blindfold_file(
+     "${path.module}/certs/server.key",  # Correct
+     ...
+   )
+   ```
+
+2. Verify the file exists and is readable
+
+### Invalid Base64
+
+**Symptom:** Error about invalid base64 encoding.
+
+**Solution:** Ensure you're base64-encoding your plaintext:
+```hcl
+# Correct
+location = provider::f5xc::blindfold(
+  base64encode(var.secret),  # base64encode() wraps the secret
+  ...
+)
+
+# Incorrect
+location = provider::f5xc::blindfold(
+  var.secret,  # Raw secret will fail
+  ...
+)
+```
+
+## Clean Up
+
+To remove all resources created by this guide:
+
+```bash
+terraform destroy
+```
+
+Type `yes` to confirm destruction.
+
+!> **Warning:** This will immediately remove all created resources. Ensure you have backups of any certificates or credentials you need.
+
+## Next Steps
+
+Now that you understand blindfold encryption, explore related resources:
+
+- [Certificate Resource](../resources/certificate) - Full certificate management
+- [Cloud Credentials Resource](../resources/cloud_credentials) - Cloud provider authentication
+- [HTTP Load Balancer Guide](./http-loadbalancer) - Use certificates in load balancers
+- [blindfold Function Reference](../functions/blindfold) - Function API details
+- [blindfold_file Function Reference](../functions/blindfold_file) - Function API details
+
+## Support
+
+- **Provider Documentation:** [F5XC Provider](../index)
+- **F5 Documentation:** [F5 Distributed Cloud Docs](https://docs.cloud.f5.com/)
+- **Secret Management:** [F5XC Secret Management](https://docs.cloud.f5.com/docs/how-to/secrets-management)
+- **Issues:** [GitHub Issues](https://github.com/robinmordasiewicz/terraform-provider-f5xc/issues)


### PR DESCRIPTION
## Summary

Add a comprehensive guide for using F5XC Blindfold Secret Management functions (`blindfold()` and `blindfold_file()`) to securely encrypt sensitive data.

## Related Issue

Closes #345

## Changes Made

### Guide Template (`templates/guides/blindfold.md`)
- Security model explanation (local RSA-OAEP encryption)
- Prerequisites and authentication setup instructions
- Step-by-step quick start guide with openssl commands for generating test certificates
- Use cases for TLS certificates, AWS/Azure/GCP cloud credentials, and container registries
- Technical details including RSA-OAEP size limitations (~190 bytes)
- Troubleshooting section for common errors

### Working Examples (`examples/guides/blindfold/`)
- `main.tf` - Five complete examples with toggle variables
- `variables.tf` - Well-documented configuration variables
- `outputs.tf` - Helpful outputs with deployment verification instructions
- `terraform.tfvars.example` - Configuration template with detailed comments
- `README.md` - Quick-start instructions

### Bug Fix (`internal/blindfold/auth.go`)
- Fixed P12 authentication to handle certificate chains
- Changed from `go-pkcs12.Decode` to `golang.org/x/crypto/pkcs12.ToPEM`
- Resolves "expected exactly two safe bags in the PFX PDU" error when P12 files contain CA certificates

### Security Enhancement (`.gitignore`)
- Added patterns to prevent accidental commit of certificates and secrets
- Protects `*.pem`, `*.key`, `*.p12`, `*.crt`, `terraform.tfvars`, etc.

## Testing

- [x] `terraform validate` passes
- [x] `terraform apply` tested against F5XC staging environment
- [x] Certificate resource created successfully
- [x] `terraform destroy` cleaned up resources properly

## Technical Notes

- RSA-OAEP encryption limits plaintext to ~190 bytes (2048-bit key)
- TLS private keys (~1700 bytes) exceed this limit, so the certificate example uses `clear_secret_info`
- Smaller secrets (API keys, passwords, tokens) work well with `blindfold()` function

🤖 Generated with [Claude Code](https://claude.com/claude-code)