### PR TITLE
fix(workflow): regenerate docs after provider regeneration

### DIFF
--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -311,7 +311,10 @@ jobs:
           echo "::endgroup::"
 
       - name: Regenerate documentation (if needed)
-        if: needs.regenerate-docs.outputs.changed == 'true'
+        # Regenerate docs if:
+        # 1. The standalone docs job found changes (template/example changes), OR
+        # 2. Provider was regenerated (schema descriptions may have changed)
+        if: needs.regenerate-docs.outputs.changed == 'true' || needs.regenerate-provider.outputs.changed == 'true'
         run: |
           go run tools/generate-examples.go
           # Retry tfplugindocs generate


### PR DESCRIPTION
## Summary
Fixes the race condition where docs aren't regenerated after provider code regeneration.

## Related Issue
Fixes #357

## Changes Made
- Modified `create-regeneration-pr` job to regenerate docs when EITHER:
  1. The standalone docs job found changes (templates/examples), OR
  2. Provider code was regenerated (schema descriptions may have changed)

## Problem Solved
When `generate-all-schemas.go` is modified to change MarkdownDescription output,
the docs were not being regenerated because:
1. Standalone docs job ran with OLD provider code → "no changes"
2. Provider regeneration created NEW descriptions
3. Docs regeneration was skipped due to step 1's output

Now docs will always regenerate after provider regeneration.

## Testing
This will be tested when the workflow runs on the next merge to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)