### PR TITLE
docs: add AI-enhanced schema section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,24 @@ export VES_API_TOKEN="your-api-token"
 - [Provider Documentation](https://registry.terraform.io/providers/robinmordasiewicz/f5xc/latest/docs)
 - [F5 Distributed Cloud API](https://docs.cloud.f5.com/)
 
+## AI-Enhanced Schema
+
+For AI agents and tooling, an enhanced schema wrapper is available that adds an `ai_hints` namespace with OneOf constraints, enum values, resource categories, and recommended defaults:
+
+```bash
+terraform providers schema -json | go run tools/terraform-schema-ai/main.go -stdin
+```
+
+The wrapper enriches the standard Terraform schema with:
+
+- **OneOf groups**: Mutually exclusive fields extracted from OpenAPI specs
+- **Recommended defaults**: Best practice default choices for OneOf constraints
+- **Resource categories**: Load Balancing, Security, DNS, Networking, etc.
+- **Dependencies**: Common resource creation order
+- **Enum values**: Valid values for enum fields
+
+The original `provider_schemas` output remains unchanged; AI hints are added in a separate `ai_hints` namespace.
+
 ## License
 
 [Mozilla Public License 2.0](LICENSE)


### PR DESCRIPTION
## Summary

Add documentation for the `terraform-schema-ai` wrapper tool to the README.

## Changes

- Added new "AI-Enhanced Schema" section explaining the wrapper tool
- Documents usage: `terraform providers schema -json | go run tools/terraform-schema-ai/main.go -stdin`
- Lists the AI hints provided: OneOf groups, recommended defaults, categories, dependencies, enums

🤖 Generated with [Claude Code](https://claude.com/claude-code)