### PR TITLE
refactor!: rename environment variables from F5XC_* to VES_* prefix

### DIFF
--- a/.claude/agents/terraform-test-developer.md
+++ b/.claude/agents/terraform-test-developer.md
@@ -96,7 +96,7 @@ func TestAccResourceName_basic(t *testing.T) {
 
 When working with this F5XC Terraform provider:
 - Resources require `namespace` for most operations
-- API authentication uses `F5XC_API_TOKEN` environment variable
+- API authentication uses `VES_API_TOKEN` environment variable
 - Import IDs typically follow `namespace/name` format
 - Many resources have complex nested structures from OpenAPI specs
 

--- a/.claude/skills/terraform-provider-testing/SKILL.md
+++ b/.claude/skills/terraform-provider-testing/SKILL.md
@@ -196,9 +196,9 @@ Every test development follows this iterative pattern:
 vim internal/provider/example_resource_test.go
 
 # Phase 2: Run Test (expect failures)
-F5XC_API_URL="https://tenant.console.ves.volterra.io/api" \
-F5XC_API_P12_FILE="/path/to/cert.p12" \
-F5XC_P12_PASSWORD="password" \  # pragma: allowlist secret
+VES_API_URL="https://tenant.console.ves.volterra.io/api" \
+VES_P12_FILE="/path/to/cert.p12" \
+VES_P12_PASSWORD="password" \  # pragma: allowlist secret
 TF_ACC=1 go test -v -timeout 15m \
   -run TestAccExampleResource_basic ./internal/provider/...
 
@@ -764,9 +764,9 @@ func TestAccBotDefenseAdvanced_basic(t *testing.T) {
 
 ```bash
 # Required for ALL acceptance tests
-export F5XC_API_P12_FILE="/path/to/api-certificate.p12"
-export F5XC_P12_PASSWORD="your-password"  # pragma: allowlist secret
-export F5XC_API_URL="https://tenant.console.ves.volterra.io/api"
+export VES_P12_FILE="/path/to/api-certificate.p12"
+export VES_P12_PASSWORD="your-password"  # pragma: allowlist secret
+export VES_API_URL="https://tenant.console.ves.volterra.io/api"
 export TF_ACC=1
 ```
 

--- a/.claude/skills/terraform-provider-testing/debugging-with-delve.md
+++ b/.claude/skills/terraform-provider-testing/debugging-with-delve.md
@@ -35,9 +35,9 @@ dlv version
             ],
             "env": {
                 "TF_ACC": "1",
-                "F5XC_API_P12_FILE": "/path/to/cert.p12",
-                "F5XC_P12_PASSWORD": "password",  // pragma: allowlist secret
-                "F5XC_API_URL": "https://api.example.com"
+                "VES_P12_FILE": "/path/to/cert.p12",
+                "VES_P12_PASSWORD": "password",  // pragma: allowlist secret
+                "VES_API_URL": "https://api.example.com"
             }
         }
     ]
@@ -322,9 +322,9 @@ dlv connect :2345
 ### Debug Namespace Resource
 
 ```bash
-TF_ACC=1 F5XC_API_P12_FILE="/path/to/cert.p12" \
-  F5XC_P12_PASSWORD="password" \  # pragma: allowlist secret
-  F5XC_API_URL="https://api.example.com" \
+TF_ACC=1 VES_P12_FILE="/path/to/cert.p12" \
+  VES_P12_PASSWORD="password" \  # pragma: allowlist secret
+  VES_API_URL="https://api.example.com" \
   dlv test ./internal/provider/... -- -test.run TestAccNamespaceResource_basic -test.v
 
 (dlv) break internal/provider/namespace_resource.go:resourceNamespaceCreate

--- a/.github-runner-docker/.env.example
+++ b/.github-runner-docker/.env.example
@@ -22,5 +22,5 @@ RUNNER_LABELS=self-hosted,Linux,X64,container
 # F5 XC API Credentials (for acceptance tests)
 # Get API token from F5 XC Console:
 #   Administration → Personal Management → Credentials → Add Credentials → API Token
-F5XC_API_URL=https://console.ves.volterra.io
-F5XC_API_TOKEN=your-api-token-here
+VES_API_URL=https://console.ves.volterra.io
+VES_API_TOKEN=your-api-token-here

--- a/.github-runner-docker/README.md
+++ b/.github-runner-docker/README.md
@@ -22,8 +22,8 @@ cp .env.example .env
 Edit `.env` with your values:
 - `GITHUB_REPOSITORY` - Your repo (e.g., `owner/repo`)
 - `GITHUB_TOKEN` - Personal Access Token with `repo` scope
-- `F5XC_API_URL` - F5 XC API URL
-- `F5XC_API_TOKEN` - F5 XC API Token
+- `VES_API_URL` - F5 XC API URL
+- `VES_API_TOKEN` - F5 XC API Token
 
 ### 2. Build and Start
 

--- a/.github-runner-docker/docker-compose.yml
+++ b/.github-runner-docker/docker-compose.yml
@@ -31,8 +31,8 @@ services:
       # Optional: Additional labels
       - RUNNER_LABELS=${RUNNER_LABELS:-self-hosted,Linux,X64,container}
       # F5 XC API credentials (passed to workflow jobs)
-      - F5XC_API_URL=${F5XC_API_URL:-}
-      - F5XC_API_TOKEN=${F5XC_API_TOKEN:-}
+      - VES_API_URL=${VES_API_URL:-}
+      - VES_API_TOKEN=${VES_API_TOKEN:-}
     volumes:
       # Persist runner work directory for caching
       - runner-work:/home/runner/actions-runner/_work

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -27,13 +27,13 @@
 # Required Secrets for Real API Tests (choose ONE auth method):
 #
 #   Option 1 - API Token (RECOMMENDED - most secure, no files):
-#     - F5XC_API_URL: F5 XC Console API URL (e.g., https://tenant.console.ves.volterra.io)
-#     - F5XC_API_TOKEN: API token from F5 XC Console
+#     - VES_API_URL: F5 XC Console API URL (e.g., https://tenant.console.ves.volterra.io)
+#     - VES_API_TOKEN: API token from F5 XC Console
 #
 #   Option 2 - P12 Certificate (legacy):
-#     - F5XC_API_URL: F5 XC Console API URL
-#     - F5XC_API_P12_BASE64: base64 -i /path/to/cert.p12 | tr -d '\n'
-#     - F5XC_P12_PASSWORD: Password for the P12 certificate
+#     - VES_API_URL: F5 XC Console API URL
+#     - VES_P12_BASE64: base64 -i /path/to/cert.p12 | tr -d '\n'
+#     - VES_P12_PASSWORD: Password for the P12 certificate
 #
 # IMPORTANT: Real API tests require self-hosted runner with network access
 # to the F5 XC environment.
@@ -142,9 +142,9 @@ jobs:
 
           # Run mock tests and capture output
           # Note: TF_ACC=1 is required for resource.Test() even with mock server
-          # F5XC_MOCK_MODE=1 ensures mock server is used instead of real API
+          # VES_MOCK_MODE=1 ensures mock server is used instead of real API
           # Tests include both provider resources AND provider-defined functions
-          TF_ACC=1 F5XC_MOCK_MODE=1 go test -json \
+          TF_ACC=1 VES_MOCK_MODE=1 go test -json \
             -parallel "$PARALLEL" \
             -timeout "${TIMEOUT}m" \
             -run 'TestMock.*' \
@@ -226,31 +226,31 @@ jobs:
       - name: Verify API credentials
         id: verify-creds
         env:
-          F5XC_API_URL: ${{ secrets.F5XC_API_URL }}
-          F5XC_API_TOKEN: ${{ secrets.F5XC_API_TOKEN }}
-          F5XC_API_P12_BASE64: ${{ secrets.F5XC_API_P12_BASE64 }}
-          F5XC_P12_PASSWORD: ${{ secrets.F5XC_P12_PASSWORD }}
+          VES_API_URL: ${{ secrets.VES_API_URL }}
+          VES_API_TOKEN: ${{ secrets.VES_API_TOKEN }}
+          VES_P12_BASE64: ${{ secrets.VES_P12_BASE64 }}
+          VES_P12_PASSWORD: ${{ secrets.VES_P12_PASSWORD }}
         run: |
           echo "Checking API credentials..."
 
-          if [ -z "$F5XC_API_URL" ]; then
-            echo "::error::F5XC_API_URL secret not configured"
+          if [ -z "$VES_API_URL" ]; then
+            echo "::error::VES_API_URL secret not configured"
             exit 1
           fi
-          echo "✓ API URL configured: $F5XC_API_URL"
+          echo "✓ API URL configured: $VES_API_URL"
 
           # Check which auth method is configured
-          if [ -n "$F5XC_API_TOKEN" ]; then
+          if [ -n "$VES_API_TOKEN" ]; then
             echo "✓ Using API Token authentication (recommended)"
             echo "auth_method=token" >> $GITHUB_OUTPUT
-          elif [ -n "$F5XC_API_P12_BASE64" ] && [ -n "$F5XC_P12_PASSWORD" ]; then
+          elif [ -n "$VES_P12_BASE64" ] && [ -n "$VES_P12_PASSWORD" ]; then
             echo "✓ Using P12 certificate authentication"
             echo "auth_method=p12" >> $GITHUB_OUTPUT
           else
             echo "::error::No authentication configured!"
             echo "Configure either:"
-            echo "  - F5XC_API_TOKEN (recommended)"
-            echo "  - F5XC_API_P12_BASE64 + F5XC_P12_PASSWORD"
+            echo "  - VES_API_TOKEN (recommended)"
+            echo "  - VES_P12_BASE64 + VES_P12_PASSWORD"
             exit 1
           fi
 
@@ -258,14 +258,14 @@ jobs:
         id: setup-p12
         if: steps.verify-creds.outputs.auth_method == 'p12'
         env:
-          F5XC_API_P12_BASE64: ${{ secrets.F5XC_API_P12_BASE64 }}
+          VES_P12_BASE64: ${{ secrets.VES_P12_BASE64 }}
         run: |
           # Create secure temp directory
           P12_DIR=$(mktemp -d)
           P12_FILE="${P12_DIR}/api-creds.p12"
 
           # Decode base64 P12 to temp file
-          echo "$F5XC_API_P12_BASE64" | base64 -d > "$P12_FILE"
+          echo "$VES_P12_BASE64" | base64 -d > "$P12_FILE"
 
           # Verify file was created and has content
           if [ ! -s "$P12_FILE" ]; then
@@ -280,12 +280,12 @@ jobs:
       - name: Run real API tests
         id: run-tests
         env:
-          F5XC_API_URL: ${{ secrets.F5XC_API_URL }}
+          VES_API_URL: ${{ secrets.VES_API_URL }}
           # Token auth (if configured)
-          F5XC_API_TOKEN: ${{ secrets.F5XC_API_TOKEN }}
+          VES_API_TOKEN: ${{ secrets.VES_API_TOKEN }}
           # P12 auth (if configured)
-          F5XC_API_P12_FILE: ${{ steps.setup-p12.outputs.p12_file }}
-          F5XC_P12_PASSWORD: ${{ secrets.F5XC_P12_PASSWORD }}
+          VES_P12_FILE: ${{ steps.setup-p12.outputs.p12_file }}
+          VES_P12_PASSWORD: ${{ secrets.VES_P12_PASSWORD }}
           TF_ACC: '1'
         run: |
           mkdir -p test-reports
@@ -373,16 +373,16 @@ jobs:
 
       - name: Setup P12 certificate (if using P12 auth)
         id: setup-p12
-        if: ${{ secrets.F5XC_API_P12_BASE64 != '' }}
+        if: ${{ secrets.VES_P12_BASE64 != '' }}
         env:
-          F5XC_API_P12_BASE64: ${{ secrets.F5XC_API_P12_BASE64 }}
+          VES_P12_BASE64: ${{ secrets.VES_P12_BASE64 }}
         run: |
           # Create secure temp directory
           P12_DIR=$(mktemp -d)
           P12_FILE="${P12_DIR}/api-creds.p12"
 
           # Decode base64 P12 to temp file
-          echo "$F5XC_API_P12_BASE64" | base64 -d > "$P12_FILE"
+          echo "$VES_P12_BASE64" | base64 -d > "$P12_FILE"
 
           # Verify file was created and has content
           if [ ! -s "$P12_FILE" ]; then
@@ -397,10 +397,10 @@ jobs:
       - name: Run sweepers
         id: sweep
         env:
-          F5XC_API_URL: ${{ secrets.F5XC_API_URL }}
-          F5XC_API_TOKEN: ${{ secrets.F5XC_API_TOKEN }}
-          F5XC_API_P12_FILE: ${{ steps.setup-p12.outputs.p12_file }}
-          F5XC_P12_PASSWORD: ${{ secrets.F5XC_P12_PASSWORD }}
+          VES_API_URL: ${{ secrets.VES_API_URL }}
+          VES_API_TOKEN: ${{ secrets.VES_API_TOKEN }}
+          VES_P12_FILE: ${{ steps.setup-p12.outputs.p12_file }}
+          VES_P12_PASSWORD: ${{ secrets.VES_P12_PASSWORD }}
           TF_ACC: '1'
         run: |
           echo "Running sweepers to clean up test resources..."

--- a/.github/workflows/discover-defaults.yml
+++ b/.github/workflows/discover-defaults.yml
@@ -97,20 +97,20 @@ jobs:
 
       - name: Verify API credentials
         env:
-          F5XC_API_URL: ${{ secrets.F5XC_API_URL }}
-          F5XC_API_P12_FILE: ${{ secrets.F5XC_API_P12_FILE }}
-          F5XC_P12_PASSWORD: ${{ secrets.F5XC_P12_PASSWORD }}
+          VES_API_URL: ${{ secrets.VES_API_URL }}
+          VES_P12_FILE: ${{ secrets.VES_P12_FILE }}
+          VES_P12_PASSWORD: ${{ secrets.VES_P12_PASSWORD }}
         run: |
           echo "Checking API credentials..."
-          if [ -z "$F5XC_API_URL" ]; then
-            echo "::error::F5XC_API_URL secret not configured"
+          if [ -z "$VES_API_URL" ]; then
+            echo "::error::VES_API_URL secret not configured"
             echo "Configure repository secrets for API access"
             exit 1
           fi
-          echo "API URL configured: $F5XC_API_URL"
+          echo "API URL configured: $VES_API_URL"
 
-          if [ -z "$F5XC_API_P12_FILE" ] || [ -z "$F5XC_P12_PASSWORD" ]; then
-            echo "::error::F5XC_API_P12_FILE or F5XC_P12_PASSWORD not configured"
+          if [ -z "$VES_P12_FILE" ] || [ -z "$VES_P12_PASSWORD" ]; then
+            echo "::error::VES_P12_FILE or VES_P12_PASSWORD not configured"
             exit 1
           fi
           echo "P12 credentials configured"
@@ -118,9 +118,9 @@ jobs:
       - name: Run discovery
         id: discover
         env:
-          F5XC_API_URL: ${{ secrets.F5XC_API_URL }}
-          F5XC_API_P12_FILE: ${{ secrets.F5XC_API_P12_FILE }}
-          F5XC_P12_PASSWORD: ${{ secrets.F5XC_P12_PASSWORD }}
+          VES_API_URL: ${{ secrets.VES_API_URL }}
+          VES_P12_FILE: ${{ secrets.VES_P12_FILE }}
+          VES_P12_PASSWORD: ${{ secrets.VES_P12_PASSWORD }}
         run: |
           MODE="${{ inputs.mode || 'discover' }}"
           RESOURCE="${{ inputs.resource }}"

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -197,15 +197,6 @@
         "line_number": 21
       }
     ],
-    "internal/acctest/acctest.go": [
-      {
-        "type": "Secret Keyword",
-        "filename": "internal/acctest/acctest.go",
-        "hashed_secret": "a5b0613ec0f3047c546641acfbb384d35561ebf7",
-        "is_verified": false,
-        "line_number": 46
-      }
-    ],
     "internal/client/client_test.go": [
       {
         "type": "Private Key",
@@ -731,5 +722,5 @@
       }
     ]
   },
-  "generated_at": "2025-12-02T19:42:30Z"
+  "generated_at": "2025-12-12T01:53:26Z"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -648,7 +648,7 @@ go build -o terraform-provider-f5xc
 # Run all tests
 go test ./...
 
-# Run acceptance tests (requires F5XC_API_TOKEN)
+# Run acceptance tests (requires VES_API_TOKEN or VES_P12_FILE)
 TF_ACC=1 go test ./... -v -timeout 120m
 
 # Generate documentation (requires terraform CLI)
@@ -701,8 +701,10 @@ The `tools/` directory contains generators for scaffolding resources from F5 Ope
 
 ## Environment Variables
 
-- `F5XC_API_TOKEN` - Required API token for F5 Distributed Cloud
-- `F5XC_API_URL` - Optional API URL (defaults to `https://console.ves.volterra.io/api`)
+- `VES_API_TOKEN` - API token for F5 Distributed Cloud (one of token or P12 required)
+- `VES_API_URL` - Optional API URL (defaults to `https://console.ves.volterra.io/api`)
+- `VES_P12_FILE` - Path to P12 certificate file (alternative to token auth)
+- `VES_P12_PASSWORD` - Password for P12 file (required with VES_P12_FILE)
 - `TF_ACC=1` - Enable acceptance tests
 
 ## Key Dependencies

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ provider "f5xc" {}
 Set your API token as an environment variable:
 
 ```bash
-export F5XC_API_TOKEN="your-api-token"
+export VES_API_TOKEN="your-api-token"
 ```
 
 ## Documentation

--- a/examples/guides/authentication/README.md
+++ b/examples/guides/authentication/README.md
@@ -8,8 +8,8 @@ This example demonstrates the three authentication methods supported by the F5XC
 
 ```bash
 # For API Token authentication
-export F5XC_API_URL="https://your-tenant.console.ves.volterra.io/api"
-export F5XC_API_TOKEN="your-api-token"
+export VES_API_URL="https://your-tenant.console.ves.volterra.io/api"
+export VES_API_TOKEN="your-api-token"
 
 # Initialize and apply
 terraform init
@@ -32,9 +32,9 @@ terraform plan
 
 | Method | Environment Variables | Security Level |
 |--------|----------------------|----------------|
-| API Token | `F5XC_API_TOKEN` | Standard (one-way TLS) |
-| P12 Certificate | `F5XC_API_P12_FILE`, `F5XC_P12_PASSWORD` | High (mTLS) |
-| PEM Certificate | `F5XC_API_CERT`, `F5XC_API_KEY` | High (mTLS) |
+| API Token | `VES_API_TOKEN` | Standard (one-way TLS) |
+| P12 Certificate | `VES_P12_FILE`, `VES_P12_PASSWORD` | High (mTLS) |
+| PEM Certificate | `VES_CERT`, `VES_KEY` | High (mTLS) |
 
 ## Files
 

--- a/examples/guides/authentication/main.tf
+++ b/examples/guides/authentication/main.tf
@@ -29,18 +29,18 @@ terraform {
 # variables and the provider block remains empty.
 #
 # For API Token:
-#   export F5XC_API_URL="https://your-tenant.console.ves.volterra.io/api"
-#   export F5XC_API_TOKEN="your-api-token"
+#   export VES_API_URL="https://your-tenant.console.ves.volterra.io/api"
+#   export VES_API_TOKEN="your-api-token"
 #
 # For P12 Certificate:
-#   export F5XC_API_URL="https://your-tenant.console.ves.volterra.io/api"
-#   export F5XC_API_P12_FILE="/path/to/credentials.p12"
-#   export F5XC_P12_PASSWORD="your-p12-password"  # pragma: allowlist secret
+#   export VES_API_URL="https://your-tenant.console.ves.volterra.io/api"
+#   export VES_P12_FILE="/path/to/credentials.p12"
+#   export VES_P12_PASSWORD="your-p12-password"  # pragma: allowlist secret
 #
 # For PEM Certificate:
-#   export F5XC_API_URL="https://your-tenant.console.ves.volterra.io/api"
-#   export F5XC_API_CERT="/path/to/certificate.pem"
-#   export F5XC_API_KEY="/path/to/private-key.pem"
+#   export VES_API_URL="https://your-tenant.console.ves.volterra.io/api"
+#   export VES_CERT="/path/to/certificate.pem"
+#   export VES_KEY="/path/to/private-key.pem"
 
 provider "f5xc" {
   # Authentication via environment variables

--- a/examples/guides/authentication/outputs.tf
+++ b/examples/guides/authentication/outputs.tf
@@ -6,12 +6,12 @@
 
 output "api_url" {
   description = "The F5XC API URL used for authentication (from environment or configuration)"
-  value       = var.f5xc_api_url != "" ? var.f5xc_api_url : "Set via F5XC_API_URL environment variable"
+  value       = var.ves_api_url != "" ? var.ves_api_url : "Set via VES_API_URL environment variable"
 }
 
 output "authentication_method" {
   description = "The authentication method being used based on configuration"
-  value       = var.f5xc_api_token != "" ? "API Token" : (var.f5xc_api_p12_file != "" ? "P12 Certificate" : (var.f5xc_api_cert != "" ? "PEM Certificate" : "Environment Variables"))
+  value       = var.ves_api_token != "" ? "API Token" : (var.ves_p12_file != "" ? "P12 Certificate" : (var.ves_cert != "" ? "PEM Certificate" : "Environment Variables"))
 }
 
 output "system_namespace" {

--- a/examples/guides/authentication/terraform.tfvars.example
+++ b/examples/guides/authentication/terraform.tfvars.example
@@ -20,18 +20,18 @@
 # Instead of using this file, set environment variables:
 #
 # For API Token:
-#   export F5XC_API_URL="https://your-tenant.console.ves.volterra.io/api"
-#   export F5XC_API_TOKEN="your-api-token"
+#   export VES_API_URL="https://your-tenant.console.ves.volterra.io/api"
+#   export VES_API_TOKEN="your-api-token"
 #
 # For P12 Certificate:
-#   export F5XC_API_URL="https://your-tenant.console.ves.volterra.io/api"
-#   export F5XC_API_P12_FILE="/path/to/credentials.p12"
-#   export F5XC_P12_PASSWORD="your-p12-password"  # pragma: allowlist secret
+#   export VES_API_URL="https://your-tenant.console.ves.volterra.io/api"
+#   export VES_P12_FILE="/path/to/credentials.p12"
+#   export VES_P12_PASSWORD="your-p12-password"  # pragma: allowlist secret
 #
 # For PEM Certificate:
-#   export F5XC_API_URL="https://your-tenant.console.ves.volterra.io/api"
-#   export F5XC_API_CERT="/path/to/certificate.pem"
-#   export F5XC_API_KEY="/path/to/private-key.pem"
+#   export VES_API_URL="https://your-tenant.console.ves.volterra.io/api"
+#   export VES_CERT="/path/to/certificate.pem"
+#   export VES_KEY="/path/to/private-key.pem"
 #
 # Then leave the provider block empty in main.tf:
 #   provider "f5xc" {}
@@ -46,7 +46,7 @@
 # Your F5 Distributed Cloud tenant API URL
 # Format: https://your-tenant.console.ves.volterra.io/api
 
-f5xc_api_url = "https://your-tenant.console.ves.volterra.io/api"
+ves_api_url = "https://your-tenant.console.ves.volterra.io/api"
 
 # -----------------------------------------------------------------------------
 # API Token Authentication
@@ -54,7 +54,7 @@ f5xc_api_url = "https://your-tenant.console.ves.volterra.io/api"
 # Uncomment and fill in to use API token authentication.
 # Create token in Console: Administration > Personal Management > Credentials
 
-# f5xc_api_token = "your-api-token-here"
+# ves_api_token = "your-api-token-here"
 
 # -----------------------------------------------------------------------------
 # P12 Certificate Authentication (Recommended for Production)
@@ -62,8 +62,8 @@ f5xc_api_url = "https://your-tenant.console.ves.volterra.io/api"
 # Uncomment and fill in to use P12 certificate authentication.
 # Download P12 from Console: Administration > Personal Management > Credentials
 
-# f5xc_api_p12_file = "/absolute/path/to/your-credentials.p12"
-# f5xc_p12_password = "your-p12-password"  # pragma: allowlist secret
+# ves_p12_file = "/absolute/path/to/your-credentials.p12"
+# ves_p12_password = "your-p12-password"  # pragma: allowlist secret
 
 # -----------------------------------------------------------------------------
 # PEM Certificate Authentication
@@ -73,8 +73,8 @@ f5xc_api_url = "https://your-tenant.console.ves.volterra.io/api"
 #   openssl pkcs12 -in creds.p12 -nodes -nokeys -out cert.pem
 #   openssl pkcs12 -in creds.p12 -nodes -nocerts -out key.pem
 
-# f5xc_api_cert = "/absolute/path/to/certificate.pem"
-# f5xc_api_key  = "/absolute/path/to/private-key.pem"
+# ves_cert = "/absolute/path/to/certificate.pem"
+# ves_key  = "/absolute/path/to/private-key.pem"
 
 # Optional: CA certificate for server verification
-# f5xc_api_ca_cert = "/absolute/path/to/ca-cert.pem"
+# ves_cacert = "/absolute/path/to/ca-cert.pem"

--- a/examples/guides/authentication/variables.tf
+++ b/examples/guides/authentication/variables.tf
@@ -11,13 +11,13 @@
 # API URL Configuration
 # -----------------------------------------------------------------------------
 
-variable "f5xc_api_url" {
+variable "ves_api_url" {
   description = "F5 Distributed Cloud API URL. Format: https://your-tenant.console.ves.volterra.io/api"
   type        = string
   default     = ""
 
   validation {
-    condition     = var.f5xc_api_url == "" || can(regex("^https://.*\\.console\\.ves\\.volterra\\.io/api$", var.f5xc_api_url))
+    condition     = var.ves_api_url == "" || can(regex("^https://.*\\.console\\.ves\\.volterra\\.io/api$", var.ves_api_url))
     error_message = "API URL must be in format: https://your-tenant.console.ves.volterra.io/api"
   }
 }
@@ -26,7 +26,7 @@ variable "f5xc_api_url" {
 # API Token Authentication
 # -----------------------------------------------------------------------------
 
-variable "f5xc_api_token" {
+variable "ves_api_token" {
   description = "F5 Distributed Cloud API token for bearer authentication. Create in Console under Administration > Personal Management > Credentials."
   type        = string
   default     = ""
@@ -37,18 +37,18 @@ variable "f5xc_api_token" {
 # P12 Certificate Authentication
 # -----------------------------------------------------------------------------
 
-variable "f5xc_api_p12_file" {
+variable "ves_p12_file" {
   description = "Path to the P12 certificate file. Download from Console under Administration > Personal Management > Credentials."
   type        = string
   default     = ""
 
   validation {
-    condition     = var.f5xc_api_p12_file == "" || can(regex(".*\\.p12$", var.f5xc_api_p12_file))
+    condition     = var.ves_p12_file == "" || can(regex(".*\\.p12$", var.ves_p12_file))
     error_message = "P12 file path must end with .p12 extension."
   }
 }
 
-variable "f5xc_p12_password" {
+variable "ves_p12_password" {
   description = "Password for the P12 certificate file. Set when creating the certificate in the Console."
   type        = string
   default     = ""
@@ -59,25 +59,25 @@ variable "f5xc_p12_password" {
 # PEM Certificate Authentication
 # -----------------------------------------------------------------------------
 
-variable "f5xc_api_cert" {
+variable "ves_cert" {
   description = "Path to the PEM certificate file. Extract from P12 using: openssl pkcs12 -in creds.p12 -nodes -nokeys -out cert.pem"
   type        = string
   default     = ""
 
   validation {
-    condition     = var.f5xc_api_cert == "" || can(regex(".*\\.(pem|cert|crt)$", var.f5xc_api_cert))
+    condition     = var.ves_cert == "" || can(regex(".*\\.(pem|cert|crt)$", var.ves_cert))
     error_message = "Certificate file path must end with .pem, .cert, or .crt extension."
   }
 }
 
-variable "f5xc_api_key" {
+variable "ves_key" {
   description = "Path to the PEM private key file. Extract from P12 using: openssl pkcs12 -in creds.p12 -nodes -nocerts -out key.pem"
   type        = string
   default     = ""
   sensitive   = true
 }
 
-variable "f5xc_api_ca_cert" {
+variable "ves_cacert" {
   description = "Optional path to CA certificate for server verification."
   type        = string
   default     = ""

--- a/examples/guides/blindfold/README.md
+++ b/examples/guides/blindfold/README.md
@@ -20,8 +20,8 @@ This example demonstrates how to use F5XC Blindfold functions to securely encryp
 
 2. **Configure authentication:**
    ```bash
-   export F5XC_API_URL="https://your-tenant.console.ves.volterra.io/api"
-   export F5XC_API_TOKEN="your-api-token"
+   export VES_API_URL="https://your-tenant.console.ves.volterra.io/api"
+   export VES_API_TOKEN="your-api-token"
    ```
 
 3. **Copy and edit the configuration:**

--- a/examples/guides/blindfold/main.tf
+++ b/examples/guides/blindfold/main.tf
@@ -15,9 +15,9 @@ terraform {
 
 provider "f5xc" {
   # Authentication configured via environment variables:
-  # - F5XC_API_URL (required)
-  # - F5XC_API_TOKEN (token auth) OR
-  # - F5XC_API_P12_FILE + F5XC_P12_PASSWORD (P12 cert auth)
+  # - VES_API_URL (required)
+  # - VES_API_TOKEN (token auth) OR
+  # - VES_P12_FILE + VES_P12_PASSWORD (P12 cert auth)
 }
 
 # -----------------------------------------------------------------------------

--- a/examples/guides/blindfold/terraform.tfvars.example
+++ b/examples/guides/blindfold/terraform.tfvars.example
@@ -7,13 +7,13 @@
 # 2. Edit terraform.tfvars with your values
 #
 # 3. Set F5XC authentication environment variables:
-#    export F5XC_API_URL="https://your-tenant.console.ves.volterra.io/api"
-#    export F5XC_API_TOKEN="your-api-token"
+#    export VES_API_URL="https://your-tenant.console.ves.volterra.io/api"
+#    export VES_API_TOKEN="your-api-token"
 #
 #    OR for P12 certificate authentication:
-#    export F5XC_API_URL="https://your-tenant.console.ves.volterra.io/api"
-#    export F5XC_API_P12_FILE="/path/to/your-credentials.p12"
-#    export F5XC_P12_PASSWORD="your-p12-password"  # pragma: allowlist secret
+#    export VES_API_URL="https://your-tenant.console.ves.volterra.io/api"
+#    export VES_P12_FILE="/path/to/your-credentials.p12"
+#    export VES_P12_PASSWORD="your-p12-password"  # pragma: allowlist secret
 #
 # 4. Run terraform:
 #    terraform init

--- a/examples/guides/http-loadbalancer/README.md
+++ b/examples/guides/http-loadbalancer/README.md
@@ -21,8 +21,8 @@ Deploy a production-ready HTTP Load Balancer on F5 Distributed Cloud with:
 ### 1. Set Environment Variables
 
 ```bash
-export F5XC_API_URL="https://your-tenant.console.ves.volterra.io/api"
-export F5XC_API_TOKEN="your-api-token"
+export VES_API_URL="https://your-tenant.console.ves.volterra.io/api"
+export VES_API_TOKEN="your-api-token"
 ```
 
 ### 2. Configure Your Deployment

--- a/examples/guides/http-loadbalancer/main.tf
+++ b/examples/guides/http-loadbalancer/main.tf
@@ -18,8 +18,8 @@ terraform {
 }
 
 # Provider configuration uses environment variables:
-# F5XC_API_URL   - Your tenant URL (e.g., https://tenant.console.ves.volterra.io/api)
-# F5XC_API_TOKEN - Your API token
+# VES_API_URL   - Your tenant URL (e.g., https://tenant.console.ves.volterra.io/api)
+# VES_API_TOKEN - Your API token
 provider "f5xc" {}
 
 # -----------------------------------------------------------------------------

--- a/examples/guides/http-loadbalancer/terraform.tfvars.example
+++ b/examples/guides/http-loadbalancer/terraform.tfvars.example
@@ -8,8 +8,8 @@
 # 4. Run: terraform init && terraform plan && terraform apply
 #
 # AUTHENTICATION (environment variables - do NOT put credentials in this file):
-#   export F5XC_API_URL="https://your-tenant.console.ves.volterra.io/api"
-#   export F5XC_API_TOKEN="your-api-token"
+#   export VES_API_URL="https://your-tenant.console.ves.volterra.io/api"
+#   export VES_API_TOKEN="your-api-token"
 
 # -----------------------------------------------------------------------------
 # Namespace Configuration

--- a/examples/guides/http-loadbalancer/variables.tf
+++ b/examples/guides/http-loadbalancer/variables.tf
@@ -1,8 +1,8 @@
 # HTTP Load Balancer Guide - Variables
 # =====================================
 # Authentication is handled via environment variables:
-#   F5XC_API_URL   - Your tenant URL
-#   F5XC_API_TOKEN - Your API token
+#   VES_API_URL   - Your tenant URL
+#   VES_API_TOKEN - Your API token
 
 # -----------------------------------------------------------------------------
 # Namespace Configuration

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -1,14 +1,14 @@
 # Configure the F5XC Provider with API Token Authentication
 provider "f5xc" {
   api_url   = "https://your-tenant.console.ves.volterra.io/api"
-  api_token = var.f5xc_api_token
+  api_token = var.ves_api_token
 }
 
 # Alternatively, use environment variables:
-# export F5XC_API_URL="https://your-tenant.console.ves.volterra.io/api"
-# export F5XC_API_TOKEN="your-api-token"
+# export VES_API_URL="https://your-tenant.console.ves.volterra.io/api"
+# export VES_API_TOKEN="your-api-token"
 
-variable "f5xc_api_token" {
+variable "ves_api_token" {
   description = "F5 Distributed Cloud API Token"
   type        = string
   sensitive   = true
@@ -18,10 +18,10 @@ variable "f5xc_api_token" {
 # provider "f5xc" {
 #   api_url      = "https://your-tenant.console.ves.volterra.io/api"
 #   api_p12_file = "/path/to/certificate.p12"
-#   p12_password = var.f5xc_p12_password
+#   p12_password = var.ves_p12_password
 # }
 #
 # Environment variables for P12 authentication:
-# export F5XC_API_URL="https://your-tenant.console.ves.volterra.io/api"
-# export F5XC_API_P12_FILE="/path/to/certificate.p12"
-# export F5XC_P12_PASSWORD="your-p12-password"
+# export VES_API_URL="https://your-tenant.console.ves.volterra.io/api"
+# export VES_P12_FILE="/path/to/certificate.p12"
+# export VES_P12_PASSWORD="your-p12-password"

--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -32,27 +32,28 @@ var (
 )
 
 // Environment variable names for acceptance tests
+// Using VES_* prefix for vesctl CLI compatibility.
 const (
 	// EnvF5XCURL is the environment variable for the F5 XC API URL
-	EnvF5XCURL = "F5XC_API_URL"
+	EnvF5XCURL = "VES_API_URL"
 
 	// EnvF5XCToken is the environment variable for the F5 XC API token
-	EnvF5XCToken = "F5XC_API_TOKEN"
+	EnvF5XCToken = "VES_API_TOKEN"
 
 	// EnvF5XCP12File is the environment variable for the P12 certificate file path
-	EnvF5XCP12File = "F5XC_API_P12_FILE"
+	EnvF5XCP12File = "VES_P12_FILE"
 
 	// EnvF5XCP12Password is the environment variable for the P12 certificate password
-	EnvF5XCP12Password = "F5XC_P12_PASSWORD"
+	EnvF5XCP12Password = "VES_P12_PASSWORD" // pragma: allowlist secret
 
 	// EnvF5XCCert is the environment variable for the PEM certificate file path
-	EnvF5XCCert = "F5XC_API_CERT"
+	EnvF5XCCert = "VES_CERT"
 
 	// EnvF5XCKey is the environment variable for the PEM key file path
-	EnvF5XCKey = "F5XC_API_KEY"
+	EnvF5XCKey = "VES_KEY"
 
 	// EnvF5XCTenantName is the environment variable for the F5 XC tenant name
-	EnvF5XCTenantName = "F5XC_TENANT_NAME"
+	EnvF5XCTenantName = "VES_TENANT_NAME"
 
 	// EnvTFAccTest enables acceptance tests
 	EnvTFAccTest = "TF_ACC"
@@ -107,7 +108,7 @@ func DetectAuthMethod() AuthMethod {
 
 // PreCheck validates that required environment variables are set before running tests.
 // It also logs the test category as REAL_API for reporting purposes.
-// When F5XC_MOCK_MODE is set, it automatically configures the environment to use
+// When VES_MOCK_MODE is set, it automatically configures the environment to use
 // the global mock server instead of requiring real credentials.
 func PreCheck(t *testing.T) {
 	t.Helper()
@@ -119,7 +120,7 @@ func PreCheck(t *testing.T) {
 	// Log test category for reporting
 	if IsMockMode() {
 		LogTestCategory(t, TestCategoryMock)
-		t.Logf("Using mock server mode (F5XC_MOCK_MODE=1)")
+		t.Logf("Using mock server mode (VES_MOCK_MODE=1)")
 		return // Skip credential validation for mock mode
 	}
 
@@ -154,7 +155,7 @@ func PreCheck(t *testing.T) {
 }
 
 // SkipIfNotAccTest skips the test if TF_ACC is not set and mock mode is not enabled.
-// When F5XC_MOCK_MODE is set, tests run without requiring TF_ACC.
+// When VES_MOCK_MODE is set, tests run without requiring TF_ACC.
 func SkipIfNotAccTest(t *testing.T) {
 	t.Helper()
 
@@ -178,12 +179,12 @@ func RandomNameWithSuffix(prefix, suffix string) string {
 	return fmt.Sprintf("%s-%s-%s", prefix, acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum), suffix)
 }
 
-// TestNamespace returns the namespace for tests (default: "system")
+// TestNamespace returns the namespace for tests (default: "default")
 func TestNamespace() string {
-	if ns := os.Getenv("F5XC_TEST_NAMESPACE"); ns != "" {
+	if ns := os.Getenv("VES_DEFAULT_NAMESPACE"); ns != "" {
 		return ns
 	}
-	return "system"
+	return "default"
 }
 
 // ConfigCompose composes multiple Terraform configurations

--- a/internal/acctest/mock_helpers.go
+++ b/internal/acctest/mock_helpers.go
@@ -20,7 +20,7 @@ import (
 )
 
 var (
-	// globalMockServer is a shared mock server for all tests when F5XC_MOCK_MODE is set
+	// globalMockServer is a shared mock server for all tests when VES_MOCK_MODE is set
 	globalMockServer     *mocks.Server
 	globalMockServerOnce sync.Once
 	globalMockServerMu   sync.Mutex
@@ -69,12 +69,12 @@ func SetupMockTest(t *testing.T) *MockTestConfig {
 	server := mocks.NewServer()
 
 	// Save original environment
-	originalURL := os.Getenv("F5XC_API_URL")
-	originalToken := os.Getenv("F5XC_API_TOKEN")
+	originalURL := os.Getenv("VES_API_URL")
+	originalToken := os.Getenv("VES_API_TOKEN")
 
 	// Configure environment to point to mock server
-	_ = os.Setenv("F5XC_API_URL", server.URL())
-	_ = os.Setenv("F5XC_API_TOKEN", "mock-token")
+	_ = os.Setenv("VES_API_URL", server.URL())
+	_ = os.Setenv("VES_API_TOKEN", "mock-token")
 
 	return &MockTestConfig{
 		Server:        server,
@@ -87,15 +87,15 @@ func SetupMockTest(t *testing.T) *MockTestConfig {
 func (m *MockTestConfig) Cleanup() {
 	// Restore original environment
 	if m.OriginalURL != "" {
-		_ = os.Setenv("F5XC_API_URL", m.OriginalURL)
+		_ = os.Setenv("VES_API_URL", m.OriginalURL)
 	} else {
-		_ = os.Unsetenv("F5XC_API_URL")
+		_ = os.Unsetenv("VES_API_URL")
 	}
 
 	if m.OriginalToken != "" {
-		_ = os.Setenv("F5XC_API_TOKEN", m.OriginalToken)
+		_ = os.Setenv("VES_API_TOKEN", m.OriginalToken)
 	} else {
-		_ = os.Unsetenv("F5XC_API_TOKEN")
+		_ = os.Unsetenv("VES_API_TOKEN")
 	}
 
 	// Close mock server
@@ -161,62 +161,62 @@ func MockParallelTest(t *testing.T, testCase resource.TestCase) {
 	resource.ParallelTest(t, testCase)
 }
 
-// SkipIfNoMockMode skips the test if F5XC_MOCK_MODE is not set.
+// SkipIfNoMockMode skips the test if VES_MOCK_MODE is not set.
 // This allows running mock tests only when explicitly requested.
 func SkipIfNoMockMode(t *testing.T) {
 	t.Helper()
 
-	if os.Getenv("F5XC_MOCK_MODE") == "" {
-		t.Skip("Skipping mock test: F5XC_MOCK_MODE not set")
+	if os.Getenv("VES_MOCK_MODE") == "" {
+		t.Skip("Skipping mock test: VES_MOCK_MODE not set")
 	}
 }
 
-// SkipIfRealAPI skips the test if running against the real API (F5XC_MOCK_MODE is not set).
+// SkipIfRealAPI skips the test if running against the real API (VES_MOCK_MODE is not set).
 // Use this for tests that have known API behavioral constraints that don't affect mock testing,
 // such as ephemeral resource lifecycles, infrastructure dependencies, or staging environment limitations.
 // The message should explain why this test cannot run against the real API.
 func SkipIfRealAPI(t *testing.T, message string) {
 	t.Helper()
 
-	if os.Getenv("F5XC_MOCK_MODE") == "" {
+	if os.Getenv("VES_MOCK_MODE") == "" {
 		t.Skipf("Skipping on real API: %s", message)
 	}
 }
 
 // IsMockMode returns true if mock mode is enabled
 func IsMockMode() bool {
-	return os.Getenv("F5XC_MOCK_MODE") != ""
+	return os.Getenv("VES_MOCK_MODE") != ""
 }
 
 // GetGlobalMockServer returns the global mock server, creating it if necessary.
-// This ensures all tests share the same mock server when F5XC_MOCK_MODE is set.
+// This ensures all tests share the same mock server when VES_MOCK_MODE is set.
 func GetGlobalMockServer() *mocks.Server {
 	globalMockServerOnce.Do(func() {
 		globalMockServer = mocks.NewServer()
 
 		// Store original environment variables
 		globalMockServerMu.Lock()
-		originalEnvVars["F5XC_API_URL"] = os.Getenv("F5XC_API_URL")
-		originalEnvVars["F5XC_API_TOKEN"] = os.Getenv("F5XC_API_TOKEN")
-		originalEnvVars["F5XC_API_P12_FILE"] = os.Getenv("F5XC_API_P12_FILE")
-		originalEnvVars["F5XC_P12_PASSWORD"] = os.Getenv("F5XC_P12_PASSWORD")
-		originalEnvVars["F5XC_API_CERT"] = os.Getenv("F5XC_API_CERT")
-		originalEnvVars["F5XC_API_KEY"] = os.Getenv("F5XC_API_KEY")
+		originalEnvVars["VES_API_URL"] = os.Getenv("VES_API_URL")
+		originalEnvVars["VES_API_TOKEN"] = os.Getenv("VES_API_TOKEN")
+		originalEnvVars["VES_P12_FILE"] = os.Getenv("VES_P12_FILE")
+		originalEnvVars["VES_P12_PASSWORD"] = os.Getenv("VES_P12_PASSWORD")
+		originalEnvVars["VES_CERT"] = os.Getenv("VES_CERT")
+		originalEnvVars["VES_KEY"] = os.Getenv("VES_KEY")
 		globalMockServerMu.Unlock()
 
 		// Override environment to use mock server
-		_ = os.Setenv("F5XC_API_URL", globalMockServer.URL())
-		_ = os.Setenv("F5XC_API_TOKEN", "mock-token")
+		_ = os.Setenv("VES_API_URL", globalMockServer.URL())
+		_ = os.Setenv("VES_API_TOKEN", "mock-token")
 		// Clear P12/PEM credentials so the provider uses token auth
-		_ = os.Unsetenv("F5XC_API_P12_FILE")
-		_ = os.Unsetenv("F5XC_P12_PASSWORD")
-		_ = os.Unsetenv("F5XC_API_CERT")
-		_ = os.Unsetenv("F5XC_API_KEY")
+		_ = os.Unsetenv("VES_P12_FILE")
+		_ = os.Unsetenv("VES_P12_PASSWORD")
+		_ = os.Unsetenv("VES_CERT")
+		_ = os.Unsetenv("VES_KEY")
 	})
 	return globalMockServer
 }
 
-// EnsureMockModeConfigured ensures that if F5XC_MOCK_MODE is set,
+// EnsureMockModeConfigured ensures that if VES_MOCK_MODE is set,
 // the environment is configured to use the mock server.
 // This should be called early in test setup.
 func EnsureMockModeConfigured() {
@@ -227,7 +227,7 @@ func EnsureMockModeConfigured() {
 
 // RunWithMockOrReal runs a test with either mock or real API depending on environment.
 // If TF_ACC and real credentials are set, uses real API.
-// If F5XC_MOCK_MODE is set, uses mock server.
+// If VES_MOCK_MODE is set, uses mock server.
 // Otherwise skips the test.
 func RunWithMockOrReal(t *testing.T, testCase resource.TestCase, mockSetup func(*MockTestConfig)) {
 	t.Helper()
@@ -244,7 +244,7 @@ func RunWithMockOrReal(t *testing.T, testCase resource.TestCase, mockSetup func(
 	}
 
 	// Check if mock mode is enabled
-	if os.Getenv("F5XC_MOCK_MODE") != "" {
+	if os.Getenv("VES_MOCK_MODE") != "" {
 		mockCfg := SetupMockTest(t)
 		defer mockCfg.Cleanup()
 
@@ -258,7 +258,7 @@ func RunWithMockOrReal(t *testing.T, testCase resource.TestCase, mockSetup func(
 		return
 	}
 
-	t.Skip("Skipping: neither TF_ACC with credentials nor F5XC_MOCK_MODE is set")
+	t.Skip("Skipping: neither TF_ACC with credentials nor VES_MOCK_MODE is set")
 }
 
 // MockResourceTestCase creates a test case configured for mock testing

--- a/internal/blindfold/auth.go
+++ b/internal/blindfold/auth.go
@@ -62,11 +62,12 @@ type AuthResult struct {
 }
 
 // Environment variable names for F5XC authentication.
+// Using VES_* prefix for vesctl CLI compatibility.
 const (
-	EnvAPIURL      = "F5XC_API_URL"
-	EnvAPIToken    = "F5XC_API_TOKEN"
-	EnvP12File     = "F5XC_API_P12_FILE"
-	EnvP12Password = "F5XC_P12_PASSWORD" // pragma: allowlist secret
+	EnvAPIURL      = "VES_API_URL"
+	EnvAPIToken    = "VES_API_TOKEN"
+	EnvP12File     = "VES_P12_FILE"
+	EnvP12Password = "VES_P12_PASSWORD" // pragma: allowlist secret
 )
 
 // DefaultAPIURL is the default F5XC API URL.
@@ -105,8 +106,8 @@ func GetAuthConfigFromEnv() (*AuthConfig, error) {
 // It prioritizes API token authentication over P12 certificate authentication.
 //
 // Priority:
-//  1. API token (F5XC_API_TOKEN)
-//  2. P12 certificate (F5XC_API_P12_FILE + F5XC_P12_PASSWORD)
+//  1. API token (VES_API_TOKEN)
+//  2. P12 certificate (VES_P12_FILE + VES_P12_PASSWORD)
 //
 // Returns an AuthResult containing the client and authentication metadata.
 func CreateAuthenticatedClient(config *AuthConfig) (*AuthResult, error) {

--- a/internal/client/child_tenant_types.go
+++ b/internal/client/child_tenant_types.go
@@ -17,8 +17,7 @@ type ChildTenant struct {
 // CreateChildTenant creates a new ChildTenant
 func (c *Client) CreateChildTenant(ctx context.Context, resource *ChildTenant) (*ChildTenant, error) {
 	var result ChildTenant
-	path := "/api/web/namespaces/system/partner-management/child_tenants"
-	_ = resource.Metadata.Namespace // Namespace not required in API path for this resource
+	path := fmt.Sprintf("/api/web/namespaces/%s/child_tenants", resource.Metadata.Namespace)
 	err := c.Post(ctx, path, resource, &result)
 	return &result, err
 }
@@ -26,8 +25,7 @@ func (c *Client) CreateChildTenant(ctx context.Context, resource *ChildTenant) (
 // GetChildTenant retrieves a ChildTenant
 func (c *Client) GetChildTenant(ctx context.Context, namespace, name string) (*ChildTenant, error) {
 	var result ChildTenant
-	path := fmt.Sprintf("/api/web/namespaces/system/partner-management/child_tenants/%s", name)
-	_ = namespace // Namespace not required in API path for this resource
+	path := fmt.Sprintf("/api/web/namespaces/%s/child_tenants/%s", namespace, name)
 	err := c.Get(ctx, path, &result)
 	return &result, err
 }
@@ -35,15 +33,13 @@ func (c *Client) GetChildTenant(ctx context.Context, namespace, name string) (*C
 // UpdateChildTenant updates a ChildTenant
 func (c *Client) UpdateChildTenant(ctx context.Context, resource *ChildTenant) (*ChildTenant, error) {
 	var result ChildTenant
-	path := fmt.Sprintf("/api/web/namespaces/system/partner-management/child_tenants/%s", resource.Metadata.Name)
-	_ = resource.Metadata.Namespace // Namespace not required in API path for this resource
+	path := fmt.Sprintf("/api/web/namespaces/%s/child_tenants/%s", resource.Metadata.Namespace, resource.Metadata.Name)
 	err := c.Put(ctx, path, resource, &result)
 	return &result, err
 }
 
 // DeleteChildTenant deletes a ChildTenant
 func (c *Client) DeleteChildTenant(ctx context.Context, namespace, name string) error {
-	path := fmt.Sprintf("/api/web/namespaces/system/partner-management/child_tenants/%s", name)
-	_ = namespace // Namespace not required in API path for this resource
+	path := fmt.Sprintf("/api/web/namespaces/%s/child_tenants/%s", namespace, name)
 	return c.Delete(ctx, path)
 }

--- a/internal/functions/blindfold.go
+++ b/internal/functions/blindfold.go
@@ -120,8 +120,8 @@ func (f *BlindfoldFunction) Run(ctx context.Context, req function.RunRequest, re
 		resp.Error = function.NewFuncError(
 			fmt.Sprintf("Authentication configuration error: %s\n\n"+
 				"Configure one of:\n"+
-				"  - F5XC_API_TOKEN for API token authentication\n"+
-				"  - F5XC_API_P12_FILE and F5XC_P12_PASSWORD for P12 certificate authentication",
+				"  - VES_API_TOKEN for API token authentication\n"+
+				"  - VES_P12_FILE and VES_P12_PASSWORD for P12 certificate authentication",
 				err),
 		)
 		return

--- a/internal/functions/blindfold_acc_test.go
+++ b/internal/functions/blindfold_acc_test.go
@@ -3,8 +3,8 @@
 // Acceptance tests for blindfold functions.
 // These tests require:
 //   - TF_ACC=1
-//   - F5XC_API_URL set to F5XC console URL
-//   - Either F5XC_API_TOKEN or (F5XC_API_P12_FILE + F5XC_P12_PASSWORD)
+//   - VES_API_URL set to F5XC console URL
+//   - Either VES_API_TOKEN or (VES_P12_FILE + VES_P12_PASSWORD)
 //
 // Run with: TF_ACC=1 go test -v -timeout 15m -run "TestAcc.*Blindfold" ./internal/functions/...
 
@@ -41,7 +41,7 @@ func skipIfNoAuth(t *testing.T) {
 	p12File := os.Getenv(blindfold.EnvP12File)
 
 	if token == "" && p12File == "" {
-		t.Skip("Acceptance tests skipped: no authentication configured (F5XC_API_TOKEN or F5XC_API_P12_FILE)")
+		t.Skip("Acceptance tests skipped: no authentication configured (VES_API_TOKEN or VES_P12_FILE)")
 	}
 }
 
@@ -49,7 +49,7 @@ func skipIfNoAuth(t *testing.T) {
 func skipIfNoURL(t *testing.T) {
 	t.Helper()
 	if os.Getenv(blindfold.EnvAPIURL) == "" {
-		t.Skip("Acceptance tests skipped: F5XC_API_URL not set")
+		t.Skip("Acceptance tests skipped: VES_API_URL not set")
 	}
 }
 
@@ -452,7 +452,7 @@ func TestAccBlindfoldFunction_P12Auth(t *testing.T) {
 	p12Password := os.Getenv(blindfold.EnvP12Password)
 
 	if p12File == "" || p12Password == "" {
-		t.Skip("Skipping P12 auth test: F5XC_API_P12_FILE and F5XC_P12_PASSWORD not set")
+		t.Skip("Skipping P12 auth test: VES_P12_FILE and VES_P12_PASSWORD not set")
 	}
 
 	// Temporarily unset token to force P12 auth
@@ -494,7 +494,7 @@ func TestAccBlindfoldFunction_TokenAuth(t *testing.T) {
 	token := os.Getenv(blindfold.EnvAPIToken)
 
 	if token == "" {
-		t.Skip("Skipping token auth test: F5XC_API_TOKEN not set")
+		t.Skip("Skipping token auth test: VES_API_TOKEN not set")
 	}
 
 	fn := &BlindfoldFunction{}

--- a/internal/functions/blindfold_file.go
+++ b/internal/functions/blindfold_file.go
@@ -126,8 +126,8 @@ func (f *BlindfoldFileFunction) Run(ctx context.Context, req function.RunRequest
 		resp.Error = function.NewFuncError(
 			fmt.Sprintf("Authentication configuration error: %s\n\n"+
 				"Configure one of:\n"+
-				"  - F5XC_API_TOKEN for API token authentication\n"+
-				"  - F5XC_API_P12_FILE and F5XC_P12_PASSWORD for P12 certificate authentication",
+				"  - VES_API_TOKEN for API token authentication\n"+
+				"  - VES_P12_FILE and VES_P12_PASSWORD for P12 certificate authentication",
 				err),
 		)
 		return

--- a/internal/mocks/README.md
+++ b/internal/mocks/README.md
@@ -17,10 +17,10 @@ The mock testing infrastructure enables:
 
 ```bash
 # Run all mock tests
-F5XC_MOCK_MODE=1 go test -v ./internal/provider/ -run TestMock -timeout 5m
+VES_MOCK_MODE=1 go test -v ./internal/provider/ -run TestMock -timeout 5m
 
 # Run specific mock test
-F5XC_MOCK_MODE=1 go test -v ./internal/provider/ -run TestMockAWSVPCSiteResource_basic -timeout 5m
+VES_MOCK_MODE=1 go test -v ./internal/provider/ -run TestMockAWSVPCSiteResource_basic -timeout 5m
 ```
 
 ### Writing a Mock Test
@@ -288,7 +288,7 @@ func TestResource_hybridMode(t *testing.T) {
     }
 
     // Runs with real API if TF_ACC + credentials set
-    // Runs with mock if F5XC_MOCK_MODE=1 set
+    // Runs with mock if VES_MOCK_MODE=1 set
     // Skips if neither available
     acctest.RunWithMockOrReal(t, testCase, func(mockCfg *acctest.MockTestConfig) {
         // Optional: customize mock setup
@@ -338,10 +338,10 @@ mockCfg.SetupMyResourceMock("system", "test-resource")
 
 | Variable | Purpose |
 |----------|---------|
-| `F5XC_MOCK_MODE=1` | Enable mock testing mode |
+| `VES_MOCK_MODE=1` | Enable mock testing mode |
 | `TF_ACC=1` | Enable real acceptance tests |
-| `F5XC_API_URL` | Real API URL (for non-mock tests) |
-| `F5XC_API_TOKEN` | Real API token (for non-mock tests) |
+| `VES_API_URL` | Real API URL (for non-mock tests) |
+| `VES_API_TOKEN` | Real API token (for non-mock tests) |
 
 ## Test Categories and Reporting
 
@@ -431,9 +431,9 @@ mockCfg.PrePopulateResource(path, response)
 ```
 
 ### Tests not running
-Check that `F5XC_MOCK_MODE=1` is set:
+Check that `VES_MOCK_MODE=1` is set:
 ```bash
-F5XC_MOCK_MODE=1 go test -v ./internal/provider/ -run TestMock
+VES_MOCK_MODE=1 go test -v ./internal/provider/ -run TestMock
 ```
 
 ### Cascade delete not working

--- a/scripts/run-all-tests.sh
+++ b/scripts/run-all-tests.sh
@@ -2,26 +2,27 @@
 # Sequential test runner with rate limit protection
 #
 # Required environment variables:
-#   F5XC_API_URL - F5 XC API URL (e.g., https://console.ves.volterra.io/api)
-#   F5XC_API_P12_FILE - Path to P12 certificate file
-#   F5XC_P12_PASSWORD - Password for P12 certificate
+#   VES_API_URL - F5 XC API URL (e.g., https://console.ves.volterra.io/api)
+#   VES_P12_FILE - Path to P12 certificate file (or VES_API_TOKEN for token auth)
+#   VES_P12_PASSWORD - Password for P12 certificate (required with VES_P12_FILE)
 #   TF_ACC=1 - Enable acceptance tests
 
 set -e
 
 # Validate required environment variables
-if [[ -z "$F5XC_API_URL" ]]; then
-    echo "ERROR: F5XC_API_URL environment variable is required"
+if [[ -z "${VES_API_URL:-}" ]]; then
+    echo "ERROR: VES_API_URL environment variable is required"
     exit 1
 fi
 
-if [[ -z "$F5XC_API_P12_FILE" ]]; then
-    echo "ERROR: F5XC_API_P12_FILE environment variable is required"
+# Check for authentication (either P12 or token)
+if [[ -z "${VES_P12_FILE:-}" ]] && [[ -z "${VES_API_TOKEN:-}" ]]; then
+    echo "ERROR: VES_P12_FILE or VES_API_TOKEN environment variable is required"
     exit 1
 fi
 
-if [[ -z "$F5XC_P12_PASSWORD" ]]; then
-    echo "ERROR: F5XC_P12_PASSWORD environment variable is required"
+if [[ -n "${VES_P12_FILE:-}" ]] && [[ -z "${VES_P12_PASSWORD:-}" ]]; then
+    echo "ERROR: VES_P12_PASSWORD environment variable is required when using VES_P12_FILE"
     exit 1
 fi
 

--- a/scripts/run-comprehensive-tests.sh
+++ b/scripts/run-comprehensive-tests.sh
@@ -20,9 +20,10 @@
 #   --help             Show this help message
 #
 # Environment Variables (required for real-only or full mode):
-#   F5XC_API_URL        - F5 XC API URL
-#   F5XC_API_P12_FILE   - Path to P12 certificate file
-#   F5XC_P12_PASSWORD   - Password for P12 certificate
+#   VES_API_URL         - F5 XC API URL
+#   VES_P12_FILE        - Path to P12 certificate file
+#   VES_P12_PASSWORD    - Password for P12 certificate
+#   VES_API_TOKEN       - API token (alternative to P12 auth)
 #
 # Exit Codes:
 #   0 - All tests passed
@@ -135,14 +136,14 @@ log_verbose() {
 validate_real_api_env() {
     local missing=()
 
-    if [[ -z "${F5XC_API_URL:-}" ]]; then
-        missing+=("F5XC_API_URL")
+    if [[ -z "${VES_API_URL:-}" ]]; then
+        missing+=("VES_API_URL")
     fi
-    if [[ -z "${F5XC_API_P12_FILE:-}" ]]; then
-        missing+=("F5XC_API_P12_FILE")
+    if [[ -z "${VES_P12_FILE:-}" ]] && [[ -z "${VES_API_TOKEN:-}" ]]; then
+        missing+=("VES_P12_FILE or VES_API_TOKEN")
     fi
-    if [[ -z "${F5XC_P12_PASSWORD:-}" ]]; then
-        missing+=("F5XC_P12_PASSWORD")
+    if [[ -n "${VES_P12_FILE:-}" ]] && [[ -z "${VES_P12_PASSWORD:-}" ]]; then
+        missing+=("VES_P12_PASSWORD (required with VES_P12_FILE)")
     fi
 
     if [[ ${#missing[@]} -gt 0 ]]; then
@@ -153,9 +154,9 @@ validate_real_api_env() {
         return 1
     fi
 
-    # Verify P12 file exists
-    if [[ ! -f "$F5XC_API_P12_FILE" ]]; then
-        log_error "P12 file not found: $F5XC_API_P12_FILE"
+    # Verify P12 file exists if using P12 auth
+    if [[ -n "${VES_P12_FILE:-}" ]] && [[ ! -f "$VES_P12_FILE" ]]; then
+        log_error "P12 file not found: $VES_P12_FILE"
         return 1
     fi
 
@@ -175,12 +176,12 @@ run_mock_tests() {
     local output_file="$OUTPUT_DIR/test-output-mock.json"
 
     if [[ "$DRY_RUN" == "true" ]]; then
-        log_info "[DRY-RUN] Would run: F5XC_MOCK_MODE=1 go test -json -parallel $PARALLEL -timeout ${TIMEOUT}m -run 'TestMock.*' ./internal/provider/..."
+        log_info "[DRY-RUN] Would run: VES_MOCK_MODE=1 go test -json -parallel $PARALLEL -timeout ${TIMEOUT}m -run 'TestMock.*' ./internal/provider/..."
         return 0
     fi
 
     # Mock tests run in parallel - no rate limiting needed for local tests
-    F5XC_MOCK_MODE=1 go test -json \
+    VES_MOCK_MODE=1 go test -json \
         -parallel "$PARALLEL" \
         -timeout "${TIMEOUT}m" \
         -run 'TestMock.*' \

--- a/scripts/setup-self-hosted-runner.sh
+++ b/scripts/setup-self-hosted-runner.sh
@@ -19,8 +19,8 @@
 #   --runner-name NAME  Set runner name (default: hostname-f5xc)
 #
 # Environment Variables:
-#   F5XC_API_URL    - F5 XC API URL (used in non-interactive mode)
-#   F5XC_API_TOKEN  - F5 XC API Token (used in non-interactive mode)
+#   VES_API_URL     - F5 XC API URL (used in non-interactive mode)
+#   VES_API_TOKEN   - F5 XC API Token (used in non-interactive mode)
 #   GITHUB_TOKEN    - GitHub PAT for container mode (repo scope required)
 #
 # Container Mode Requirements:
@@ -213,7 +213,7 @@ configure_credentials() {
     log_step "Configuring F5 XC API credentials"
 
     # Use environment variables if available (non-interactive mode)
-    if [[ -n "${F5XC_API_URL:-}" ]] && [[ -n "${F5XC_API_TOKEN:-}" ]]; then
+    if [[ -n "${VES_API_URL:-}" ]] && [[ -n "${VES_API_TOKEN:-}" ]]; then
         log_info "Using credentials from environment variables"
     else
         echo ""
@@ -223,18 +223,18 @@ configure_credentials() {
         echo "  3. Copy the token"
         echo ""
 
-        prompt_input "F5 XC API URL" "https://console.ves.volterra.io" "F5XC_API_URL" "false"
-        prompt_input "F5 XC API Token" "" "F5XC_API_TOKEN" "true"
+        prompt_input "F5 XC API URL" "https://console.ves.volterra.io" "VES_API_URL" "false"
+        prompt_input "F5 XC API Token" "" "VES_API_TOKEN" "true"
     fi
 
-    if [[ -z "${F5XC_API_TOKEN:-}" ]]; then
-        log_error "API Token is required (set F5XC_API_TOKEN or provide interactively)"
+    if [[ -z "${VES_API_TOKEN:-}" ]]; then
+        log_error "API Token is required (set VES_API_TOKEN or provide interactively)"
         exit 1
     fi
 
     log_info "Setting GitHub secrets..."
-    echo "$F5XC_API_URL" | gh secret set F5XC_API_URL --repo "$REPO_FULL"
-    echo "$F5XC_API_TOKEN" | gh secret set F5XC_API_TOKEN --repo "$REPO_FULL"
+    echo "$VES_API_URL" | gh secret set VES_API_URL --repo "$REPO_FULL"
+    echo "$VES_API_TOKEN" | gh secret set VES_API_TOKEN --repo "$REPO_FULL"
     log_success "Secrets configured"
 }
 
@@ -403,7 +403,7 @@ print_summary() {
     echo ""
     echo "  Repository:  $REPO_FULL"
     echo "  Runner:      $RUNNER_DIR"
-    [[ -n "${F5XC_API_URL:-}" ]] && echo "  API URL:     $F5XC_API_URL"
+    [[ -n "${VES_API_URL:-}" ]] && echo "  API URL:     $VES_API_URL"
     echo ""
     echo "  Trigger tests:"
     echo "    gh workflow run acceptance-tests.yml -f mode=full"
@@ -473,8 +473,8 @@ configure_container_env() {
     fi
 
     # Get F5XC credentials if not skipping secrets
-    local f5xc_url="${F5XC_API_URL:-}"
-    local f5xc_token="${F5XC_API_TOKEN:-}"
+    local f5xc_url="${VES_API_URL:-}"
+    local f5xc_token="${VES_API_TOKEN:-}"
 
     if [[ "$SKIP_SECRETS" != "true" ]]; then  # pragma: allowlist secret
         if [[ -z "$f5xc_url" ]] || [[ -z "$f5xc_token" ]]; then
@@ -489,8 +489,8 @@ configure_container_env() {
 
         # Set GitHub secrets
         log_info "Setting GitHub secrets..."
-        echo "$f5xc_url" | gh secret set F5XC_API_URL --repo "$REPO_FULL"
-        echo "$f5xc_token" | gh secret set F5XC_API_TOKEN --repo "$REPO_FULL"
+        echo "$f5xc_url" | gh secret set VES_API_URL --repo "$REPO_FULL"
+        echo "$f5xc_token" | gh secret set VES_API_TOKEN --repo "$REPO_FULL"
         log_success "GitHub secrets configured"
     fi
 
@@ -504,8 +504,8 @@ GITHUB_REPOSITORY=${REPO_FULL}
 GITHUB_TOKEN=${github_token}
 RUNNER_NAME=${runner_name}
 RUNNER_LABELS=self-hosted,Linux,X64,container
-F5XC_API_URL=${f5xc_url:-}
-F5XC_API_TOKEN=${f5xc_token:-}
+VES_API_URL=${f5xc_url:-}
+VES_API_TOKEN=${f5xc_token:-}
 EOF
 
     chmod 600 "$env_file"
@@ -564,7 +564,7 @@ print_container_summary() {
     echo ""
     echo "  Repository:  $REPO_FULL"
     echo "  Runner:      Docker container (f5xc-github-runner)"
-    [[ -n "${F5XC_API_URL:-}" ]] && echo "  API URL:     $F5XC_API_URL"
+    [[ -n "${VES_API_URL:-}" ]] && echo "  API URL:     $VES_API_URL"
     echo ""
     echo "  Commands:"
     echo "    View logs:    cd .github-runner-docker && docker-compose logs -f"

--- a/templates/guides/authentication.md
+++ b/templates/guides/authentication.md
@@ -95,9 +95,9 @@ P12 certificates provide mutual TLS (mTLS) authentication, where both the client
 **Using Environment Variables:**
 
 ```bash
-export F5XC_API_URL="https://your-tenant.console.ves.volterra.io/api"
-export F5XC_API_P12_FILE="/path/to/your-credentials.p12"
-export F5XC_P12_PASSWORD="your-p12-password"  # pragma: allowlist secret
+export VES_API_URL="https://your-tenant.console.ves.volterra.io/api"
+export VES_P12_FILE="/path/to/your-credentials.p12"
+export VES_P12_PASSWORD="your-p12-password"  # pragma: allowlist secret
 ```
 
 **Using Provider Configuration:**
@@ -134,9 +134,9 @@ openssl pkcs12 -in ~/your-tenant.console.ves.volterra.io.api-creds.p12 \
 **Using Environment Variables:**
 
 ```bash
-export F5XC_API_URL="https://your-tenant.console.ves.volterra.io/api"
-export F5XC_API_CERT="/path/to/certs/f5xc.cert"
-export F5XC_API_KEY="/path/to/certs/f5xc.key"
+export VES_API_URL="https://your-tenant.console.ves.volterra.io/api"
+export VES_CERT="/path/to/certs/f5xc.cert"
+export VES_KEY="/path/to/certs/f5xc.key"
 ```
 
 **Using Provider Configuration:**
@@ -149,7 +149,7 @@ provider "f5xc" {
 }
 ```
 
-~> **Note:** If you need to verify the server certificate, you can also specify a CA certificate using `F5XC_API_CA_CERT` environment variable or `api_ca_cert` provider attribute.
+~> **Note:** If you need to verify the server certificate, you can also specify a CA certificate using `VES_CACERT` environment variable or `api_ca_cert` provider attribute.
 
 ### Method 3: API Token Authentication (Simplest)
 
@@ -158,8 +158,8 @@ API tokens provide the simplest authentication method using bearer token authent
 **Using Environment Variables:**
 
 ```bash
-export F5XC_API_URL="https://your-tenant.console.ves.volterra.io/api"
-export F5XC_API_TOKEN="your-api-token"
+export VES_API_URL="https://your-tenant.console.ves.volterra.io/api"
+export VES_API_TOKEN="your-api-token"
 ```
 
 **Using Provider Configuration:**
@@ -186,13 +186,13 @@ Environment variables are the recommended approach because they:
 
 | Variable | Description | Required |
 |----------|-------------|----------|
-| `F5XC_API_URL` | F5XC tenant API URL | Yes |
-| `F5XC_API_TOKEN` | API token for bearer authentication | One of: token, P12, or PEM |
-| `F5XC_API_P12_FILE` | Path to P12 certificate file | With `F5XC_P12_PASSWORD` |
-| `F5XC_P12_PASSWORD` | Password for P12 file | With `F5XC_API_P12_FILE` |
-| `F5XC_API_CERT` | Path to PEM certificate file | With `F5XC_API_KEY` |
-| `F5XC_API_KEY` | Path to PEM private key file | With `F5XC_API_CERT` |
-| `F5XC_API_CA_CERT` | Path to CA certificate for server verification | No |
+| `VES_API_URL` | F5XC tenant API URL | Yes |
+| `VES_API_TOKEN` | API token for bearer authentication | One of: token, P12, or PEM |
+| `VES_P12_FILE` | Path to P12 certificate file | With `VES_P12_PASSWORD` |
+| `VES_P12_PASSWORD` | Password for P12 file | With `VES_P12_FILE` |
+| `VES_CERT` | Path to PEM certificate file | With `VES_KEY` |
+| `VES_KEY` | Path to PEM private key file | With `VES_CERT` |
+| `VES_CACERT` | Path to CA certificate for server verification | No |
 
 **Adding to Shell Profile:**
 
@@ -200,8 +200,8 @@ For persistence across terminal sessions, add exports to your shell profile:
 
 ```bash
 # Add to ~/.bashrc or ~/.zshrc
-export F5XC_API_URL="https://your-tenant.console.ves.volterra.io/api"
-export F5XC_API_TOKEN="your-api-token"
+export VES_API_URL="https://your-tenant.console.ves.volterra.io/api"
+export VES_API_TOKEN="your-api-token"
 ```
 
 Then reload your shell: `source ~/.zshrc` or `source ~/.bashrc`
@@ -274,15 +274,15 @@ jobs:
 
       - name: Terraform Plan
         env:
-          F5XC_API_URL: ${{ secrets.F5XC_API_URL }}
-          F5XC_API_TOKEN: ${{ secrets.F5XC_API_TOKEN }}
+          VES_API_URL: ${{ secrets.VES_API_URL }}
+          VES_API_TOKEN: ${{ secrets.VES_API_TOKEN }}
         run: terraform plan -out=tfplan
 
       - name: Terraform Apply
         if: github.ref == 'refs/heads/main' && github.event_name == 'push'
         env:
-          F5XC_API_URL: ${{ secrets.F5XC_API_URL }}
-          F5XC_API_TOKEN: ${{ secrets.F5XC_API_TOKEN }}
+          VES_API_URL: ${{ secrets.VES_API_URL }}
+          VES_API_TOKEN: ${{ secrets.VES_API_TOKEN }}
         run: terraform apply -auto-approve tfplan
 ```
 
@@ -295,8 +295,8 @@ jobs:
 
 | Secret Name | Value |
 |-------------|-------|
-| `F5XC_API_URL` | `https://your-tenant.console.ves.volterra.io/api` |
-| `F5XC_API_TOKEN` | Your API token value |
+| `VES_API_URL` | `https://your-tenant.console.ves.volterra.io/api` |
+| `VES_API_TOKEN` | Your API token value |
 
 ### GitHub Actions with P12 Certificate (More Secure)
 
@@ -325,7 +325,7 @@ jobs:
 
       - name: Setup P12 Certificate
         run: |
-          echo "${{ secrets.F5XC_P12_BASE64 }}" | base64 -d > /tmp/f5xc-credentials.p12
+          echo "${{ secrets.VES_P12_BASE64 }}" | base64 -d > /tmp/f5xc-credentials.p12
           chmod 600 /tmp/f5xc-credentials.p12
 
       - name: Terraform Init
@@ -333,17 +333,17 @@ jobs:
 
       - name: Terraform Plan
         env:
-          F5XC_API_URL: ${{ secrets.F5XC_API_URL }}
-          F5XC_API_P12_FILE: /tmp/f5xc-credentials.p12
-          F5XC_P12_PASSWORD: ${{ secrets.F5XC_P12_PASSWORD }}
+          VES_API_URL: ${{ secrets.VES_API_URL }}
+          VES_P12_FILE: /tmp/f5xc-credentials.p12
+          VES_P12_PASSWORD: ${{ secrets.VES_P12_PASSWORD }}
         run: terraform plan -out=tfplan
 
       - name: Terraform Apply
         if: github.ref == 'refs/heads/main' && github.event_name == 'push'
         env:
-          F5XC_API_URL: ${{ secrets.F5XC_API_URL }}
-          F5XC_API_P12_FILE: /tmp/f5xc-credentials.p12
-          F5XC_P12_PASSWORD: ${{ secrets.F5XC_P12_PASSWORD }}
+          VES_API_URL: ${{ secrets.VES_API_URL }}
+          VES_P12_FILE: /tmp/f5xc-credentials.p12
+          VES_P12_PASSWORD: ${{ secrets.VES_P12_PASSWORD }}
         run: terraform apply -auto-approve tfplan
 
       - name: Cleanup Credentials
@@ -369,9 +369,9 @@ base64 -w 0 your-credentials.p12
 
 | Secret Name | Value |
 |-------------|-------|
-| `F5XC_API_URL` | `https://your-tenant.console.ves.volterra.io/api` |
-| `F5XC_P12_BASE64` | Base64-encoded P12 file contents |
-| `F5XC_P12_PASSWORD` | Password for the P12 file |
+| `VES_API_URL` | `https://your-tenant.console.ves.volterra.io/api` |
+| `VES_P12_BASE64` | Base64-encoded P12 file contents |
+| `VES_P12_PASSWORD` | Password for the P12 file |
 
 ## Security Best Practices
 
@@ -414,8 +414,8 @@ When creating credentials, consider:
 
 ```bash
 # Verify environment variables are set
-echo $F5XC_API_URL
-echo $F5XC_API_TOKEN
+echo $VES_API_URL
+echo $VES_API_TOKEN
 ```
 
 ### Certificate Verification Failed
@@ -452,8 +452,8 @@ openssl pkcs12 -in your-credentials.p12 -nokeys -info
 1. Ensure variables are exported (not just set)
 
    ```bash
-   export F5XC_API_TOKEN="token"  # Correct
-   F5XC_API_TOKEN="token"         # Won't work with Terraform
+   export VES_API_TOKEN="token"  # Correct
+   VES_API_TOKEN="token"         # Won't work with Terraform
    ```
 
 2. Verify spelling matches exactly (case-sensitive)

--- a/templates/guides/blindfold.md
+++ b/templates/guides/blindfold.md
@@ -66,15 +66,15 @@ Configure one of these authentication methods via environment variables:
 
 **Option 1: API Token (Recommended for development)**
 ```bash
-export F5XC_API_URL="https://your-tenant.console.ves.volterra.io/api"
-export F5XC_API_TOKEN="your-api-token"
+export VES_API_URL="https://your-tenant.console.ves.volterra.io/api"
+export VES_API_TOKEN="your-api-token"
 ```
 
 **Option 2: P12 Certificate (Recommended for production)**
 ```bash
-export F5XC_API_URL="https://your-tenant.console.ves.volterra.io/api"
-export F5XC_API_P12_FILE="/path/to/your-credentials.p12"
-export F5XC_P12_PASSWORD="your-p12-password"  # pragma: allowlist secret
+export VES_API_URL="https://your-tenant.console.ves.volterra.io/api"
+export VES_P12_FILE="/path/to/your-credentials.p12"
+export VES_P12_PASSWORD="your-p12-password"  # pragma: allowlist secret
 ```
 
 -> **Tip:** Add these to your shell profile (`~/.bashrc` or `~/.zshrc`) for persistence across terminal sessions.
@@ -407,12 +407,12 @@ Field descriptions:
 **Solution:**
 ```bash
 # Verify environment variables are set
-echo $F5XC_API_URL
-echo $F5XC_API_TOKEN  # or F5XC_API_P12_FILE
+echo $VES_API_URL
+echo $VES_API_TOKEN  # or VES_P12_FILE
 
 # Set them if missing
-export F5XC_API_URL="https://your-tenant.console.ves.volterra.io/api"
-export F5XC_API_TOKEN="your-api-token"
+export VES_API_URL="https://your-tenant.console.ves.volterra.io/api"
+export VES_API_TOKEN="your-api-token"
 ```
 
 ### Policy Not Found

--- a/templates/guides/http-loadbalancer.md
+++ b/templates/guides/http-loadbalancer.md
@@ -42,8 +42,8 @@ cd terraform-provider-f5xc/examples/guides/http-loadbalancer
 Configure authentication using environment variables. **Never commit credentials to version control.**
 
 ```bash
-export F5XC_API_URL="https://your-tenant.console.ves.volterra.io/api"
-export F5XC_API_TOKEN="your-api-token"
+export VES_API_URL="https://your-tenant.console.ves.volterra.io/api"
+export VES_API_TOKEN="your-api-token"
 ```
 
 -> **Tip:** Add these to your shell profile (`~/.bashrc` or `~/.zshrc`) for persistence across terminal sessions.

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -36,19 +36,19 @@ Learn more about [how to generate API credentials](https://docs.cloud.f5.com/doc
 
 ### Required (one of the following authentication methods)
 
-* `api_token` - F5 Distributed Cloud API Token (`String`, Sensitive). Can also be set via `F5XC_API_TOKEN` environment variable.
+* `api_token` - F5 Distributed Cloud API Token (`String`, Sensitive). Can also be set via `VES_API_TOKEN` environment variable.
 
-* `api_p12_file` - Path to PKCS#12 certificate bundle file (`String`). Can also be set via `F5XC_API_P12_FILE` environment variable. Requires `p12_password`.
+* `api_p12_file` - Path to PKCS#12 certificate bundle file (`String`). Can also be set via `VES_P12_FILE` environment variable. Requires `p12_password`.
 
-* `api_cert` and `api_key` - Paths to PEM-encoded certificate and private key files (`String`). Can also be set via `F5XC_API_CERT` and `F5XC_API_KEY` environment variables.
+* `api_cert` and `api_key` - Paths to PEM-encoded certificate and private key files (`String`). Can also be set via `VES_CERT` and `VES_KEY` environment variables.
 
 ### Optional
 
-* `api_url` - F5 Distributed Cloud API URL (`String`). Defaults to `https://console.ves.volterra.io/api`. Can also be set via `F5XC_API_URL` environment variable.
+* `api_url` - F5 Distributed Cloud API URL (`String`). Defaults to `https://console.ves.volterra.io/api`. Can also be set via `VES_API_URL` environment variable.
 
-* `p12_password` - Password for PKCS#12 certificate bundle (`String`, Sensitive). Required when using `api_p12_file`. Can also be set via `F5XC_P12_PASSWORD` environment variable.
+* `p12_password` - Password for PKCS#12 certificate bundle (`String`, Sensitive). Required when using `api_p12_file`. Can also be set via `VES_P12_PASSWORD` environment variable.
 
-* `api_ca_cert` - Path to PEM-encoded CA certificate file (`String`). Optional, used for server certificate verification. Can also be set via `F5XC_API_CA_CERT` environment variable.
+* `api_ca_cert` - Path to PEM-encoded CA certificate file (`String`). Optional, used for server certificate verification. Can also be set via `VES_CACERT` environment variable.
 
 ## Authentication Options
 
@@ -68,8 +68,8 @@ provider "f5xc" {
 **Environment Variables:**
 
 ```bash
-export F5XC_API_URL="https://your-tenant.console.ves.volterra.io/api"
-export F5XC_API_TOKEN="your-api-token"
+export VES_API_URL="https://your-tenant.console.ves.volterra.io/api"
+export VES_API_TOKEN="your-api-token"
 ```
 
 ### Option 2: P12 Certificate Authentication
@@ -89,9 +89,9 @@ provider "f5xc" {
 **Environment Variables:**
 
 ```bash
-export F5XC_API_URL="https://your-tenant.console.ves.volterra.io/api"
-export F5XC_API_P12_FILE="/path/to/certificate.p12"
-export F5XC_P12_PASSWORD="your-p12-password"
+export VES_API_URL="https://your-tenant.console.ves.volterra.io/api"
+export VES_P12_FILE="/path/to/certificate.p12"
+export VES_P12_PASSWORD="your-p12-password"
 ```
 
 ### Option 3: PEM Certificate Authentication
@@ -112,10 +112,10 @@ provider "f5xc" {
 **Environment Variables:**
 
 ```bash
-export F5XC_API_URL="https://your-tenant.console.ves.volterra.io/api"
-export F5XC_API_CERT="/path/to/certificate.crt"
-export F5XC_API_KEY="/path/to/private.key"
-export F5XC_API_CA_CERT="/path/to/ca-certificate.crt"  # Optional
+export VES_API_URL="https://your-tenant.console.ves.volterra.io/api"
+export VES_CERT="/path/to/certificate.crt"
+export VES_KEY="/path/to/private.key"
+export VES_CACERT="/path/to/ca-certificate.crt"  # Optional
 ```
 
 -> **Note:** Environment variables are the recommended approach for CI/CD pipelines and to avoid storing sensitive credentials in version control.

--- a/tools/discover-defaults.go
+++ b/tools/discover-defaults.go
@@ -13,9 +13,9 @@
 //
 // Environment Variables Required:
 //
-//	F5XC_API_URL - API URL (e.g., https://tenant.console.ves.volterra.io/api)
-//	F5XC_API_P12_FILE + F5XC_P12_PASSWORD - P12 certificate authentication
-//	or F5XC_API_TOKEN - Token authentication
+//	VES_API_URL - API URL (e.g., https://tenant.console.ves.volterra.io/api)
+//	VES_P12_FILE + VES_P12_PASSWORD - P12 certificate authentication
+//	or VES_API_TOKEN - Token authentication
 package main
 
 import (
@@ -459,9 +459,9 @@ func main() {
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error creating API client: %v\n", err)
 		fmt.Fprintf(os.Stderr, "\nRequired environment variables:\n")
-		fmt.Fprintf(os.Stderr, "  F5XC_API_URL - API URL\n")
-		fmt.Fprintf(os.Stderr, "  F5XC_API_P12_FILE + F5XC_P12_PASSWORD - P12 cert auth\n")
-		fmt.Fprintf(os.Stderr, "  or F5XC_API_TOKEN - Token auth\n")
+		fmt.Fprintf(os.Stderr, "  VES_API_URL - API URL\n")
+		fmt.Fprintf(os.Stderr, "  VES_P12_FILE + VES_P12_PASSWORD - P12 cert auth\n")
+		fmt.Fprintf(os.Stderr, "  or VES_API_TOKEN - Token auth\n")
 		os.Exit(1)
 	}
 
@@ -469,7 +469,7 @@ func main() {
 	db := &DefaultsDatabase{
 		Version:     "1.0.0",
 		GeneratedAt: time.Now().UTC().Format(time.RFC3339),
-		APIEndpoint: os.Getenv("F5XC_API_URL"),
+		APIEndpoint: os.Getenv("VES_API_URL"),
 		Resources:   make(map[string]*DiscoveryResult),
 	}
 
@@ -576,20 +576,20 @@ func main() {
 // ============================================================================
 
 func createClient() (*client.Client, error) {
-	apiURL := os.Getenv("F5XC_API_URL")
+	apiURL := os.Getenv("VES_API_URL")
 	if apiURL == "" {
-		return nil, fmt.Errorf("F5XC_API_URL environment variable not set")
+		return nil, fmt.Errorf("VES_API_URL environment variable not set")
 	}
 
 	// Try P12 authentication first
-	p12File := os.Getenv("F5XC_API_P12_FILE")
-	p12Password := os.Getenv("F5XC_P12_PASSWORD")
+	p12File := os.Getenv("VES_P12_FILE")
+	p12Password := os.Getenv("VES_P12_PASSWORD")
 	if p12File != "" && p12Password != "" {
 		return client.NewClientWithP12(apiURL, p12File, p12Password)
 	}
 
 	// Fall back to token authentication
-	apiToken := os.Getenv("F5XC_API_TOKEN")
+	apiToken := os.Getenv("VES_API_TOKEN")
 	if apiToken != "" {
 		return client.NewClient(apiURL, apiToken), nil
 	}

--- a/tools/generate-all-schemas.go
+++ b/tools/generate-all-schemas.go
@@ -13,7 +13,7 @@
 // Usage: go run tools/generate-all-schemas.go [--spec-dir=/path/to/specs] [--dry-run]
 //
 // Environment Variables:
-//   F5XC_SPEC_DIR - Directory containing OpenAPI spec files (default: /tmp)
+//   VES_SPEC_DIR - Directory containing OpenAPI spec files (default: /tmp)
 
 package main
 
@@ -141,7 +141,7 @@ func main() {
 
 	// Check for spec directory
 	if specDir == "" {
-		specDir = os.Getenv("F5XC_SPEC_DIR")
+		specDir = os.Getenv("VES_SPEC_DIR")
 	}
 	if specDir == "" {
 		specDir = "docs/specifications/api"
@@ -166,7 +166,7 @@ func main() {
 
 	if len(specFiles) == 0 {
 		fmt.Printf("❌ No spec files found matching pattern: %s\n", pattern)
-		fmt.Println("💡 Tip: Download specs from docs.cloud.f5.com or set F5XC_SPEC_DIR")
+		fmt.Println("💡 Tip: Download specs from docs.cloud.f5.com or set VES_SPEC_DIR")
 		os.Exit(1)
 	}
 
@@ -3317,44 +3317,44 @@ func (p *F5XCProvider) Schema(ctx context.Context, req provider.SchemaRequest, r
 				MarkdownDescription: "F5 Distributed Cloud API URL (base URL without '/api' suffix). " +
 					"Defaults to https://console.ves.volterra.io. " +
 					"Example: https://tenant.console.ves.volterra.io (NOT https://tenant.console.ves.volterra.io/api). " +
-					"Can also be set via F5XC_API_URL environment variable.",
+					"Can also be set via VES_API_URL environment variable.",
 				Optional: true,
 			},
 			"api_token": schema.StringAttribute{
 				MarkdownDescription: "F5 Distributed Cloud API Token for token-based authentication. " +
-					"Can also be set via F5XC_API_TOKEN environment variable. " +
+					"Can also be set via VES_API_TOKEN environment variable. " +
 					"Either api_token or api_p12_file/api_cert must be specified.",
 				Optional:  true,
 				Sensitive: true,
 			},
 			"api_p12_file": schema.StringAttribute{
 				MarkdownDescription: "Path to PKCS#12 certificate bundle file for certificate-based authentication. " +
-					"Can also be set via F5XC_API_P12_FILE environment variable. " +
+					"Can also be set via VES_P12_FILE environment variable. " +
 					"When using P12 authentication, p12_password must also be provided.",
 				Optional:  true,
 				Sensitive: false,
 			},
 			"p12_password": schema.StringAttribute{
 				MarkdownDescription: "Password for the PKCS#12 certificate bundle. " +
-					"Can also be set via F5XC_P12_PASSWORD environment variable.",
+					"Can also be set via VES_P12_PASSWORD environment variable.",
 				Optional:  true,
 				Sensitive: true,
 			},
 			"api_cert": schema.StringAttribute{
 				MarkdownDescription: "Path to PEM-encoded client certificate file for certificate-based authentication. " +
-					"Can also be set via F5XC_API_CERT environment variable. " +
+					"Can also be set via VES_CERT environment variable. " +
 					"When using certificate authentication, api_key must also be provided.",
 				Optional: true,
 			},
 			"api_key": schema.StringAttribute{
 				MarkdownDescription: "Path to PEM-encoded client private key file for certificate-based authentication. " +
-					"Can also be set via F5XC_API_KEY environment variable.",
+					"Can also be set via VES_KEY environment variable.",
 				Optional:  true,
 				Sensitive: true,
 			},
 			"api_ca_cert": schema.StringAttribute{
 				MarkdownDescription: "Path to PEM-encoded CA certificate file for verifying the F5XC API server. " +
-					"Can also be set via F5XC_API_CA_CERT environment variable. Optional.",
+					"Can also be set via VES_CACERT environment variable. Optional.",
 				Optional: true,
 			},
 		},
@@ -3373,13 +3373,13 @@ func (p *F5XCProvider) Configure(ctx context.Context, req provider.ConfigureRequ
 	}
 
 	// Get configuration values from environment variables first
-	apiURL := os.Getenv("F5XC_API_URL")
-	apiToken := os.Getenv("F5XC_API_TOKEN")
-	apiP12File := os.Getenv("F5XC_API_P12_FILE")
-	p12Password := os.Getenv("F5XC_P12_PASSWORD")
-	apiCert := os.Getenv("F5XC_API_CERT")
-	apiKey := os.Getenv("F5XC_API_KEY")
-	apiCACert := os.Getenv("F5XC_API_CA_CERT")
+	apiURL := os.Getenv("VES_API_URL")
+	apiToken := os.Getenv("VES_API_TOKEN")
+	apiP12File := os.Getenv("VES_P12_FILE")
+	p12Password := os.Getenv("VES_P12_PASSWORD")
+	apiCert := os.Getenv("VES_CERT")
+	apiKey := os.Getenv("VES_KEY")
+	apiCACert := os.Getenv("VES_CACERT")
 
 	// Configuration values override environment variables
 	if !config.APIURL.IsNull() {
@@ -3421,7 +3421,7 @@ func (p *F5XCProvider) Configure(ctx context.Context, req provider.ConfigureRequ
 				path.Root("p12_password"),
 				"Missing P12 Password",
 				"When using P12 certificate authentication (api_p12_file), the p12_password must be provided. "+
-					"Set the p12_password value in the configuration or use the F5XC_P12_PASSWORD environment variable.",
+					"Set the p12_password value in the configuration or use the VES_P12_PASSWORD environment variable.",
 			)
 			return
 		}
@@ -3456,9 +3456,9 @@ func (p *F5XCProvider) Configure(ctx context.Context, req provider.ConfigureRequ
 		resp.Diagnostics.AddError(
 			"Missing Authentication Configuration",
 			"The provider requires authentication. Please configure one of the following:\n"+
-				"  - api_token (or F5XC_API_TOKEN environment variable) for API token authentication\n"+
-				"  - api_p12_file and p12_password (or F5XC_API_P12_FILE and F5XC_P12_PASSWORD environment variables) for P12 certificate authentication\n"+
-				"  - api_cert and api_key (or F5XC_API_CERT and F5XC_API_KEY environment variables) for PEM certificate authentication",
+				"  - api_token (or VES_API_TOKEN environment variable) for API token authentication\n"+
+				"  - api_p12_file and p12_password (or VES_P12_FILE and VES_P12_PASSWORD environment variables) for P12 certificate authentication\n"+
+				"  - api_cert and api_key (or VES_CERT and VES_KEY environment variables) for PEM certificate authentication",
 		)
 		return
 	}


### PR DESCRIPTION
## Summary
Refactors all environment variable names from `F5XC_*` prefix to `VES_*` prefix to align with vesctl CLI naming conventions.

## Related Issue
Closes #389

## Breaking Change
**All environment variable names have been changed.** Users must update their configuration.

### User-Facing Authentication Variables
| Old | New |
|-----|-----|
| `F5XC_API_URL` | `VES_API_URL` |
| `F5XC_API_TOKEN` | `VES_API_TOKEN` |
| `F5XC_API_P12_FILE` | `VES_P12_FILE` |
| `F5XC_P12_PASSWORD` | `VES_P12_PASSWORD` |
| `F5XC_API_CERT` | `VES_CERT` |
| `F5XC_API_KEY` | `VES_KEY` |
| `F5XC_API_CA_CERT` | `VES_CACERT` |

### Internal/Testing Variables
| Old | New |
|-----|-----|
| `F5XC_MOCK_MODE` | `VES_MOCK_MODE` |
| `F5XC_TEST_NAMESPACE` | `VES_DEFAULT_NAMESPACE` |
| `F5XC_TENANT_NAME` | `VES_TENANT_NAME` |

## Changes Made
- Updated generator tool (`tools/generate-all-schemas.go`)
- Updated authentication packages (`internal/blindfold/`, `internal/acctest/`)
- Updated provider functions (`internal/functions/`)
- Updated documentation templates (`templates/`)
- Updated example configurations (`examples/`)
- Updated CI/CD workflows (`.github/workflows/`)
- Updated scripts and Makefile

## Testing
- [x] Unit tests pass
- [x] Build succeeds
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)