### PR TITLE
fix(ci): update Go version to 1.24 for acceptance tests

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -83,7 +83,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  GO_VERSION: '1.23'
+  GO_VERSION: '1.24'
 
 jobs:
   # ═══════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary
Fixes Go version mismatch in acceptance tests workflow.

## Related Issue
Closes #367

## Changes Made
- Updated GO_VERSION from 1.23 to 1.24 in acceptance-tests.yml
- go.mod requires go >= 1.24.0

## Testing
- Workflow failed with: `go.mod requires go >= 1.24.0 (running go 1.23.12)`
- This fix aligns the workflow Go version with go.mod requirements

🤖 Generated with [Claude Code](https://claude.com/claude-code)