### PR TITLE
chore: trigger docs regeneration with updated workflow

### DIFF
--- a/tools/generate-all-schemas.go
+++ b/tools/generate-all-schemas.go
@@ -1391,6 +1391,7 @@ func toTitleCase(s string) string {
 
 // toHumanName converts a resource name to human-readable format for documentation.
 // Unlike toTitleCase which produces Go type names, this produces readable names with spaces.
+// Used in transformResourceDescription() to generate user-friendly resource descriptions.
 // Example: "http_loadbalancer" -> "HTTP Load Balancer"
 func toHumanName(s string) string {
 	return naming.ToHumanReadableName(s)


### PR DESCRIPTION
## Summary
Add clarifying comment to toHumanName function documentation.

This is a trivial change that triggers the regeneration workflow to update all docs with human-readable resource names.

## Related Issue
Closes #359

## Background
PR #355 added human-readable naming but due to a race condition (fixed in #358), docs weren't regenerated.
This PR triggers the fixed workflow to complete the documentation update.

## Changes Made
- Added comment clarifying where toHumanName is used

🤖 Generated with [Claude Code](https://claude.com/claude-code)