### PR TITLE
feat(docs): use human-readable resource names in documentation

### DIFF
--- a/tools/pkg/naming/acronyms.go
+++ b/tools/pkg/naming/acronyms.go
@@ -61,6 +61,16 @@ var CompoundWords = map[string]string{
 	"fastcgi":      "FastCGI",
 }
 
+// CompoundWordsHumanReadable defines compound words for human-readable documentation.
+// These are split with spaces unlike CompoundWords which are for Go type names.
+// Example: "loadbalancer" -> "Load Balancer"
+var CompoundWordsHumanReadable = map[string]string{
+	"loadbalancer": "Load Balancer",
+	"bigip":        "BIG-IP",
+	"websocket":    "WebSocket",
+	"fastcgi":      "FastCGI",
+}
+
 // IsUppercaseAcronym returns true if the given string (in any case) is a known uppercase acronym.
 func IsUppercaseAcronym(s string) bool {
 	return UppercaseAcronyms[ToUpper(s)]

--- a/tools/pkg/naming/naming.go
+++ b/tools/pkg/naming/naming.go
@@ -95,6 +95,33 @@ func ToHumanName(resourceName string) string {
 	return strings.Join(result, " ")
 }
 
+// ToHumanReadableName converts a resource name to human-readable format with proper spacing.
+// Unlike ToHumanName, this function also handles compound words with spaces.
+// Example: "http_loadbalancer" -> "HTTP Load Balancer"
+func ToHumanReadableName(resourceName string) string {
+	parts := strings.Split(resourceName, "_")
+	var result []string
+
+	for _, part := range parts {
+		lower := strings.ToLower(part)
+		upper := strings.ToUpper(part)
+
+		if UppercaseAcronyms[upper] {
+			result = append(result, upper)
+		} else if compound, ok := CompoundWordsHumanReadable[lower]; ok {
+			// Handle compound words with spaces (e.g., "loadbalancer" -> "Load Balancer")
+			result = append(result, compound)
+		} else if mixed, ok := MixedCaseAcronyms[lower]; ok {
+			result = append(result, mixed)
+		} else {
+			// Capitalize first letter
+			result = append(result, strings.Title(lower)) //nolint:staticcheck // strings.Title is fine for single words
+		}
+	}
+
+	return strings.Join(result, " ")
+}
+
 // ToAnchorName converts a name to an anchor-friendly format (kebab-case).
 // Example: "http_load_balancer" -> "http-load-balancer"
 func ToAnchorName(name string) string {

--- a/tools/pkg/naming/naming_test.go
+++ b/tools/pkg/naming/naming_test.go
@@ -101,6 +101,35 @@ func TestToHumanName(t *testing.T) {
 	}
 }
 
+func TestToHumanReadableName(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"http_loadbalancer", "HTTP Load Balancer"},   // compound word with spaces
+		{"tcp_loadbalancer", "TCP Load Balancer"},     // compound word with spaces
+		{"udp_loadbalancer", "UDP Load Balancer"},     // compound word with spaces
+		{"cdn_loadbalancer", "CDN Load Balancer"},     // compound word with spaces
+		{"dns_zone", "DNS Zone"},                      // acronym + word
+		{"aws_vpc_site", "AWS VPC Site"},              // multiple acronyms
+		{"origin_pool", "Origin Pool"},                // regular words
+		{"app_firewall", "App Firewall"},              // regular words
+		{"mtls_config", "mTLS Config"},                // mixed case acronym
+		{"oauth_provider", "OAuth Provider"},          // mixed case acronym
+		{"bigip_server", "BIG-IP Server"},             // compound word with special formatting
+		{"websocket_connection", "WebSocket Connection"}, // mixed case compound word
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result := ToHumanReadableName(tt.input)
+			if result != tt.expected {
+				t.Errorf("ToHumanReadableName(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
 func TestToAnchorName(t *testing.T) {
 	tests := []struct {
 		input    string


### PR DESCRIPTION
## Summary
Change documentation resource names from PascalCase (`HTTPLoadBalancer`) to human-readable format with spaces (`HTTP Load Balancer`).

## Related Issue
Closes #354

## Changes Made
- Add `CompoundWordsHumanReadable` map to `tools/pkg/naming/acronyms.go` for compound word handling
- Add `ToHumanReadableName()` function to `tools/pkg/naming/naming.go`
- Update `tools/generate-all-schemas.go` to use `toHumanName()` for documentation descriptions
- Add unit tests for the new function

## Expected Results
| Resource | Before | After |
|----------|--------|-------|
| http_loadbalancer | HTTPLoadBalancer | HTTP Load Balancer |
| tcp_loadbalancer | TCPLoadBalancer | TCP Load Balancer |
| dns_zone | DNSZone | DNS Zone |
| origin_pool | OriginPool | Origin Pool |
| app_firewall | AppFirewall | App Firewall |

## Testing
- [x] Unit tests pass (`go test ./tools/pkg/naming/...`)
- [x] Tools compile (`go build ./tools/...`)
- [x] Pre-commit hooks pass

## Note
After merge, CI/CD will regenerate all 144+ resources with the new human-readable names via `on-merge.yml` workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)