### PR TITLE
fix(ci): add TF_ACC=1 for mock tests

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -123,7 +123,9 @@ jobs:
           echo "Running mock tests with parallelism: $PARALLEL"
 
           # Run mock tests and capture output
-          F5XC_MOCK_MODE=1 go test -json \
+          # Note: TF_ACC=1 is required for resource.Test() even with mock server
+          # F5XC_MOCK_MODE=1 ensures mock server is used instead of real API
+          TF_ACC=1 F5XC_MOCK_MODE=1 go test -json \
             -parallel "$PARALLEL" \
             -timeout "${TIMEOUT}m" \
             -run 'TestMock.*' \


### PR DESCRIPTION
## Summary
Fixes mock tests being skipped due to missing TF_ACC environment variable.

## Related Issue
Closes #367

## Problem
The Terraform SDK's `resource.Test()` requires `TF_ACC=1` to run any acceptance test. Without it, all tests skip with:
```
Acceptance tests skipped unless env 'TF_ACC' set
```

Our workflow was only setting `F5XC_MOCK_MODE=1`, which tells our provider to use the mock server, but doesn't satisfy the SDK requirement.

## Solution
Now mock tests set both:
- `TF_ACC=1`: Required by HashiCorp testing framework
- `F5XC_MOCK_MODE=1`: Directs provider to use mock server instead of real API

This is safe because mock tests use a mock HTTP server and never hit real F5 XC APIs.

## Testing
- [x] Local validation: `TF_ACC=1 F5XC_MOCK_MODE=1 go test -v -run TestMock ./internal/provider/...`
- [ ] CI will validate after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)