### PR TITLE
docs: remove redundant Quick Start section and fix table alignment

### DIFF
--- a/templates/guides/authentication.md
+++ b/templates/guides/authentication.md
@@ -23,22 +23,6 @@ Before you begin, ensure you have:
 - **Terraform >= 1.8** - Download and install from <https://www.terraform.io/downloads>
 - **Console Access** - Ability to create credentials in the F5XC Console
 
-## Quick Start
-
-The fastest way to authenticate is using environment variables with an API token:
-
-```bash
-# Set your tenant URL and API token
-export F5XC_API_URL="https://your-tenant.console.ves.volterra.io/api"
-export F5XC_API_TOKEN="your-api-token"
-
-# Verify authentication
-terraform init
-terraform plan
-```
-
--> **Tip:** F5 recommends API certificates for production as they offer more robust security via Mutual TLS (mTLS) authentication. API tokens use one-way TLS authentication.
-
 ## Creating Credentials in F5 Distributed Cloud
 
 ### Personal Credentials

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -12,9 +12,9 @@ This is a community-maintained provider built from public F5 API documentation.
 
 ## Requirements
 
-| Name | Version |
-|------|---------|
-| terraform | >= 1.8 |
+| Name      | Version |
+|-----------|---------|
+| terraform | >= 1.8  |
 
 -> **Note:** This provider uses provider-defined functions which require Terraform 1.8 or later. For details, see the [Functions](/docs/functions) documentation.
 


### PR DESCRIPTION
## Summary

- Removes the redundant Quick Start section from the authentication guide (already covered in main landing page documentation)
- Fixes MD060 markdown linting error for table column alignment in index.md.tmpl

## Related Issue

Closes #386

## Changes Made

- `templates/guides/authentication.md`: Removed Quick Start section (lines 26-40)
- `templates/index.md.tmpl`: Fixed table column alignment to pass MD060 lint rule

## Testing

- [x] Pre-commit hooks pass (lint-generated-preview verified passing)
- [x] No generated files committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)