### PR TITLE
chore(tests): standardize environment variable naming to VES_* convention

### DIFF
--- a/internal/provider/aws_vpc_site_resource_mock_test.go
+++ b/internal/provider/aws_vpc_site_resource_mock_test.go
@@ -20,7 +20,7 @@ import (
 // They validate provider logic without requiring cloud credentials.
 //
 // Run with:
-//   F5XC_MOCK_MODE=1 go test -v ./internal/provider/ -run TestMockAWSVPCSite -timeout 5m
+//   VES_MOCK_MODE=1 go test -v ./internal/provider/ -run TestMockAWSVPCSite -timeout 5m
 //
 // These tests complement the real acceptance tests by:
 // 1. Testing provider CRUD logic without cloud dependencies

--- a/internal/provider/child_tenant_manager_data_source_test.go
+++ b/internal/provider/child_tenant_manager_data_source_test.go
@@ -20,7 +20,7 @@ import (
 // with child tenant management capabilities.
 //
 // Run with:
-//   TF_ACC=1 F5XC_API_URL="..." F5XC_API_P12_FILE="..." F5XC_P12_PASSWORD="..." \
+//   TF_ACC=1 VES_API_URL="..." VES_P12_FILE="..." VES_P12_PASSWORD="..." \
 //   go test -v ./internal/provider/ -run TestAccChildTenantManagerDataSource -timeout 30m
 // =============================================================================
 

--- a/internal/provider/dns_domain_resource_test.go
+++ b/internal/provider/dns_domain_resource_test.go
@@ -35,7 +35,7 @@ import (
 // 10. DNSSEC Mode Test - Test dnssec_mode attribute functionality
 //
 // Run with:
-//   TF_ACC=1 F5XC_API_URL="..." F5XC_API_P12_FILE="..." F5XC_P12_PASSWORD="..." \
+//   TF_ACC=1 VES_API_URL="..." VES_P12_FILE="..." VES_P12_PASSWORD="..." \
 //   go test -v ./internal/provider/ -run TestAccDNSDomainResource -timeout 30m
 // =============================================================================
 

--- a/internal/provider/dns_zone_resource_test.go
+++ b/internal/provider/dns_zone_resource_test.go
@@ -34,7 +34,7 @@ import (
 // 9. Requires Replace Test - Name change forces replacement
 //
 // Run with:
-//   TF_ACC=1 F5XC_API_URL="..." F5XC_API_P12_FILE="..." F5XC_P12_PASSWORD="..." \
+//   TF_ACC=1 VES_API_URL="..." VES_P12_FILE="..." VES_P12_PASSWORD="..." \
 //   go test -v ./internal/provider/ -run TestAccDNSZoneResource -timeout 30m
 // =============================================================================
 

--- a/internal/provider/healthcheck_resource_test.go
+++ b/internal/provider/healthcheck_resource_test.go
@@ -25,7 +25,7 @@ import (
 //
 // Run with:
 //
-//	TF_ACC=1 F5XC_API_URL="..." F5XC_API_P12_FILE="..." F5XC_P12_PASSWORD="..." \
+//	TF_ACC=1 VES_API_URL="..." VES_P12_FILE="..." VES_P12_PASSWORD="..." \
 //	go test -v ./internal/provider/ -run TestAccHealthcheckResource -timeout 30m
 //
 // =============================================================================

--- a/internal/provider/ip_prefix_set_resource_test.go
+++ b/internal/provider/ip_prefix_set_resource_test.go
@@ -35,7 +35,7 @@ import (
 // 9. IPv4 Prefixes Test - Test nested block configuration
 //
 // Run with:
-//   TF_ACC=1 F5XC_API_URL="..." F5XC_API_P12_FILE="..." F5XC_P12_PASSWORD="..." \
+//   TF_ACC=1 VES_API_URL="..." VES_P12_FILE="..." VES_P12_PASSWORD="..." \
 //   go test -v ./internal/provider/ -run TestAccIPPrefixSetResource -timeout 30m
 // =============================================================================
 

--- a/internal/provider/namespace_resource_test.go
+++ b/internal/provider/namespace_resource_test.go
@@ -33,7 +33,7 @@ import (
 // 8. Plan Checks - Verify planned actions
 //
 // Run with:
-//   TF_ACC=1 F5XC_API_URL="..." F5XC_API_P12_FILE="..." F5XC_P12_PASSWORD="..." \
+//   TF_ACC=1 VES_API_URL="..." VES_P12_FILE="..." VES_P12_PASSWORD="..." \
 //   go test -v ./internal/provider/ -run TestAccNamespaceResource -timeout 30m
 // =============================================================================
 

--- a/internal/provider/secret_policy_resource_test.go
+++ b/internal/provider/secret_policy_resource_test.go
@@ -26,7 +26,7 @@ import (
 // 4. Update Tests - Test mutable attributes
 //
 // Run with:
-//   TF_ACC=1 F5XC_API_URL="..." F5XC_API_P12_FILE="..." F5XC_P12_PASSWORD="..." \
+//   TF_ACC=1 VES_API_URL="..." VES_P12_FILE="..." VES_P12_PASSWORD="..." \
 //   go test -v ./internal/provider/ -run TestAccSecretPolicyResource -timeout 30m
 // =============================================================================
 

--- a/internal/provider/secret_policy_rule_resource_test.go
+++ b/internal/provider/secret_policy_rule_resource_test.go
@@ -28,7 +28,7 @@ import (
 // for client identification (client_name, client_name_matcher, client_selector)
 //
 // Run with:
-//   TF_ACC=1 F5XC_API_URL="..." F5XC_API_P12_FILE="..." F5XC_P12_PASSWORD="..." \
+//   TF_ACC=1 VES_API_URL="..." VES_P12_FILE="..." VES_P12_PASSWORD="..." \
 //   go test -v ./internal/provider/ -run TestAccSecretPolicyRuleResource -timeout 30m
 // =============================================================================
 

--- a/internal/provider/securemesh_site_resource_test.go
+++ b/internal/provider/securemesh_site_resource_test.go
@@ -35,7 +35,7 @@ import (
 // 9. Requires Replace Test - Name/namespace change forces replacement
 //
 // Run with:
-//   TF_ACC=1 F5XC_API_URL="..." F5XC_API_P12_FILE="..." F5XC_P12_PASSWORD="..." \
+//   TF_ACC=1 VES_API_URL="..." VES_P12_FILE="..." VES_P12_PASSWORD="..." \
 //   go test -v ./internal/provider/ -run TestAccSecuremeshSiteResource -timeout 30m
 // =============================================================================
 

--- a/internal/provider/securemesh_site_v2_resource_test.go
+++ b/internal/provider/securemesh_site_v2_resource_test.go
@@ -33,7 +33,7 @@ import (
 // 7. Requires Replace Test - Verify name/namespace changes force replacement
 //
 // Run with:
-//   TF_ACC=1 F5XC_API_URL="..." F5XC_API_P12_FILE="..." F5XC_P12_PASSWORD="..." \
+//   TF_ACC=1 VES_API_URL="..." VES_P12_FILE="..." VES_P12_PASSWORD="..." \
 //   go test -v ./internal/provider/ -run TestAccSecuremeshSiteV2Resource -timeout 30m
 // =============================================================================
 

--- a/internal/provider/sensitive_data_policy_resource_test.go
+++ b/internal/provider/sensitive_data_policy_resource_test.go
@@ -34,7 +34,7 @@ import (
 // 8. Plan Checks - Verify planned actions
 //
 // Run with:
-//   TF_ACC=1 F5XC_API_URL="..." F5XC_API_P12_FILE="..." F5XC_P12_PASSWORD="..." \
+//   TF_ACC=1 VES_API_URL="..." VES_P12_FILE="..." VES_P12_PASSWORD="..." \
 //   go test -v ./internal/provider/ -run TestAccSensitiveDataPolicyResource -timeout 30m
 // =============================================================================
 

--- a/internal/provider/service_policy_rule_data_source_test.go
+++ b/internal/provider/service_policy_rule_data_source_test.go
@@ -19,7 +19,7 @@ import (
 // Service Policy Rule requires system namespace and waf_action block.
 //
 // Run with:
-//   TF_ACC=1 F5XC_API_URL="..." F5XC_API_P12_FILE="..." F5XC_P12_PASSWORD="..." \
+//   TF_ACC=1 VES_API_URL="..." VES_P12_FILE="..." VES_P12_PASSWORD="..." \
 //   go test -v ./internal/provider/ -run TestAccServicePolicyRuleDataSource -timeout 30m
 // =============================================================================
 

--- a/internal/provider/service_policy_rule_resource_test.go
+++ b/internal/provider/service_policy_rule_resource_test.go
@@ -23,7 +23,7 @@ import (
 // 1. Basic Lifecycle Test - Create, Read, Import with custom namespace
 //
 // Run with:
-//   TF_ACC=1 F5XC_API_URL="..." F5XC_API_P12_FILE="..." F5XC_P12_PASSWORD="..." \
+//   TF_ACC=1 VES_API_URL="..." VES_P12_FILE="..." VES_P12_PASSWORD="..." \
 //   go test -v ./internal/provider/ -run TestAccServicePolicyRuleResource -timeout 30m
 // =============================================================================
 

--- a/internal/provider/site_mesh_group_resource_test.go
+++ b/internal/provider/site_mesh_group_resource_test.go
@@ -35,7 +35,7 @@ import (
 // 9. Requires Replace Test - Name/namespace change forces replacement
 //
 // Run with:
-//   TF_ACC=1 F5XC_API_URL="..." F5XC_API_P12_FILE="..." F5XC_P12_PASSWORD="..." \
+//   TF_ACC=1 VES_API_URL="..." VES_P12_FILE="..." VES_P12_PASSWORD="..." \
 //   go test -v ./internal/provider/ -run TestAccSiteMeshGroupResource -timeout 30m
 // =============================================================================
 

--- a/internal/provider/srv6_network_slice_data_source_test.go
+++ b/internal/provider/srv6_network_slice_data_source_test.go
@@ -20,7 +20,7 @@ import (
 // in all F5 XC tenant configurations.
 //
 // Run with:
-//   TF_ACC=1 F5XC_API_URL="..." F5XC_API_P12_FILE="..." F5XC_P12_PASSWORD="..." \
+//   TF_ACC=1 VES_API_URL="..." VES_P12_FILE="..." VES_P12_PASSWORD="..." \
 //   go test -v ./internal/provider/ -run TestAccSrv6NetworkSliceDataSource -timeout 30m
 // =============================================================================
 

--- a/internal/provider/srv6_network_slice_resource_test.go
+++ b/internal/provider/srv6_network_slice_resource_test.go
@@ -21,7 +21,7 @@ import (
 // in all F5 XC tenant configurations.
 //
 // Run with:
-//   TF_ACC=1 F5XC_API_URL="..." F5XC_API_P12_FILE="..." F5XC_P12_PASSWORD="..." \
+//   TF_ACC=1 VES_API_URL="..." VES_P12_FILE="..." VES_P12_PASSWORD="..." \
 //   go test -v ./internal/provider/ -run TestAccSrv6NetworkSliceResource -timeout 30m
 // =============================================================================
 

--- a/internal/provider/tcp_loadbalancer_resource_test.go
+++ b/internal/provider/tcp_loadbalancer_resource_test.go
@@ -26,7 +26,7 @@ import (
 //
 // Run with:
 //
-//	TF_ACC=1 F5XC_API_URL="..." F5XC_API_P12_FILE="..." F5XC_P12_PASSWORD="..." \
+//	TF_ACC=1 VES_API_URL="..." VES_P12_FILE="..." VES_P12_PASSWORD="..." \
 //	go test -v ./internal/provider/ -run TestAccTCPLoadBalancerResource -timeout 30m
 //
 // =============================================================================

--- a/internal/provider/tenant_configuration_resource_mock_test.go
+++ b/internal/provider/tenant_configuration_resource_mock_test.go
@@ -23,7 +23,7 @@ import (
 // 4. Run tests in CI/CD without special permissions
 //
 // Run with:
-//   F5XC_MOCK_MODE=1 go test -v ./internal/provider/ -run TestMockTenantConfiguration -timeout 5m
+//   VES_MOCK_MODE=1 go test -v ./internal/provider/ -run TestMockTenantConfiguration -timeout 5m
 // =============================================================================
 
 // TestMockTenantConfigurationResource_basic tests basic tenant configuration operations

--- a/internal/provider/tenant_configuration_resource_test.go
+++ b/internal/provider/tenant_configuration_resource_test.go
@@ -33,7 +33,7 @@ import (
 // 7. Plan Checks - Verify planned actions
 //
 // Run with:
-//   TF_ACC=1 F5XC_API_URL="..." F5XC_API_P12_FILE="..." F5XC_P12_PASSWORD="..." \
+//   TF_ACC=1 VES_API_URL="..." VES_P12_FILE="..." VES_P12_PASSWORD="..." \
 //   go test -v ./internal/provider/ -run TestAccTenantConfigurationResource -timeout 30m
 // =============================================================================
 

--- a/internal/provider/tenant_profile_resource_test.go
+++ b/internal/provider/tenant_profile_resource_test.go
@@ -23,7 +23,7 @@ import (
 // 1. Basic Lifecycle Test - Create, Read, Import with custom namespace
 //
 // Run with:
-//   TF_ACC=1 F5XC_API_URL="..." F5XC_API_P12_FILE="..." F5XC_P12_PASSWORD="..." \
+//   TF_ACC=1 VES_API_URL="..." VES_P12_FILE="..." VES_P12_PASSWORD="..." \
 //   go test -v ./internal/provider/ -run TestAccTenantProfileResource -timeout 30m
 // =============================================================================
 

--- a/internal/provider/ticket_tracking_system_resource_test.go
+++ b/internal/provider/ticket_tracking_system_resource_test.go
@@ -28,7 +28,7 @@ import (
 // to avoid API race conditions.
 //
 // Run with:
-//   TF_ACC=1 F5XC_API_URL="..." F5XC_API_P12_FILE="..." F5XC_P12_PASSWORD="..." \
+//   TF_ACC=1 VES_API_URL="..." VES_P12_FILE="..." VES_P12_PASSWORD="..." \
 //   go test -v ./internal/provider/ -run TestAccTicketTrackingSystemResource -timeout 30m
 // =============================================================================
 

--- a/internal/provider/token_resource_test.go
+++ b/internal/provider/token_resource_test.go
@@ -29,7 +29,7 @@ import (
 //
 // Run with:
 //
-//	TF_ACC=1 F5XC_API_URL="..." F5XC_API_P12_FILE="..." F5XC_P12_PASSWORD="..." \
+//	TF_ACC=1 VES_API_URL="..." VES_P12_FILE="..." VES_P12_PASSWORD="..." \
 //	go test -v ./internal/provider/ -run TestAccTokenResource -timeout 30m
 //
 // =============================================================================

--- a/internal/provider/trusted_ca_list_resource_test.go
+++ b/internal/provider/trusted_ca_list_resource_test.go
@@ -28,7 +28,7 @@ import (
 // Tests create a temporary namespace and wait for it to be ready
 //
 // Run with:
-//   TF_ACC=1 F5XC_API_URL="..." F5XC_API_P12_FILE="..." F5XC_P12_PASSWORD="..." \
+//   TF_ACC=1 VES_API_URL="..." VES_P12_FILE="..." VES_P12_PASSWORD="..." \
 //   go test -v ./internal/provider/ -run TestAccTrustedCaListResource -timeout 30m
 // =============================================================================
 

--- a/internal/provider/tunnel_resource_test.go
+++ b/internal/provider/tunnel_resource_test.go
@@ -23,7 +23,7 @@ import (
 // 1. Basic Lifecycle Test - Create, Read, Import, Delete with API verification
 //
 // Run with:
-//   TF_ACC=1 F5XC_API_URL="..." F5XC_API_P12_FILE="..." F5XC_P12_PASSWORD="..." \
+//   TF_ACC=1 VES_API_URL="..." VES_P12_FILE="..." VES_P12_PASSWORD="..." \
 //   go test -v ./internal/provider/ -run TestAccTunnelResource -timeout 30m
 // =============================================================================
 

--- a/internal/provider/udp_loadbalancer_resource_test.go
+++ b/internal/provider/udp_loadbalancer_resource_test.go
@@ -26,7 +26,7 @@ import (
 //
 // Run with:
 //
-//	TF_ACC=1 F5XC_API_URL="..." F5XC_API_P12_FILE="..." F5XC_P12_PASSWORD="..." \
+//	TF_ACC=1 VES_API_URL="..." VES_P12_FILE="..." VES_P12_PASSWORD="..." \
 //	go test -v ./internal/provider/ -run TestAccUDPLoadBalancerResource -timeout 30m
 //
 // =============================================================================

--- a/internal/provider/usb_policy_resource_test.go
+++ b/internal/provider/usb_policy_resource_test.go
@@ -26,7 +26,7 @@ import (
 // 4. Custom Namespace Pattern - Create namespace with time_sleep delay
 //
 // Run with:
-//   TF_ACC=1 F5XC_API_URL="..." F5XC_API_P12_FILE="..." F5XC_P12_PASSWORD="..." \
+//   TF_ACC=1 VES_API_URL="..." VES_P12_FILE="..." VES_P12_PASSWORD="..." \
 //   go test -v ./internal/provider/ -run TestAccUsbPolicyResource -timeout 30m
 // =============================================================================
 

--- a/internal/provider/virtual_host_resource_test.go
+++ b/internal/provider/virtual_host_resource_test.go
@@ -36,7 +36,7 @@ import (
 // 10. Domains Test - Test domains attribute functionality
 //
 // Run with:
-//   TF_ACC=1 F5XC_API_URL="..." F5XC_API_P12_FILE="..." F5XC_P12_PASSWORD="..." \
+//   TF_ACC=1 VES_API_URL="..." VES_P12_FILE="..." VES_P12_PASSWORD="..." \
 //   go test -v ./internal/provider/ -run TestAccVirtualHostResource -timeout 30m
 // =============================================================================
 

--- a/internal/provider/virtual_k8s_resource_test.go
+++ b/internal/provider/virtual_k8s_resource_test.go
@@ -22,7 +22,7 @@ import (
 // - Custom namespace pattern with time_sleep delay
 //
 // Run with:
-//   TF_ACC=1 F5XC_API_URL="..." F5XC_API_P12_FILE="..." F5XC_P12_PASSWORD="..." \
+//   TF_ACC=1 VES_API_URL="..." VES_P12_FILE="..." VES_P12_PASSWORD="..." \
 //   go test -v ./internal/provider/ -run TestAccVirtualK8SResource -timeout 30m
 // =============================================================================
 

--- a/internal/provider/virtual_network_resource_test.go
+++ b/internal/provider/virtual_network_resource_test.go
@@ -47,7 +47,7 @@ func testAccVirtualNetworkImportStateIdFunc(resourceName string) resource.Import
 // 8. Plan Checks - Verify planned actions
 //
 // Run with:
-//   TF_ACC=1 F5XC_API_URL="..." F5XC_API_P12_FILE="..." F5XC_P12_PASSWORD="..." \
+//   TF_ACC=1 VES_API_URL="..." VES_P12_FILE="..." VES_P12_PASSWORD="..." \
 //   go test -v ./internal/provider/ -run TestAccVirtualNetworkResource -timeout 30m
 // =============================================================================
 

--- a/internal/provider/virtual_site_resource_test.go
+++ b/internal/provider/virtual_site_resource_test.go
@@ -33,7 +33,7 @@ import (
 // 7. Error/Validation Tests - Invalid configuration handling
 //
 // Run with:
-//   TF_ACC=1 F5XC_API_URL="..." F5XC_API_P12_FILE="..." F5XC_P12_PASSWORD="..." \
+//   TF_ACC=1 VES_API_URL="..." VES_P12_FILE="..." VES_P12_PASSWORD="..." \
 //   go test -v ./internal/provider/ -run TestAccVirtualSiteResource -timeout 30m
 // =============================================================================
 

--- a/internal/provider/voltshare_admin_policy_resource_test.go
+++ b/internal/provider/voltshare_admin_policy_resource_test.go
@@ -27,7 +27,7 @@ import (
 // 5. Empty Plan Test - Verify no drift after apply
 //
 // Run with:
-//   TF_ACC=1 F5XC_API_URL="..." F5XC_API_P12_FILE="..." F5XC_P12_PASSWORD="..." \
+//   TF_ACC=1 VES_API_URL="..." VES_P12_FILE="..." VES_P12_PASSWORD="..." \
 //   go test -v ./internal/provider/ -run TestAccVoltshareAdminPolicyResource -timeout 30m
 // =============================================================================
 

--- a/internal/provider/voltstack_site_resource_test.go
+++ b/internal/provider/voltstack_site_resource_test.go
@@ -33,7 +33,7 @@ import (
 // Production deployments require comprehensive site configuration.
 //
 // Run with:
-//   TF_ACC=1 F5XC_API_URL="..." F5XC_API_P12_FILE="..." F5XC_P12_PASSWORD="..." \
+//   TF_ACC=1 VES_API_URL="..." VES_P12_FILE="..." VES_P12_PASSWORD="..." \
 //   go test -v ./internal/provider/ -run TestAccVoltstackSiteResource -timeout 30m
 // =============================================================================
 

--- a/internal/provider/waf_exclusion_policy_resource_test.go
+++ b/internal/provider/waf_exclusion_policy_resource_test.go
@@ -26,7 +26,7 @@ import (
 // 4. WAF Exclusion Rules Test - Test complex nested blocks
 //
 // Run with:
-//   TF_ACC=1 F5XC_API_URL="..." F5XC_API_P12_FILE="..." F5XC_P12_PASSWORD="..." \
+//   TF_ACC=1 VES_API_URL="..." VES_P12_FILE="..." VES_P12_PASSWORD="..." \
 //   go test -v ./internal/provider/ -run TestAccWAFExclusionPolicyResource -timeout 30m
 // =============================================================================
 

--- a/internal/provider/workload_flavor_resource_test.go
+++ b/internal/provider/workload_flavor_resource_test.go
@@ -35,7 +35,7 @@ import (
 // 9. Requires Replace Test - Verify attributes that force replacement
 //
 // Run with:
-//   TF_ACC=1 F5XC_API_URL="..." F5XC_API_P12_FILE="..." F5XC_P12_PASSWORD="..." \
+//   TF_ACC=1 VES_API_URL="..." VES_P12_FILE="..." VES_P12_PASSWORD="..." \
 //   go test -v ./internal/provider/ -run TestAccWorkloadFlavorResource -timeout 30m
 // =============================================================================
 

--- a/internal/provider/workload_resource_test.go
+++ b/internal/provider/workload_resource_test.go
@@ -30,7 +30,7 @@ import (
 // before creating the workload.
 //
 // Run with:
-//   TF_ACC=1 F5XC_API_URL="..." F5XC_API_P12_FILE="..." F5XC_P12_PASSWORD="..." \
+//   TF_ACC=1 VES_API_URL="..." VES_P12_FILE="..." VES_P12_PASSWORD="..." \
 //   go test -v ./internal/provider/ -run TestAccWorkloadResource -timeout 30m
 // =============================================================================
 


### PR DESCRIPTION
## Summary
Update test file comments to use the standardized `VES_*` environment variable naming convention instead of the deprecated `F5XC_*` prefix.

## Related Issue
Closes #408

## Changes Made
Updated 36 test files to use consistent naming:
- `F5XC_API_URL` → `VES_API_URL`
- `F5XC_API_P12_FILE` → `VES_P12_FILE`
- `F5XC_P12_PASSWORD` → `VES_P12_PASSWORD`
- `F5XC_MOCK_MODE` → `VES_MOCK_MODE`

## Testing
- [x] Pre-commit hooks pass
- [x] golangci-lint passes
- [x] go build check passes
- [x] go vet check passes

## Context
This is a documentation/comment-only change. The actual code already uses `VES_*` variables consistently in:
- `internal/provider/provider.go`
- `internal/blindfold/auth.go`
- `internal/acctest/mock_helpers.go`
- All workflow files

🤖 Generated with [Claude Code](https://claude.com/claude-code)