### PR TITLE
fix(docs): remove underscore escaping that breaks code examples

### DIFF
--- a/tools/transform-docs.go
+++ b/tools/transform-docs.go
@@ -1675,14 +1675,13 @@ func escapeEmphasisMarkersInContent(content string) string {
 	bracketUnderscore := regexp.MustCompile(`\[_\]`)
 	content = bracketUnderscore.ReplaceAllString(content, "[\\_]")
 
-	// Pattern 6: Underscore emphasis like _text_ that's not in backticks
-	// MD049 requires consistent emphasis style (asterisks preferred)
-	// Match _word_ patterns that look like emphasis but aren't code
-	// Escape underscores to prevent them being interpreted as emphasis
-	underscoreEmphasis := regexp.MustCompile(`([^` + "`" + `\\])_([a-zA-Z][a-zA-Z0-9_]*[a-zA-Z0-9])_([^` + "`" + `])`)
-	content = underscoreEmphasis.ReplaceAllString(content, "$1\\_$2\\_$3")
+	// NOTE: Pattern 6 (underscore emphasis escaping) was removed in issue #351
+	// The regex was too broad and incorrectly escaped snake_case identifiers
+	// like "http_loadbalancer" → "http\_loadbalancer", breaking code examples
+	// on the Terraform Registry. The Registry's markdown renderer handles
+	// underscores correctly without escaping.
 
-	// Pattern 7: Email addresses - wrap in backticks for MD034 compliance
+	// Pattern 6: Email addresses - wrap in backticks for MD034 compliance
 	// Match email patterns like user@domain.com that are not already in backticks
 	// The negative lookbehind/ahead for backticks prevents double-wrapping
 	emailRegex := regexp.MustCompile(`([^` + "`" + `])([a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,})([^` + "`" + `])`)


### PR DESCRIPTION
## Summary

Removes the Pattern 6 underscore escaping regex from `tools/transform-docs.go` that was incorrectly escaping snake_case identifiers in documentation, breaking code examples on the Terraform Registry.

## Related Issue

Fixes #351

## Root Cause

The problematic regex:
```go
underscoreEmphasis := regexp.MustCompile(`([^` + "`" + `\\])_([a-zA-Z][a-zA-Z0-9_]*[a-zA-Z0-9])_([^` + "`" + `])`)
content = underscoreEmphasis.ReplaceAllString(content, "$1\\_$2\\_$3")
```

Was intended to escape markdown emphasis patterns like `_text_` but was too broad and matched snake_case identifiers like `http_loadbalancer`, incorrectly converting them to `http\_loadbalancer`.

## Changes Made

- Removed the Pattern 6 underscore escaping code (lines 1678-1683)
- Added explanatory comment documenting why this pattern was removed

## Impact

After this PR merges, the CI/CD pipeline will regenerate all 288+ documentation files without the incorrect escaping. Code examples on the Terraform Registry will display correctly.

## Before/After

**Before (v1.49.1 - broken):**
```hcl
resource "f5xc\_http\_loadbalancer" "example" {
```

**After (this fix):**
```hcl
resource "f5xc_http_loadbalancer" "example" {
```

## Verification

Compare on Terraform Registry after merge:
- Current (broken): https://registry.terraform.io/providers/robinmordasiewicz/f5xc/1.49.1/docs/resources/http_loadbalancer
- Previous (correct): https://registry.terraform.io/providers/robinmordasiewicz/f5xc/1.49.0/docs/resources/http_loadbalancer

🤖 Generated with [Claude Code](https://claude.com/claude-code)