### PR TITLE
docs: standardize naming convention from 'my-' to 'example-'

### DIFF
--- a/templates/data-sources.md.tmpl
+++ b/templates/data-sources.md.tmpl
@@ -20,7 +20,7 @@ description: |-
 {{- else }}
 ```terraform
 data "{{ .Name }}" "example" {
-  name      = "my-resource"
+  name      = "example-resource"
   namespace = "system"
 }
 ```

--- a/templates/guides/blindfold.md
+++ b/templates/guides/blindfold.md
@@ -101,7 +101,7 @@ Edit `terraform.tfvars` to enable the examples you want to test:
 enable_certificate_example = true
 
 # Namespace configuration
-namespace_name   = "my-blindfold-test"
+namespace_name   = "example-blindfold-test"
 create_namespace = true
 ```
 
@@ -193,7 +193,7 @@ Store TLS certificates for load balancers. Note that TLS private keys are typica
 
 ```hcl
 resource "f5xc_certificate" "example" {
-  name      = "my-certificate"
+  name      = "example-certificate"
   namespace = "shared"
 
   certificate_url = "string:///${base64encode(file("${path.module}/certs/server.crt"))}"
@@ -319,8 +319,8 @@ While the built-in `ves-io-allow-volterra` policy works for most cases, you can 
 
 ```hcl
 locals {
-  policy_name = "my-custom-policy"
-  policy_ns   = "my-namespace"
+  policy_name = "example-custom-policy"
+  policy_ns   = "example-namespace"
 }
 
 # Reference your custom policy

--- a/templates/guides/http-loadbalancer.md
+++ b/templates/guides/http-loadbalancer.md
@@ -65,7 +65,7 @@ origin_server = "origin.example.com"
 origin_port   = 443
 
 # Namespace configuration
-namespace_name   = "my-app"
+namespace_name   = "example-app"
 create_namespace = true
 
 # Security features (all enabled by default)
@@ -108,7 +108,7 @@ After deployment, Terraform outputs a CNAME target. Create a DNS record:
 To deploy into an existing namespace instead of creating a new one:
 
 ```hcl
-namespace_name   = "my-existing-namespace"
+namespace_name   = "example-namespace"
 create_namespace = false
 ```
 

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -132,7 +132,7 @@ export VES_CACERT="/path/to/ca-certificate.crt"  # Optional
 
 ```hcl
 resource "f5xc_namespace" "example" {
-  name = "my-namespace"
+  name = "example-namespace"
 }
 ```
 
@@ -140,8 +140,8 @@ resource "f5xc_namespace" "example" {
 
 ```hcl
 resource "f5xc_http_loadbalancer" "example" {
-  name      = "my-load-balancer"
-  namespace = "my-namespace"
+  name      = "example-load-balancer"
+  namespace = "example-namespace"
   domains   = ["example.com"]
 }
 ```


### PR DESCRIPTION
## Summary

Standardizes naming convention across documentation templates by replacing all instances of `my-` prefix with `example-` prefix.

## Related Issue

Closes #399

## Changes Made

- **templates/index.md.tmpl**: 3 replacements
  - `my-namespace` → `example-namespace` (2 instances)
  - `my-load-balancer` → `example-load-balancer`
- **templates/data-sources.md.tmpl**: 1 replacement
  - `my-resource` → `example-resource`
- **templates/guides/http-loadbalancer.md**: 2 replacements
  - `my-app` → `example-app`
  - `my-existing-namespace` → `example-namespace`
- **templates/guides/blindfold.md**: 4 replacements
  - `my-blindfold-test` → `example-blindfold-test`
  - `my-certificate` → `example-certificate`
  - `my-custom-policy` → `example-custom-policy`
  - `my-namespace` → `example-namespace`

## Analysis Summary

| Location | Status |
|----------|--------|
| Generator tools (`tools/`) | ✅ Already uses `example-` (41+ instances) |
| Template files (`templates/`) | ✅ Fixed in this PR (10 replacements) |
| OpenAPI specs (`docs/specifications/api/`) | ⏭️ Skipped - external source, only 9 instances |

## Testing

- [x] All template files updated
- [x] Pre-commit hooks pass
- [x] No generated files modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)