### PR TITLE
feat(ci): add runner toggle for VPN vs public API access

### DIFF
--- a/.github-runner-docker/Dockerfile
+++ b/.github-runner-docker/Dockerfile
@@ -13,7 +13,7 @@ FROM ubuntu:22.04
 
 # Versions - update these as needed
 ARG RUNNER_VERSION=2.329.0
-ARG GO_VERSION=1.23.3
+ARG GO_VERSION=1.24.2
 ARG TERRAFORM_VERSION=1.9.8
 # TARGETARCH is automatically set by Docker buildx (amd64, arm64)
 ARG TARGETARCH
@@ -65,7 +65,11 @@ RUN useradd -m -s /bin/bash runner \
 WORKDIR /home/runner/actions-runner
 
 # Download and extract GitHub Actions runner
-RUN curl -fsSL "https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-${TARGETARCH}-${RUNNER_VERSION}.tar.gz" | tar -xzf - \
+RUN curl -fsSL "https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-${TARGETARCH}-${RUNNER_VERSION}.tar.gz" | tar -xzf -
+
+# Create tool cache directory for actions/setup-go and other actions
+# This prevents permission errors when GitHub Actions try to cache tools
+RUN mkdir -p /home/runner/actions-runner/_work/_tool \
     && chown -R runner:runner /home/runner
 
 # Switch to runner user

--- a/.github-runner-docker/docker-compose.yml
+++ b/.github-runner-docker/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       context: .
       args:
         - RUNNER_VERSION=2.321.0
-        - GO_VERSION=1.23.3
+        - GO_VERSION=1.24.2
         - TERRAFORM_VERSION=1.9.8
     image: f5xc-runner:latest
     container_name: f5xc-github-runner

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -1,18 +1,22 @@
 # Acceptance Tests Workflow
 #
 # This workflow runs comprehensive acceptance tests for the F5 XC Terraform Provider.
-# It supports both mock tests (fast, parallel) and real API tests (self-hosted runner).
+# It supports both mock tests (fast, parallel) and real API tests.
 #
 # Triggers:
-#   - Manual dispatch with mode selection
+#   - Manual dispatch with mode and runner selection
 #   - Pull requests (mock tests only for safety)
 #   - Weekly scheduled run (full suite)
 #
 # Test Modes:
 #   - mock-only: Parallel mock tests, runs on ubuntu-latest
-#   - real-only: Sequential real API tests, requires self-hosted runner
+#   - real-only: Sequential real API tests
 #   - full: Mock tests first, then real API tests
 #   - pr-subset: Mock tests only (safe for PRs)
+#
+# Runner Options:
+#   - ubuntu-latest: Standard GitHub runner for public API access (default)
+#   - self-hosted: Docker-based runner for VPN-only API access
 #
 # Required Secrets for Real API Tests (choose ONE auth method):
 #
@@ -58,6 +62,14 @@ on:
         required: false
         default: '10'
         type: string
+      runner:
+        description: 'Runner type (self-hosted for VPN-only APIs)'
+        required: false
+        default: 'ubuntu-latest'
+        type: choice
+        options:
+          - ubuntu-latest   # Public API access
+          - self-hosted     # VPN-required API access
 
   pull_request:
     branches: [main]
@@ -165,12 +177,13 @@ jobs:
           fail_on_failure: false
 
   # ═══════════════════════════════════════════════════════════════════════════
-  # Real API Tests - Require Self-Hosted Runner (SEQUENTIAL with rate limiting)
+  # Real API Tests - SEQUENTIAL with rate limiting
+  # Use self-hosted for VPN-only APIs, ubuntu-latest for public APIs
   # ═══════════════════════════════════════════════════════════════════════════
   real-api-tests:
     name: Real API Tests (Sequential)
-    # Self-hosted runner with VPN access to F5 XC staging
-    runs-on: self-hosted
+    # Runner selection: ubuntu-latest (public) or self-hosted (VPN-required)
+    runs-on: ${{ github.event.inputs.runner || 'ubuntu-latest' }}
     needs: [mock-tests]
     # Only run for full or real-only mode, and not on PRs
     if: |


### PR DESCRIPTION
## Summary
- Add runner input option to acceptance-tests workflow
- Users can choose between `ubuntu-latest` (public APIs) or `self-hosted` (VPN-only)
- Same workflow logic for both runners (simple toggle)
- Update Docker runner to pre-create `_tool` directory for setup-go compatibility
- Update Docker runner to Go 1.24.2

## How to use
1. Go to Actions → Acceptance Tests → Run workflow
2. Select `runner`: 
   - `ubuntu-latest` for public API access (default)
   - `self-hosted` for VPN-only API access

## Changes Made
- Workflow: Added `runner` input option with `ubuntu-latest` (default) and `self-hosted` choices
- Docker: Pre-create `_work/_tool` directory with proper permissions so setup-go works
- Docker: Updated Go version to 1.24.2

Closes #372

🤖 Generated with [Claude Code](https://claude.com/claude-code)