### PR TITLE
feat(ci): change acceptance tests to default to self-hosted runner

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -21,8 +21,8 @@
 #   indicate the mock server needs fixes (tests that pass on real but fail on mock).
 #
 # Runner Options:
-#   - ubuntu-latest: Standard GitHub runner for public API access (default)
-#   - self-hosted: Docker-based runner for VPN-only API access
+#   - self-hosted: Docker-based runner for VPN-only API access (default)
+#   - ubuntu-latest: Standard GitHub runner for public API access
 #
 # Required Secrets for Real API Tests (choose ONE auth method):
 #
@@ -71,11 +71,11 @@ on:
       runner:
         description: 'Runner type (self-hosted for VPN-only APIs)'
         required: false
-        default: 'ubuntu-latest'
+        default: 'self-hosted'
         type: choice
         options:
+          - self-hosted     # VPN-required API access (default)
           - ubuntu-latest   # Public API access
-          - self-hosted     # VPN-required API access
 
   pull_request:
     branches: [main]
@@ -188,8 +188,8 @@ jobs:
   # ═══════════════════════════════════════════════════════════════════════════
   real-api-tests:
     name: Real API Tests (Sequential)
-    # Runner selection: ubuntu-latest (public) or self-hosted (VPN-required)
-    runs-on: ${{ github.event.inputs.runner || 'ubuntu-latest' }}
+    # Runner selection: self-hosted (VPN-required, default) or ubuntu-latest (public)
+    runs-on: ${{ github.event.inputs.runner || 'self-hosted' }}
     needs: [mock-tests]
     # Only run for full or real-only mode, and not on PRs
     if: |


### PR DESCRIPTION
## Summary
Change the acceptance-tests.yml workflow to default to self-hosted runner instead of ubuntu-latest.

## Related Issue
Closes #377

## Changes Made
- Changed default `runner` input from `ubuntu-latest` to `self-hosted`
- Updated fallback runner for `real-api-tests` job to `self-hosted`
- Updated documentation comments to reflect new default

## Rationale
The locally hosted GitHub Actions runner provides VPN access to the F5 XC API, which is required for real API tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)