### PR TITLE
feat(mcp): add MCP server for Terraform provider documentation

### DIFF
--- a/.github/workflows/_build-mcp-server.yml
+++ b/.github/workflows/_build-mcp-server.yml
@@ -1,0 +1,92 @@
+# Reusable workflow for building and optionally publishing the MCP server
+# Called by on-merge.yml when MCP server source or documentation changes
+name: Build MCP Server
+
+on:
+  workflow_call:
+    inputs:
+      publish:
+        description: 'Whether to publish to npm'
+        required: false
+        default: false
+        type: boolean
+    outputs:
+      changed:
+        description: 'Whether the MCP server had changes'
+        value: ${{ jobs.build.outputs.changed }}
+      version:
+        description: 'The MCP server version'
+        value: ${{ jobs.build.outputs.version }}
+    secrets:
+      npm-token:
+        description: 'NPM token for publishing'
+        required: false
+
+jobs:
+  build:
+    name: Build MCP Server
+    runs-on: ubuntu-latest
+    outputs:
+      changed: ${{ steps.check.outputs.has_changes }}
+      version: ${{ steps.version.outputs.version }}
+    defaults:
+      run:
+        working-directory: mcp-server
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'npm'
+          cache-dependency-path: mcp-server/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Type check
+        run: npm run typecheck
+
+      - name: Build
+        run: npm run build
+
+      - name: Get version
+        id: version
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "MCP Server version: $VERSION"
+
+      - name: Check for changes
+        id: check
+        run: |
+          cd ..
+          CHANGED=$(git diff --name-only HEAD~1 HEAD 2>/dev/null || git diff --name-only HEAD)
+          if echo "$CHANGED" | grep -qE '^mcp-server/|^docs/'; then
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+            echo "MCP server or documentation changed"
+          else
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Publish to npm
+        if: inputs.publish && steps.check.outputs.has_changes == 'true'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.npm-token }}
+        run: |
+          # Check if version exists on npm
+          VERSION=$(node -p "require('./package.json').version")
+          PACKAGE_NAME=$(node -p "require('./package.json').name")
+
+          if npm view "$PACKAGE_NAME@$VERSION" version 2>/dev/null; then
+            echo "Version $VERSION already exists on npm, skipping publish"
+          else
+            echo "Publishing $PACKAGE_NAME@$VERSION to npm"
+            npm publish --access public
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -322,3 +322,63 @@ jobs:
           echo "::group::Running mock tests"
           go test -v ./internal/mocks/...
           echo "::endgroup::"
+
+  # ═══════════════════════════════════════════════════════════════════════════
+  # Validate MCP Server Build (for PRs affecting MCP server)
+  # ═══════════════════════════════════════════════════════════════════════════
+  validate-mcp-server:
+    name: Validate MCP Server
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    defaults:
+      run:
+        working-directory: mcp-server
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Check if MCP server validation needed
+        id: check
+        run: |
+          cd ..
+          CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD 2>/dev/null || echo "")
+
+          # Check if MCP server source changed
+          if echo "$CHANGED_FILES" | grep -qE "^mcp-server/"; then
+            echo "needs_validation=true" >> $GITHUB_OUTPUT
+            echo "MCP server files changed - validation needed"
+          else
+            echo "needs_validation=false" >> $GITHUB_OUTPUT
+            echo "No MCP server changes - skipping validation"
+          fi
+
+      - name: Setup Node.js
+        if: steps.check.outputs.needs_validation == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: mcp-server/package-lock.json
+
+      - name: Install dependencies
+        if: steps.check.outputs.needs_validation == 'true'
+        run: npm ci
+
+      - name: Type check
+        if: steps.check.outputs.needs_validation == 'true'
+        run: npm run typecheck
+
+      - name: Build
+        if: steps.check.outputs.needs_validation == 'true'
+        run: npm run build
+
+      - name: Verify build output
+        if: steps.check.outputs.needs_validation == 'true'
+        run: |
+          if [ ! -f "dist/index.js" ]; then
+            echo "::error::MCP server build did not produce dist/index.js"
+            exit 1
+          fi
+          echo "MCP server build validated successfully"

--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -57,6 +57,8 @@ jobs:
       code-changed: ${{ steps.changes.outputs.code }}
       tools-changed: ${{ steps.changes.outputs.tools }}
       functions-changed: ${{ steps.changes.outputs.functions }}
+      mcp-changed: ${{ steps.changes.outputs.mcp }}
+      docs-changed: ${{ steps.changes.outputs.docs }}
       is-bot-commit: ${{ steps.check-author.outputs.is_bot }}
       should-process: ${{ steps.should-process.outputs.result }}
       needs-regeneration: ${{ steps.should-process.outputs.needs_regeneration }}
@@ -138,6 +140,22 @@ jobs:
             echo "functions=false" >> $GITHUB_OUTPUT
           fi
 
+          # Check for MCP server source changes
+          if echo "$CHANGED" | grep -qE '^mcp-server/src/'; then
+            echo "mcp=true" >> $GITHUB_OUTPUT
+            echo "MCP server source changed"
+          else
+            echo "mcp=false" >> $GITHUB_OUTPUT
+          fi
+
+          # Check for documentation changes (triggers MCP server rebuild)
+          if echo "$CHANGED" | grep -qE '^docs/(resources|data-sources|functions|guides)/'; then
+            echo "docs=true" >> $GITHUB_OUTPUT
+            echo "Documentation changed (will trigger MCP server rebuild)"
+          else
+            echo "docs=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Determine if processing should proceed
         id: should-process
         run: |
@@ -214,7 +232,32 @@ jobs:
     uses: ./.github/workflows/_generate-docs.yml
 
   # ===========================================================================
-  # STEP 5: Create PR for regenerated content (human commits only)
+  # STEP 5: Build MCP Server (when docs, specs, or MCP source changes)
+  # ===========================================================================
+  build-mcp-server:
+    name: Build MCP Server
+    needs: [detect-changes, build-test, regenerate-docs]
+    # Build MCP server when:
+    # 1. MCP server source changed, OR
+    # 2. Documentation was regenerated, OR
+    # 3. OpenAPI specs changed (MCP server serves these)
+    if: |
+      always() &&
+      needs.detect-changes.outputs.should-process == 'true' &&
+      needs.detect-changes.outputs.is-bot-commit != 'true' &&
+      needs.build-test.result == 'success' &&
+      (needs.detect-changes.outputs.mcp-changed == 'true' ||
+       needs.detect-changes.outputs.docs-changed == 'true' ||
+       needs.detect-changes.outputs.specs-changed == 'true' ||
+       needs.regenerate-docs.outputs.changed == 'true')
+    uses: ./.github/workflows/_build-mcp-server.yml
+    with:
+      publish: true
+    secrets:
+      npm-token: ${{ secrets.NPM_TOKEN }}
+
+  # ===========================================================================
+  # STEP 6: Create PR for regenerated content (human commits only)
   # ===========================================================================
   # NOTE: We create a PR instead of pushing directly to respect branch protection.
   # The delayed tagging pattern ensures we DON'T tag here - tagging happens when
@@ -460,7 +503,7 @@ jobs:
   # ===========================================================================
   summary:
     name: Workflow Summary
-    needs: [detect-changes, build-test, regenerate-provider, regenerate-docs, create-regeneration-pr, tag-release]
+    needs: [detect-changes, build-test, regenerate-provider, regenerate-docs, build-mcp-server, create-regeneration-pr, tag-release]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -477,9 +520,12 @@ jobs:
           echo "| Code Changed | ${{ needs.detect-changes.outputs.code-changed }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Tools Changed | ${{ needs.detect-changes.outputs.tools-changed }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Functions Changed | ${{ needs.detect-changes.outputs.functions-changed }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| MCP Server Changed | ${{ needs.detect-changes.outputs.mcp-changed }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Docs Changed | ${{ needs.detect-changes.outputs.docs-changed }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Build/Test | ${{ needs.build-test.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Provider Regenerated | ${{ needs.regenerate-provider.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Docs Regenerated | ${{ needs.regenerate-docs.result }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| MCP Server Built | ${{ needs.build-mcp-server.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Regeneration PR Created | ${{ needs.create-regeneration-pr.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Tagged/Released | ${{ needs.tag-release.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY

--- a/mcp-server/.gitignore
+++ b/mcp-server/.gitignore
@@ -1,0 +1,16 @@
+# Dependencies
+node_modules/
+
+# Build output
+dist/
+
+# IDE
+.vscode/
+.idea/
+
+# OS
+.DS_Store
+
+# Logs
+*.log
+npm-debug.log*

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -1,0 +1,178 @@
+# F5 Distributed Cloud Terraform Provider MCP Server
+
+A Model Context Protocol (MCP) server that provides AI assistants with comprehensive access to the F5 Distributed Cloud (F5XC) Terraform provider documentation and OpenAPI specifications.
+
+## Features
+
+- **144+ Resource Documentation**: Complete Terraform resource docs with arguments, attributes, and examples
+- **270+ OpenAPI Specifications**: Full F5XC API specifications for all services
+- **Intelligent Search**: Search across documentation and API specs with relevance scoring
+- **Schema Exploration**: Browse and query API schema definitions
+- **Endpoint Discovery**: Find API endpoints by pattern across all specifications
+
+## Installation
+
+### From npm
+
+```bash
+npm install -g @robinmordasiewicz/f5xc-terraform-mcp
+```
+
+### From Source
+
+```bash
+cd mcp-server
+npm install
+npm run build
+```
+
+## Configuration
+
+### Claude Desktop
+
+Add to your Claude Desktop configuration (`~/Library/Application Support/Claude/claude_desktop_config.json` on macOS):
+
+```json
+{
+  "mcpServers": {
+    "f5xc-terraform": {
+      "command": "npx",
+      "args": ["-y", "@robinmordasiewicz/f5xc-terraform-mcp"]
+    }
+  }
+}
+```
+
+Or if running from source:
+
+```json
+{
+  "mcpServers": {
+    "f5xc": {
+      "command": "node",
+      "args": ["/path/to/terraform-provider-f5xc/mcp-server/dist/index.js"]
+    }
+  }
+}
+```
+
+## Available Tools
+
+### Documentation Tools
+
+| Tool | Description |
+|------|-------------|
+| `f5xc_search_docs` | Search provider documentation by keyword |
+| `f5xc_get_doc` | Get complete documentation for a resource |
+| `f5xc_list_docs` | List all available documentation |
+
+### API Specification Tools
+
+| Tool | Description |
+|------|-------------|
+| `f5xc_search_api_specs` | Search OpenAPI specifications |
+| `f5xc_get_api_spec` | Get a specific API specification |
+| `f5xc_find_endpoints` | Find API endpoints by URL pattern |
+| `f5xc_get_schema_definition` | Get a schema definition from a spec |
+| `f5xc_list_definitions` | List all definitions in a spec |
+
+### Utility Tools
+
+| Tool | Description |
+|------|-------------|
+| `f5xc_get_summary` | Get overview of all available docs and specs |
+
+## Usage Examples
+
+### Find HTTP Load Balancer Documentation
+
+```
+User: How do I configure an HTTP load balancer in F5XC with Terraform?
+
+Claude: [Uses f5xc_search_docs with query "http_loadbalancer"]
+        [Uses f5xc_get_doc with name "http_loadbalancer"]
+```
+
+### Discover API Endpoints
+
+```
+User: What API endpoints are available for managing namespaces?
+
+Claude: [Uses f5xc_find_endpoints with pattern "/namespaces"]
+```
+
+### Explore Schema Definitions
+
+```
+User: What fields are available in the app_firewall configuration?
+
+Claude: [Uses f5xc_get_api_spec with name "app_firewall"]
+        [Uses f5xc_list_definitions with spec_name "app_firewall"]
+        [Uses f5xc_get_schema_definition for specific type]
+```
+
+## Development
+
+### Build
+
+```bash
+npm run build
+```
+
+### Development Mode (with auto-reload)
+
+```bash
+npm run dev
+```
+
+### Type Check
+
+```bash
+npm run typecheck
+```
+
+## Architecture
+
+```
+mcp-server/
+├── src/
+│   ├── index.ts          # MCP server entry point
+│   ├── types.ts          # TypeScript type definitions
+│   ├── schemas/          # Zod validation schemas
+│   │   └── index.ts
+│   └── services/         # Core services
+│       ├── documentation.ts   # Doc loading and search
+│       └── api-specs.ts       # OpenAPI spec handling
+├── package.json
+├── tsconfig.json
+└── README.md
+```
+
+## Resources Served
+
+### Documentation Types
+
+- **Resources**: Terraform resources (http_loadbalancer, origin_pool, namespace, etc.)
+- **Data Sources**: Terraform data sources for reading existing resources
+- **Functions**: Provider-defined functions (blindfold, blindfold_file)
+- **Guides**: Step-by-step tutorials and how-to guides
+
+### API Specifications
+
+All F5 Distributed Cloud public APIs including:
+- HTTP/TCP Load Balancers
+- Origin Pools
+- Application Firewalls (WAF)
+- Namespaces
+- DNS Management
+- Network Policies
+- Cloud Sites (AWS, Azure, GCP)
+- And 260+ more...
+
+## License
+
+MIT
+
+## Contributing
+
+Contributions welcome! Please see the main [terraform-provider-f5xc](https://github.com/robinmordasiewicz/terraform-provider-f5xc) repository for contribution guidelines.

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,0 +1,2082 @@
+{
+  "name": "@robinmordasiewicz/f5xc-terraform-mcp",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@robinmordasiewicz/f5xc-terraform-mcp",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.6.1",
+        "glob": "^11.0.0",
+        "zod": "^3.23.8"
+      },
+      "bin": {
+        "f5xc-terraform-mcp": "dist/index.js"
+      },
+      "devDependencies": {
+        "@types/node": "^22.10.0",
+        "tsx": "^4.19.2",
+        "typescript": "^5.7.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.1.tgz",
+      "integrity": "sha512-HHB50pdsBX6k47S4u5g/CaLjqS3qwaOVE5ILsq64jyzgMhLuCuZ8rGzM9yhsAjfjkbgUPMzZEPa7DAp7yz6vuA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.1.tgz",
+      "integrity": "sha512-kFqa6/UcaTbGm/NncN9kzVOODjhZW8e+FRdSeypWe6j33gzclHtwlANs26JrupOntlcWmB0u8+8HZo8s7thHvg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.1.tgz",
+      "integrity": "sha512-45fuKmAJpxnQWixOGCrS+ro4Uvb4Re9+UTieUY2f8AEc+t7d4AaZ6eUJ3Hva7dtrxAAWHtlEFsXFMAgNnGU9uQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.1.tgz",
+      "integrity": "sha512-LBEpOz0BsgMEeHgenf5aqmn/lLNTFXVfoWMUox8CtWWYK9X4jmQzWjoGoNb8lmAYml/tQ/Ysvm8q7szu7BoxRQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.1.tgz",
+      "integrity": "sha512-veg7fL8eMSCVKL7IW4pxb54QERtedFDfY/ASrumK/SbFsXnRazxY4YykN/THYqFnFwJ0aVjiUrVG2PwcdAEqQQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.1.tgz",
+      "integrity": "sha512-+3ELd+nTzhfWb07Vol7EZ+5PTbJ/u74nC6iv4/lwIU99Ip5uuY6QoIf0Hn4m2HoV0qcnRivN3KSqc+FyCHjoVQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.1.tgz",
+      "integrity": "sha512-/8Rfgns4XD9XOSXlzUDepG8PX+AVWHliYlUkFI3K3GB6tqbdjYqdhcb4BKRd7C0BhZSoaCxhv8kTcBrcZWP+xg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.1.tgz",
+      "integrity": "sha512-GITpD8dK9C+r+5yRT/UKVT36h/DQLOHdwGVwwoHidlnA168oD3uxA878XloXebK4Ul3gDBBIvEdL7go9gCUFzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.1.tgz",
+      "integrity": "sha512-ieMID0JRZY/ZeCrsFQ3Y3NlHNCqIhTprJfDgSB3/lv5jJZ8FX3hqPyXWhe+gvS5ARMBJ242PM+VNz/ctNj//eA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.1.tgz",
+      "integrity": "sha512-W9//kCrh/6in9rWIBdKaMtuTTzNj6jSeG/haWBADqLLa9P8O5YSRDzgD5y9QBok4AYlzS6ARHifAb75V6G670Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.1.tgz",
+      "integrity": "sha512-VIUV4z8GD8rtSVMfAj1aXFahsi/+tcoXXNYmXgzISL+KB381vbSTNdeZHHHIYqFyXcoEhu9n5cT+05tRv13rlw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.1.tgz",
+      "integrity": "sha512-l4rfiiJRN7sTNI//ff65zJ9z8U+k6zcCg0LALU5iEWzY+a1mVZ8iWC1k5EsNKThZ7XCQ6YWtsZ8EWYm7r1UEsg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.1.tgz",
+      "integrity": "sha512-U0bEuAOLvO/DWFdygTHWY8C067FXz+UbzKgxYhXC0fDieFa0kDIra1FAhsAARRJbvEyso8aAqvPdNxzWuStBnA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.1.tgz",
+      "integrity": "sha512-NzdQ/Xwu6vPSf/GkdmRNsOfIeSGnh7muundsWItmBsVpMoNPVpM61qNzAVY3pZ1glzzAxLR40UyYM23eaDDbYQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.1.tgz",
+      "integrity": "sha512-7zlw8p3IApcsN7mFw0O1Z1PyEk6PlKMu18roImfl3iQHTnr/yAfYv6s4hXPidbDoI2Q0pW+5xeoM4eTCC0UdrQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.1.tgz",
+      "integrity": "sha512-cGj5wli+G+nkVQdZo3+7FDKC25Uh4ZVwOAK6A06Hsvgr8WqBBuOy/1s+PUEd/6Je+vjfm6stX0kmib5b/O2Ykw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.1.tgz",
+      "integrity": "sha512-z3H/HYI9MM0HTv3hQZ81f+AKb+yEoCRlUby1F80vbQ5XdzEMyY/9iNlAmhqiBKw4MJXwfgsh7ERGEOhrM1niMA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.1.tgz",
+      "integrity": "sha512-wzC24DxAvk8Em01YmVXyjl96Mr+ecTPyOuADAvjGg+fyBpGmxmcr2E5ttf7Im8D0sXZihpxzO1isus8MdjMCXQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.1.tgz",
+      "integrity": "sha512-1YQ8ybGi2yIXswu6eNzJsrYIGFpnlzEWRl6iR5gMgmsrR0FcNoV1m9k9sc3PuP5rUBLshOZylc9nqSgymI+TYg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.1.tgz",
+      "integrity": "sha512-5Z+DzLCrq5wmU7RDaMDe2DVXMRm2tTDvX2KU14JJVBN2CT/qov7XVix85QoJqHltpvAOZUAc3ndU56HSMWrv8g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.1.tgz",
+      "integrity": "sha512-Q73ENzIdPF5jap4wqLtsfh8YbYSZ8Q0wnxplOlZUOyZy7B4ZKW8DXGWgTCZmF8VWD7Tciwv5F4NsRf6vYlZtqg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.1.tgz",
+      "integrity": "sha512-ajbHrGM/XiK+sXM0JzEbJAen+0E+JMQZ2l4RR4VFwvV9JEERx+oxtgkpoKv1SevhjavK2z2ReHk32pjzktWbGg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.1.tgz",
+      "integrity": "sha512-IPUW+y4VIjuDVn+OMzHc5FV4GubIwPnsz6ubkvN8cuhEqH81NovB53IUlrlBkPMEPxvNnf79MGBoz8rZ2iW8HA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.1.tgz",
+      "integrity": "sha512-RIVRWiljWA6CdVu8zkWcRmGP7iRRIIwvhDKem8UMBjPql2TXM5PkDVvvrzMtj1V+WFPB4K7zkIGM7VzRtFkjdg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.1.tgz",
+      "integrity": "sha512-2BR5M8CPbptC1AK5JbJT1fWrHLvejwZidKx3UMSF0ecHMa+smhi16drIrCEggkgviBwLYd5nwrFLSl5Kho96RQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.1.tgz",
+      "integrity": "sha512-d5X6RMYv6taIymSk8JBP+nxv8DQAMY6A51GPgusqLdK9wBz5wWIXy1KjTck6HnjE9hqJzJRdk+1p/t5soSbCtw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@isaacs/balanced-match": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
+      "integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@isaacs/brace-expansion": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
+      "integrity": "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==",
+      "license": "MIT",
+      "dependencies": {
+        "@isaacs/balanced-match": "^4.0.1"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.24.3",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.24.3.tgz",
+      "integrity": "sha512-YgSHW29fuzKKAHTGe9zjNoo+yF8KaQPzDC2W9Pv41E7/57IfY+AMGJ/aDFlgTLcVVELoggKE4syABCE75u3NCw==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.0.1",
+        "express-rate-limit": "^7.5.0",
+        "jose": "^6.1.1",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.2.tgz",
+      "integrity": "sha512-LPM2G3Syo1GLzXLGJAKdqoU35XvrWzGJ21/7sgZTUpbkBaOasTj8tjwn6w+hCkqaa1TfJ/w67rJSwYItlJ2mYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.1.tgz",
+      "integrity": "sha512-nfDwkulwiZYQIGwxdy0RUmowMhKcFVcYXUU7m4QlKYim1rUtg83xm2yjZ40QjDuc291AJjjeSc9b++AWHSgSHw==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.0",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/content-disposition": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "license": "MIT"
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.1.tgz",
+      "integrity": "sha512-yY35KZckJJuVVPXpvjgxiCuVEJT67F6zDeVTv4rizyPrfGBUpZQsvmxnN+C371c2esD/hNMjj4tpBhuueLN7aA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.1",
+        "@esbuild/android-arm": "0.27.1",
+        "@esbuild/android-arm64": "0.27.1",
+        "@esbuild/android-x64": "0.27.1",
+        "@esbuild/darwin-arm64": "0.27.1",
+        "@esbuild/darwin-x64": "0.27.1",
+        "@esbuild/freebsd-arm64": "0.27.1",
+        "@esbuild/freebsd-x64": "0.27.1",
+        "@esbuild/linux-arm": "0.27.1",
+        "@esbuild/linux-arm64": "0.27.1",
+        "@esbuild/linux-ia32": "0.27.1",
+        "@esbuild/linux-loong64": "0.27.1",
+        "@esbuild/linux-mips64el": "0.27.1",
+        "@esbuild/linux-ppc64": "0.27.1",
+        "@esbuild/linux-riscv64": "0.27.1",
+        "@esbuild/linux-s390x": "0.27.1",
+        "@esbuild/linux-x64": "0.27.1",
+        "@esbuild/netbsd-arm64": "0.27.1",
+        "@esbuild/netbsd-x64": "0.27.1",
+        "@esbuild/openbsd-arm64": "0.27.1",
+        "@esbuild/openbsd-x64": "0.27.1",
+        "@esbuild/openharmony-arm64": "0.27.1",
+        "@esbuild/sunos-x64": "0.27.1",
+        "@esbuild/win32-arm64": "0.27.1",
+        "@esbuild/win32-ia32": "0.27.1",
+        "@esbuild/win32-x64": "0.27.1"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.1.tgz",
+      "integrity": "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.0.tgz",
+      "integrity": "sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/glob": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
+      "integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "foreground-child": "^3.3.1",
+        "jackspeak": "^4.1.1",
+        "minimatch": "^10.1.1",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^2.0.0"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.1.tgz",
+      "integrity": "sha512-2Tth85cXwGFHfvRgZWszZSvdo+0Xsqmw8k8ZwxScfcBneNUraK+dxRxRm24nszx80Y0TVio8kKLt5sLE7ZCLlw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jackspeak": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.1.1.tgz",
+      "integrity": "sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/jose": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
+      "integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "11.2.4",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.4.tgz",
+      "integrity": "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.1.tgz",
+      "integrity": "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/brace-expansion": "^5.0.0"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "license": "BlueOak-1.0.0"
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.1.tgz",
+      "integrity": "sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
+      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.0.tgz",
+      "integrity": "sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.5",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "mime-types": "^3.0.1",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.0.tgz",
+      "integrity": "sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.0.tgz",
+      "integrity": "sha512-HvWtU2UG41LALjajJrML6uQejQhNJx+JBO9IflpSja4R03iNWfKXrj6W2h7ljuLyc1nKS+9yDyL/9tD1U/yBnQ==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25 || ^4"
+      }
+    }
+  }
+}

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,0 +1,61 @@
+{
+  "name": "@robinmordasiewicz/f5xc-terraform-mcp",
+  "version": "1.0.0",
+  "description": "MCP server for F5 Distributed Cloud Terraform provider - provides documentation and API specification access for AI assistants",
+  "type": "module",
+  "main": "dist/index.js",
+  "bin": {
+    "f5xc-terraform-mcp": "./dist/index.js"
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "dev": "tsx watch src/index.ts",
+    "clean": "rm -rf dist",
+    "prepublishOnly": "npm run build",
+    "lint": "eslint src/**/*.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "keywords": [
+    "mcp",
+    "model-context-protocol",
+    "f5",
+    "f5xc",
+    "f5-distributed-cloud",
+    "terraform",
+    "terraform-provider",
+    "ai",
+    "claude",
+    "openapi"
+  ],
+  "author": "Robin Mordasiewicz",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/robinmordasiewicz/terraform-provider-f5xc.git",
+    "directory": "mcp-server"
+  },
+  "bugs": {
+    "url": "https://github.com/robinmordasiewicz/terraform-provider-f5xc/issues"
+  },
+  "homepage": "https://github.com/robinmordasiewicz/terraform-provider-f5xc/tree/main/mcp-server#readme",
+  "engines": {
+    "node": ">=18"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.6.1",
+    "glob": "^11.0.0",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.0",
+    "tsx": "^4.19.2",
+    "typescript": "^5.7.2"
+  },
+  "mcpName": "io.github.robinmordasiewicz/f5xc-terraform-mcp"
+}

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -1,0 +1,776 @@
+#!/usr/bin/env node
+/**
+ * F5 Distributed Cloud Terraform Provider MCP Server
+ *
+ * This MCP server provides AI assistants with access to:
+ * - Terraform provider documentation (resources, data sources, functions, guides)
+ * - F5 Distributed Cloud OpenAPI specifications (270+ specs)
+ * - Search and query capabilities for both documentation and API specs
+ */
+
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+
+import { ResponseFormat } from './types.js';
+import {
+  searchDocumentation,
+  getDocumentation,
+  listDocumentation,
+  getDocumentationSummary,
+} from './services/documentation.js';
+import {
+  searchApiSpecs,
+  getApiSpec,
+  listApiSpecs,
+  findEndpoints,
+  getSchemaDefinition,
+  listDefinitions,
+  getApiSpecsSummary,
+} from './services/api-specs.js';
+import {
+  SearchDocsSchema,
+  GetDocSchema,
+  ListDocsSchema,
+  SearchApiSpecsSchema,
+  GetApiSpecSchema,
+  FindEndpointsSchema,
+  GetSchemaDefSchema,
+  ListDefinitionsSchema,
+  GetSummarySchema,
+  type SearchDocsInput,
+  type GetDocInput,
+  type ListDocsInput,
+  type SearchApiSpecsInput,
+  type GetApiSpecInput,
+  type FindEndpointsInput,
+  type GetSchemaDefInput,
+  type ListDefinitionsInput,
+  type GetSummaryInput,
+} from './schemas/index.js';
+
+// Constants
+const CHARACTER_LIMIT = 50000; // Maximum response size
+
+// Create MCP server instance
+const server = new McpServer({
+  name: 'f5xc-terraform-mcp',
+  version: '1.0.0',
+});
+
+// =============================================================================
+// DOCUMENTATION TOOLS
+// =============================================================================
+
+server.registerTool(
+  'f5xc_search_docs',
+  {
+    title: 'Search F5XC Documentation',
+    description: `Search the F5 Distributed Cloud Terraform provider documentation.
+
+Searches across all resource documentation, data sources, functions, and guides
+to find relevant information about configuring F5XC resources with Terraform.
+
+Args:
+  - query (string): Search terms (resource names, attributes, descriptions)
+  - type (optional): Filter by 'resource', 'data-source', 'function', or 'guide'
+  - limit (number): Maximum results (default: 20, max: 50)
+  - response_format: 'markdown' or 'json'
+
+Returns:
+  List of matching documentation with relevance scores and snippets.
+
+Examples:
+  - "http_loadbalancer" -> Find HTTP load balancer documentation
+  - "origin pool" -> Find origin pool related docs
+  - "waf" -> Find Web Application Firewall docs`,
+    inputSchema: SearchDocsSchema,
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
+  },
+  async (params: SearchDocsInput) => {
+    const results = searchDocumentation(params.query, params.type, params.limit);
+
+    if (results.length === 0) {
+      return {
+        content: [{
+          type: 'text',
+          text: `No documentation found matching "${params.query}"`,
+        }],
+      };
+    }
+
+    const output = {
+      query: params.query,
+      total: results.length,
+      results: results.map(r => ({
+        name: r.name,
+        type: r.type,
+        score: r.score,
+        snippet: r.snippet,
+      })),
+    };
+
+    let textContent: string;
+    if (params.response_format === ResponseFormat.MARKDOWN) {
+      const lines = [
+        `# Documentation Search Results: "${params.query}"`,
+        '',
+        `Found ${results.length} results:`,
+        '',
+      ];
+      for (const result of results) {
+        lines.push(`## ${result.name} (${result.type})`);
+        lines.push(`Score: ${result.score}`);
+        lines.push(result.snippet);
+        lines.push('');
+      }
+      textContent = lines.join('\n');
+    } else {
+      textContent = JSON.stringify(output, null, 2);
+    }
+
+    return {
+      content: [{ type: 'text', text: textContent }],
+      structuredContent: output,
+    };
+  }
+);
+
+server.registerTool(
+  'f5xc_get_doc',
+  {
+    title: 'Get F5XC Resource Documentation',
+    description: `Get complete documentation for a specific F5XC Terraform resource.
+
+Retrieves the full markdown documentation including:
+- Resource description and usage
+- Argument reference (all configurable attributes)
+- Attribute reference (computed/read-only attributes)
+- Import instructions
+- Example configurations
+
+Args:
+  - name (string): Resource name (e.g., "http_loadbalancer", "namespace", "origin_pool")
+  - type (optional): 'resource', 'data-source', 'function', or 'guide'
+  - response_format: 'markdown' or 'json'
+
+Returns:
+  Complete documentation content.
+
+Examples:
+  - name="http_loadbalancer" -> HTTP Load Balancer resource docs
+  - name="app_firewall" -> Application Firewall (WAF) docs
+  - name="blindfold", type="function" -> Blindfold encryption function docs`,
+    inputSchema: GetDocSchema,
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
+  },
+  async (params: GetDocInput) => {
+    const doc = getDocumentation(params.name, params.type);
+
+    if (!doc) {
+      return {
+        content: [{
+          type: 'text',
+          text: `Documentation not found for "${params.name}"${params.type ? ` (type: ${params.type})` : ''}. Use f5xc_search_docs to find available documentation.`,
+        }],
+      };
+    }
+
+    const output = {
+      name: doc.name,
+      type: doc.type,
+      path: doc.path,
+      content: doc.content,
+    };
+
+    let textContent: string;
+    if (params.response_format === ResponseFormat.MARKDOWN) {
+      textContent = doc.content || `# ${doc.name}\n\nNo content available.`;
+    } else {
+      textContent = JSON.stringify(output, null, 2);
+    }
+
+    // Truncate if too long
+    if (textContent.length > CHARACTER_LIMIT) {
+      textContent = textContent.slice(0, CHARACTER_LIMIT) + '\n\n... (truncated)';
+    }
+
+    return {
+      content: [{ type: 'text', text: textContent }],
+      structuredContent: output,
+    };
+  }
+);
+
+server.registerTool(
+  'f5xc_list_docs',
+  {
+    title: 'List F5XC Documentation',
+    description: `List all available F5 Distributed Cloud Terraform provider documentation.
+
+Lists all resources, data sources, functions, and guides available in the provider.
+
+Args:
+  - type (optional): Filter by 'resource', 'data-source', 'function', or 'guide'
+  - response_format: 'markdown' or 'json'
+
+Returns:
+  List of all available documentation items.`,
+    inputSchema: ListDocsSchema,
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
+  },
+  async (params: ListDocsInput) => {
+    const docs = listDocumentation(params.type);
+
+    const output = {
+      total: docs.length,
+      type_filter: params.type || 'all',
+      items: docs.map(d => ({
+        name: d.name,
+        type: d.type,
+      })),
+    };
+
+    let textContent: string;
+    if (params.response_format === ResponseFormat.MARKDOWN) {
+      const lines = [
+        `# F5XC Terraform Documentation`,
+        '',
+        `Total: ${docs.length} items${params.type ? ` (filtered: ${params.type})` : ''}`,
+        '',
+      ];
+
+      // Group by type
+      const byType: Record<string, string[]> = {};
+      for (const doc of docs) {
+        if (!byType[doc.type]) byType[doc.type] = [];
+        byType[doc.type].push(doc.name);
+      }
+
+      for (const [type, names] of Object.entries(byType)) {
+        lines.push(`## ${type}s (${names.length})`);
+        lines.push(names.sort().join(', '));
+        lines.push('');
+      }
+
+      textContent = lines.join('\n');
+    } else {
+      textContent = JSON.stringify(output, null, 2);
+    }
+
+    return {
+      content: [{ type: 'text', text: textContent }],
+      structuredContent: output,
+    };
+  }
+);
+
+// =============================================================================
+// API SPECIFICATION TOOLS
+// =============================================================================
+
+server.registerTool(
+  'f5xc_search_api_specs',
+  {
+    title: 'Search F5XC API Specifications',
+    description: `Search the F5 Distributed Cloud OpenAPI specifications.
+
+The provider includes 270+ OpenAPI specs covering all F5XC API endpoints.
+Use this to find API specifications for specific services or operations.
+
+Args:
+  - query (string): Search terms (schema names, service names)
+  - limit (number): Maximum results (default: 20, max: 50)
+  - response_format: 'markdown' or 'json'
+
+Returns:
+  List of matching API specifications with titles and descriptions.
+
+Examples:
+  - "http_loadbalancer" -> Find HTTP LB API spec
+  - "namespace" -> Find namespace management API
+  - "waf" or "app_firewall" -> Find WAF API specs`,
+    inputSchema: SearchApiSpecsSchema,
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
+  },
+  async (params: SearchApiSpecsInput) => {
+    const results = searchApiSpecs(params.query, params.limit);
+
+    if (results.length === 0) {
+      return {
+        content: [{
+          type: 'text',
+          text: `No API specifications found matching "${params.query}"`,
+        }],
+      };
+    }
+
+    const output = {
+      query: params.query,
+      total: results.length,
+      results: results.map(r => ({
+        name: r.name,
+        snippet: r.snippet,
+        score: r.score,
+      })),
+    };
+
+    let textContent: string;
+    if (params.response_format === ResponseFormat.MARKDOWN) {
+      const lines = [
+        `# API Specification Search: "${params.query}"`,
+        '',
+        `Found ${results.length} specifications:`,
+        '',
+      ];
+      for (const result of results) {
+        lines.push(`## ${result.name}`);
+        lines.push(result.snippet);
+        lines.push('');
+      }
+      textContent = lines.join('\n');
+    } else {
+      textContent = JSON.stringify(output, null, 2);
+    }
+
+    return {
+      content: [{ type: 'text', text: textContent }],
+      structuredContent: output,
+    };
+  }
+);
+
+server.registerTool(
+  'f5xc_get_api_spec',
+  {
+    title: 'Get F5XC API Specification',
+    description: `Get a specific F5 Distributed Cloud OpenAPI specification.
+
+Retrieves the complete OpenAPI spec including:
+- API info and description
+- Available endpoints and methods
+- Request/response schemas
+- Authentication requirements
+
+Args:
+  - name (string): Spec name (e.g., "http_loadbalancer", "namespace", "app_firewall")
+  - include_paths (boolean): Include endpoint paths (default: true)
+  - include_definitions (boolean): Include schema definitions (default: false, can be large)
+  - response_format: 'markdown' or 'json'
+
+Returns:
+  OpenAPI specification content.`,
+    inputSchema: GetApiSpecSchema,
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
+  },
+  async (params: GetApiSpecInput) => {
+    const spec = getApiSpec(params.name);
+
+    if (!spec?.content) {
+      return {
+        content: [{
+          type: 'text',
+          text: `API specification not found for "${params.name}". Use f5xc_search_api_specs to find available specs.`,
+        }],
+      };
+    }
+
+    const content = spec.content;
+    const output: Record<string, unknown> = {
+      name: spec.schemaName,
+      info: content.info,
+    };
+
+    if (params.include_paths && content.paths) {
+      output.paths = Object.keys(content.paths).map(path => {
+        const pathItem = content.paths![path];
+        const methods: string[] = [];
+        if (pathItem.get) methods.push('GET');
+        if (pathItem.post) methods.push('POST');
+        if (pathItem.put) methods.push('PUT');
+        if (pathItem.delete) methods.push('DELETE');
+        if (pathItem.patch) methods.push('PATCH');
+        return { path, methods };
+      });
+    }
+
+    if (params.include_definitions) {
+      output.definitions = content.definitions || content.components?.schemas || {};
+    }
+
+    let textContent: string;
+    if (params.response_format === ResponseFormat.MARKDOWN) {
+      const lines = [
+        `# ${content.info?.title || spec.schemaName}`,
+        '',
+        content.info?.description || '',
+        '',
+        `**Version**: ${content.info?.version || 'N/A'}`,
+        '',
+      ];
+
+      if (params.include_paths && content.paths) {
+        lines.push('## Endpoints');
+        lines.push('');
+        for (const [path, pathItem] of Object.entries(content.paths)) {
+          const methods: string[] = [];
+          if (pathItem.get) methods.push('GET');
+          if (pathItem.post) methods.push('POST');
+          if (pathItem.put) methods.push('PUT');
+          if (pathItem.delete) methods.push('DELETE');
+          if (pathItem.patch) methods.push('PATCH');
+          lines.push(`- \`${methods.join('|')} ${path}\``);
+        }
+        lines.push('');
+      }
+
+      textContent = lines.join('\n');
+    } else {
+      textContent = JSON.stringify(output, null, 2);
+    }
+
+    // Truncate if too long
+    if (textContent.length > CHARACTER_LIMIT) {
+      textContent = textContent.slice(0, CHARACTER_LIMIT) + '\n\n... (truncated, use include_definitions=false for smaller response)';
+    }
+
+    return {
+      content: [{ type: 'text', text: textContent }],
+      structuredContent: output,
+    };
+  }
+);
+
+server.registerTool(
+  'f5xc_find_endpoints',
+  {
+    title: 'Find F5XC API Endpoints',
+    description: `Find API endpoints across all F5XC OpenAPI specifications.
+
+Searches through 270+ API specs to find endpoints matching a pattern.
+Useful for discovering which APIs to use for specific operations.
+
+Args:
+  - pattern (string): URL pattern to search (e.g., "/namespaces", "http_loadbalancer")
+  - method (optional): Filter by HTTP method (GET, POST, PUT, DELETE, PATCH)
+  - limit (number): Maximum results (default: 20, max: 100)
+  - response_format: 'markdown' or 'json'
+
+Returns:
+  List of matching endpoints with spec name, path, method, and description.
+
+Examples:
+  - pattern="/namespaces" -> All namespace-related endpoints
+  - pattern="config", method="POST" -> POST endpoints for configuration`,
+    inputSchema: FindEndpointsSchema,
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
+  },
+  async (params: FindEndpointsInput) => {
+    const endpoints = findEndpoints(params.pattern, params.method, params.limit);
+
+    if (endpoints.length === 0) {
+      return {
+        content: [{
+          type: 'text',
+          text: `No endpoints found matching pattern "${params.pattern}"${params.method ? ` with method ${params.method}` : ''}`,
+        }],
+      };
+    }
+
+    const output = {
+      pattern: params.pattern,
+      method_filter: params.method || 'all',
+      total: endpoints.length,
+      endpoints,
+    };
+
+    let textContent: string;
+    if (params.response_format === ResponseFormat.MARKDOWN) {
+      const lines = [
+        `# API Endpoints: "${params.pattern}"`,
+        '',
+        `Found ${endpoints.length} endpoints:`,
+        '',
+      ];
+      for (const ep of endpoints) {
+        lines.push(`## ${ep.method} ${ep.path}`);
+        lines.push(`**Spec**: ${ep.specName}`);
+        if (ep.summary) lines.push(`**Summary**: ${ep.summary}`);
+        if (ep.operationId) lines.push(`**Operation ID**: ${ep.operationId}`);
+        lines.push('');
+      }
+      textContent = lines.join('\n');
+    } else {
+      textContent = JSON.stringify(output, null, 2);
+    }
+
+    return {
+      content: [{ type: 'text', text: textContent }],
+      structuredContent: output,
+    };
+  }
+);
+
+server.registerTool(
+  'f5xc_get_schema_definition',
+  {
+    title: 'Get API Schema Definition',
+    description: `Get a specific schema definition from an F5XC OpenAPI spec.
+
+Retrieves the JSON schema for a specific type definition, useful for
+understanding the structure of API request/response objects.
+
+Args:
+  - spec_name (string): Name of the API spec
+  - definition_name (string): Name of the schema definition
+  - response_format: 'markdown' or 'json'
+
+Returns:
+  JSON schema definition with properties, types, and descriptions.`,
+    inputSchema: GetSchemaDefSchema,
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
+  },
+  async (params: GetSchemaDefInput) => {
+    const definition = getSchemaDefinition(params.spec_name, params.definition_name);
+
+    if (!definition) {
+      return {
+        content: [{
+          type: 'text',
+          text: `Schema definition "${params.definition_name}" not found in spec "${params.spec_name}". Use f5xc_list_definitions to see available definitions.`,
+        }],
+      };
+    }
+
+    const output = {
+      spec_name: params.spec_name,
+      definition_name: params.definition_name,
+      schema: definition,
+    };
+
+    let textContent: string;
+    if (params.response_format === ResponseFormat.MARKDOWN) {
+      const lines = [
+        `# Schema: ${params.definition_name}`,
+        '',
+        `**Spec**: ${params.spec_name}`,
+        '',
+        '```json',
+        JSON.stringify(definition, null, 2),
+        '```',
+      ];
+      textContent = lines.join('\n');
+    } else {
+      textContent = JSON.stringify(output, null, 2);
+    }
+
+    // Truncate if too long
+    if (textContent.length > CHARACTER_LIMIT) {
+      textContent = textContent.slice(0, CHARACTER_LIMIT) + '\n\n... (truncated)';
+    }
+
+    return {
+      content: [{ type: 'text', text: textContent }],
+      structuredContent: output,
+    };
+  }
+);
+
+server.registerTool(
+  'f5xc_list_definitions',
+  {
+    title: 'List API Schema Definitions',
+    description: `List all schema definitions in an F5XC OpenAPI spec.
+
+Lists the names of all type definitions available in a specification,
+useful for discovering what schemas are available to query.
+
+Args:
+  - spec_name (string): Name of the API spec
+  - response_format: 'markdown' or 'json'
+
+Returns:
+  List of definition names in the spec.`,
+    inputSchema: ListDefinitionsSchema,
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
+  },
+  async (params: ListDefinitionsInput) => {
+    const definitions = listDefinitions(params.spec_name);
+
+    if (definitions.length === 0) {
+      return {
+        content: [{
+          type: 'text',
+          text: `No definitions found in spec "${params.spec_name}". Use f5xc_search_api_specs to find available specs.`,
+        }],
+      };
+    }
+
+    const output = {
+      spec_name: params.spec_name,
+      total: definitions.length,
+      definitions,
+    };
+
+    let textContent: string;
+    if (params.response_format === ResponseFormat.MARKDOWN) {
+      const lines = [
+        `# Schema Definitions: ${params.spec_name}`,
+        '',
+        `Total: ${definitions.length} definitions`,
+        '',
+        definitions.sort().join(', '),
+      ];
+      textContent = lines.join('\n');
+    } else {
+      textContent = JSON.stringify(output, null, 2);
+    }
+
+    return {
+      content: [{ type: 'text', text: textContent }],
+      structuredContent: output,
+    };
+  }
+);
+
+// =============================================================================
+// SUMMARY TOOL
+// =============================================================================
+
+server.registerTool(
+  'f5xc_get_summary',
+  {
+    title: 'Get F5XC Provider Summary',
+    description: `Get a summary of all available F5 Distributed Cloud Terraform provider documentation and API specifications.
+
+Provides an overview of:
+- Total number of resources, data sources, functions, and guides
+- Total number of API specifications
+- Categories and counts
+
+Useful as a starting point to understand what's available.
+
+Args:
+  - response_format: 'markdown' or 'json'
+
+Returns:
+  Summary statistics of all documentation and API specs.`,
+    inputSchema: GetSummarySchema,
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
+  },
+  async (params: GetSummaryInput) => {
+    const docsSummary = getDocumentationSummary();
+    const apiSummary = getApiSpecsSummary();
+
+    const output = {
+      documentation: {
+        total: Object.values(docsSummary).reduce((a, b) => a + b, 0),
+        by_type: docsSummary,
+      },
+      api_specifications: {
+        total: apiSummary.total,
+        categories: apiSummary.categories,
+      },
+    };
+
+    let textContent: string;
+    if (params.response_format === ResponseFormat.MARKDOWN) {
+      const lines = [
+        '# F5 Distributed Cloud Terraform Provider',
+        '',
+        '## Documentation',
+        '',
+        `Total: ${output.documentation.total} items`,
+        '',
+      ];
+
+      for (const [type, count] of Object.entries(docsSummary)) {
+        lines.push(`- **${type}s**: ${count}`);
+      }
+
+      lines.push('');
+      lines.push('## API Specifications');
+      lines.push('');
+      lines.push(`Total: ${apiSummary.total} OpenAPI specs`);
+      lines.push('');
+      lines.push('### Available Tools');
+      lines.push('');
+      lines.push('- `f5xc_search_docs` - Search documentation');
+      lines.push('- `f5xc_get_doc` - Get specific resource documentation');
+      lines.push('- `f5xc_list_docs` - List all documentation');
+      lines.push('- `f5xc_search_api_specs` - Search API specifications');
+      lines.push('- `f5xc_get_api_spec` - Get specific API spec');
+      lines.push('- `f5xc_find_endpoints` - Find API endpoints');
+      lines.push('- `f5xc_get_schema_definition` - Get schema definition');
+      lines.push('- `f5xc_list_definitions` - List definitions in a spec');
+
+      textContent = lines.join('\n');
+    } else {
+      textContent = JSON.stringify(output, null, 2);
+    }
+
+    return {
+      content: [{ type: 'text', text: textContent }],
+      structuredContent: output,
+    };
+  }
+);
+
+// =============================================================================
+// SERVER STARTUP
+// =============================================================================
+
+async function main() {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  console.error('F5XC Terraform MCP server running on stdio');
+}
+
+main().catch(error => {
+  console.error('Server error:', error);
+  process.exit(1);
+});

--- a/mcp-server/src/schemas/index.ts
+++ b/mcp-server/src/schemas/index.ts
@@ -1,0 +1,144 @@
+/**
+ * Zod schemas for MCP tool input validation
+ */
+
+import { z } from 'zod';
+import { ResponseFormat } from '../types.js';
+
+// Common pagination schema
+export const PaginationSchema = z.object({
+  limit: z.number()
+    .int()
+    .min(1)
+    .max(100)
+    .default(20)
+    .describe('Maximum results to return (1-100)'),
+  offset: z.number()
+    .int()
+    .min(0)
+    .default(0)
+    .describe('Number of results to skip for pagination'),
+}).strict();
+
+// Response format schema
+export const ResponseFormatSchema = z.nativeEnum(ResponseFormat)
+  .default(ResponseFormat.MARKDOWN)
+  .describe('Output format: "markdown" for human-readable or "json" for machine-readable');
+
+// Search documentation schema
+export const SearchDocsSchema = z.object({
+  query: z.string()
+    .min(1, 'Query is required')
+    .max(200, 'Query must not exceed 200 characters')
+    .describe('Search query to find in documentation (resource names, attributes, descriptions)'),
+  type: z.enum(['resource', 'data-source', 'function', 'guide'])
+    .optional()
+    .describe('Filter by documentation type'),
+  limit: z.number()
+    .int()
+    .min(1)
+    .max(50)
+    .default(20)
+    .describe('Maximum results to return'),
+  response_format: ResponseFormatSchema,
+}).strict();
+
+// Get documentation schema
+export const GetDocSchema = z.object({
+  name: z.string()
+    .min(1, 'Resource name is required')
+    .describe('Name of the resource/data-source/function (e.g., "http_loadbalancer", "namespace", "blindfold")'),
+  type: z.enum(['resource', 'data-source', 'function', 'guide'])
+    .optional()
+    .describe('Type of documentation to retrieve'),
+  response_format: ResponseFormatSchema,
+}).strict();
+
+// List documentation schema
+export const ListDocsSchema = z.object({
+  type: z.enum(['resource', 'data-source', 'function', 'guide'])
+    .optional()
+    .describe('Filter by documentation type'),
+  response_format: ResponseFormatSchema,
+}).strict();
+
+// Search API specs schema
+export const SearchApiSpecsSchema = z.object({
+  query: z.string()
+    .min(1, 'Query is required')
+    .max(200, 'Query must not exceed 200 characters')
+    .describe('Search query for API specifications (schema names, endpoints)'),
+  limit: z.number()
+    .int()
+    .min(1)
+    .max(50)
+    .default(20)
+    .describe('Maximum results to return'),
+  response_format: ResponseFormatSchema,
+}).strict();
+
+// Get API spec schema
+export const GetApiSpecSchema = z.object({
+  name: z.string()
+    .min(1, 'Spec name is required')
+    .describe('Name of the API specification (e.g., "http_loadbalancer", "app_firewall", "namespace")'),
+  include_paths: z.boolean()
+    .default(true)
+    .describe('Whether to include endpoint paths in the response'),
+  include_definitions: z.boolean()
+    .default(false)
+    .describe('Whether to include schema definitions (can be large)'),
+  response_format: ResponseFormatSchema,
+}).strict();
+
+// Find endpoints schema
+export const FindEndpointsSchema = z.object({
+  pattern: z.string()
+    .min(1, 'Pattern is required')
+    .describe('URL pattern to search for (e.g., "/api/config/", "namespaces", "http_loadbalancers")'),
+  method: z.enum(['GET', 'POST', 'PUT', 'DELETE', 'PATCH'])
+    .optional()
+    .describe('Filter by HTTP method'),
+  limit: z.number()
+    .int()
+    .min(1)
+    .max(100)
+    .default(20)
+    .describe('Maximum results to return'),
+  response_format: ResponseFormatSchema,
+}).strict();
+
+// Get schema definition schema
+export const GetSchemaDefSchema = z.object({
+  spec_name: z.string()
+    .min(1, 'Spec name is required')
+    .describe('Name of the API specification containing the definition'),
+  definition_name: z.string()
+    .min(1, 'Definition name is required')
+    .describe('Name of the schema definition to retrieve'),
+  response_format: ResponseFormatSchema,
+}).strict();
+
+// List definitions schema
+export const ListDefinitionsSchema = z.object({
+  spec_name: z.string()
+    .min(1, 'Spec name is required')
+    .describe('Name of the API specification'),
+  response_format: ResponseFormatSchema,
+}).strict();
+
+// Get summary schema
+export const GetSummarySchema = z.object({
+  response_format: ResponseFormatSchema,
+}).strict();
+
+// Export type inference helpers
+export type SearchDocsInput = z.infer<typeof SearchDocsSchema>;
+export type GetDocInput = z.infer<typeof GetDocSchema>;
+export type ListDocsInput = z.infer<typeof ListDocsSchema>;
+export type SearchApiSpecsInput = z.infer<typeof SearchApiSpecsSchema>;
+export type GetApiSpecInput = z.infer<typeof GetApiSpecSchema>;
+export type FindEndpointsInput = z.infer<typeof FindEndpointsSchema>;
+export type GetSchemaDefInput = z.infer<typeof GetSchemaDefSchema>;
+export type ListDefinitionsInput = z.infer<typeof ListDefinitionsSchema>;
+export type GetSummaryInput = z.infer<typeof GetSummarySchema>;

--- a/mcp-server/src/services/api-specs.ts
+++ b/mcp-server/src/services/api-specs.ts
@@ -1,0 +1,316 @@
+/**
+ * API Specifications Service
+ * Loads and manages F5 Distributed Cloud OpenAPI specifications
+ */
+
+import { readFileSync, existsSync, readdirSync } from 'fs';
+import { join, dirname, basename } from 'path';
+import { fileURLToPath } from 'url';
+import type { ApiSpec, OpenAPISpec, SearchResult, SchemaDefinition } from '../types.js';
+
+// Get the project root (parent of mcp-server)
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const PROJECT_ROOT = join(__dirname, '..', '..', '..');
+
+// API specifications path
+const API_SPECS_PATH = join(PROJECT_ROOT, 'docs', 'specifications', 'api');
+
+// Cache for loaded specifications
+const specsCache = new Map<string, ApiSpec>();
+let allSpecs: ApiSpec[] | null = null;
+
+/**
+ * Parse schema name from filename
+ * Example: docs-cloud-f5-com.0019.public.ves.io.schema.app_firewall.ves-swagger.json
+ * Returns: app_firewall
+ */
+function parseSchemaName(filename: string): string {
+  // Remove .ves-swagger.json suffix
+  const withoutSuffix = filename.replace('.ves-swagger.json', '');
+  // Split by dots and get the meaningful parts
+  const parts = withoutSuffix.split('.');
+  // Find the schema name (usually after 'schema' or the last meaningful part)
+  const schemaIndex = parts.findIndex(p => p === 'schema');
+  if (schemaIndex !== -1 && schemaIndex < parts.length - 1) {
+    // Get everything after 'schema'
+    return parts.slice(schemaIndex + 1).join('_');
+  }
+  // Fallback: use last part
+  return parts[parts.length - 1];
+}
+
+/**
+ * Load all API specification metadata
+ */
+export function loadAllApiSpecs(): ApiSpec[] {
+  if (allSpecs) {
+    return allSpecs;
+  }
+
+  allSpecs = [];
+
+  if (!existsSync(API_SPECS_PATH)) {
+    console.error(`API specs path not found: ${API_SPECS_PATH}`);
+    return allSpecs;
+  }
+
+  const files = readdirSync(API_SPECS_PATH).filter(f => f.endsWith('.json'));
+
+  for (const file of files) {
+    const schemaName = parseSchemaName(file);
+    allSpecs.push({
+      name: file,
+      path: join(API_SPECS_PATH, file),
+      schemaName,
+    });
+  }
+
+  return allSpecs;
+}
+
+/**
+ * Get a specific API specification by schema name or filename
+ */
+export function getApiSpec(identifier: string): ApiSpec | null {
+  if (specsCache.has(identifier)) {
+    return specsCache.get(identifier)!;
+  }
+
+  const specs = loadAllApiSpecs();
+  const identifierLower = identifier.toLowerCase();
+
+  // Try to find by schema name first
+  let spec = specs.find(s =>
+    s.schemaName.toLowerCase() === identifierLower ||
+    s.schemaName.toLowerCase().replace(/_/g, '-') === identifierLower ||
+    s.schemaName.toLowerCase().includes(identifierLower)
+  );
+
+  // Then try by filename
+  if (!spec) {
+    spec = specs.find(s => s.name.toLowerCase().includes(identifierLower));
+  }
+
+  if (spec && existsSync(spec.path)) {
+    try {
+      const content = JSON.parse(readFileSync(spec.path, 'utf-8')) as OpenAPISpec;
+      spec = { ...spec, content };
+      specsCache.set(identifier, spec);
+      return spec;
+    } catch (error) {
+      console.error(`Error parsing API spec ${spec.path}:`, error);
+      return null;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * List all available API specifications
+ */
+export function listApiSpecs(): ApiSpec[] {
+  return loadAllApiSpecs();
+}
+
+/**
+ * Search API specifications
+ */
+export function searchApiSpecs(query: string, limit: number = 20): SearchResult[] {
+  const specs = loadAllApiSpecs();
+  const results: SearchResult[] = [];
+  const queryLower = query.toLowerCase();
+  const queryTerms = queryLower.split(/\s+/).filter(t => t.length > 0);
+
+  for (const spec of specs) {
+    let score = 0;
+    const schemaNameLower = spec.schemaName.toLowerCase();
+    const filenameLower = spec.name.toLowerCase();
+
+    // Exact schema name match
+    if (schemaNameLower === queryLower) {
+      score += 100;
+    }
+    // Schema name contains query
+    else if (schemaNameLower.includes(queryLower)) {
+      score += 50;
+    }
+    // Filename contains query
+    else if (filenameLower.includes(queryLower)) {
+      score += 30;
+    }
+    // Any term matches
+    else {
+      for (const term of queryTerms) {
+        if (schemaNameLower.includes(term)) {
+          score += 20;
+        }
+        if (filenameLower.includes(term)) {
+          score += 10;
+        }
+      }
+    }
+
+    if (score > 0) {
+      // Try to load spec to get additional info
+      let snippet = `Schema: ${spec.schemaName}`;
+      try {
+        if (existsSync(spec.path)) {
+          const content = JSON.parse(readFileSync(spec.path, 'utf-8')) as OpenAPISpec;
+          if (content.info?.title) {
+            snippet = content.info.title;
+          }
+          if (content.info?.description) {
+            snippet += ` - ${content.info.description.slice(0, 100)}...`;
+          }
+        }
+      } catch {
+        // Ignore parse errors for search
+      }
+
+      results.push({
+        name: spec.schemaName,
+        type: 'api-spec',
+        path: spec.path,
+        snippet,
+        score,
+      });
+    }
+  }
+
+  // Sort by score descending
+  results.sort((a, b) => b.score - a.score);
+
+  return results.slice(0, limit);
+}
+
+/**
+ * Find API endpoints matching a pattern
+ */
+export function findEndpoints(
+  pattern: string,
+  method?: string,
+  limit: number = 20
+): Array<{
+  specName: string;
+  path: string;
+  method: string;
+  summary?: string;
+  operationId?: string;
+}> {
+  const specs = loadAllApiSpecs();
+  const results: Array<{
+    specName: string;
+    path: string;
+    method: string;
+    summary?: string;
+    operationId?: string;
+  }> = [];
+  const patternLower = pattern.toLowerCase();
+
+  for (const spec of specs) {
+    if (!existsSync(spec.path)) continue;
+
+    try {
+      const content = JSON.parse(readFileSync(spec.path, 'utf-8')) as OpenAPISpec;
+      const paths = content.paths || {};
+
+      for (const [pathStr, pathItem] of Object.entries(paths)) {
+        if (!pathStr.toLowerCase().includes(patternLower)) continue;
+
+        const methods = ['get', 'post', 'put', 'delete', 'patch'] as const;
+        for (const m of methods) {
+          if (method && m.toLowerCase() !== method.toLowerCase()) continue;
+
+          const operation = pathItem[m];
+          if (operation) {
+            results.push({
+              specName: spec.schemaName,
+              path: pathStr,
+              method: m.toUpperCase(),
+              summary: operation.summary,
+              operationId: operation.operationId,
+            });
+          }
+        }
+
+        if (results.length >= limit) break;
+      }
+    } catch {
+      // Skip specs that fail to parse
+    }
+
+    if (results.length >= limit) break;
+  }
+
+  return results;
+}
+
+/**
+ * Get schema definition from a spec
+ */
+export function getSchemaDefinition(
+  specIdentifier: string,
+  definitionName: string
+): SchemaDefinition | null {
+  const spec = getApiSpec(specIdentifier);
+  if (!spec?.content) return null;
+
+  // Check Swagger 2.0 definitions
+  if (spec.content.definitions?.[definitionName]) {
+    return spec.content.definitions[definitionName];
+  }
+
+  // Check OpenAPI 3.0 component schemas
+  if (spec.content.components?.schemas?.[definitionName]) {
+    return spec.content.components.schemas[definitionName];
+  }
+
+  // Try partial match
+  const definitions = spec.content.definitions || spec.content.components?.schemas || {};
+  for (const [name, schema] of Object.entries(definitions)) {
+    if (name.toLowerCase().includes(definitionName.toLowerCase())) {
+      return schema;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * List all definitions in a spec
+ */
+export function listDefinitions(specIdentifier: string): string[] {
+  const spec = getApiSpec(specIdentifier);
+  if (!spec?.content) return [];
+
+  const definitions = spec.content.definitions || spec.content.components?.schemas || {};
+  return Object.keys(definitions);
+}
+
+/**
+ * Get API specifications summary
+ */
+export function getApiSpecsSummary(): {
+  total: number;
+  categories: Record<string, number>;
+} {
+  const specs = loadAllApiSpecs();
+  const categories: Record<string, number> = {};
+
+  for (const spec of specs) {
+    // Extract category from schema name (e.g., 'views', 'api_sec', etc.)
+    const parts = spec.name.split('.');
+    const schemaIndex = parts.findIndex(p => p === 'schema');
+    if (schemaIndex !== -1 && schemaIndex < parts.length - 1) {
+      const category = parts[schemaIndex + 1];
+      categories[category] = (categories[category] || 0) + 1;
+    }
+  }
+
+  return {
+    total: specs.length,
+    categories,
+  };
+}

--- a/mcp-server/src/services/documentation.ts
+++ b/mcp-server/src/services/documentation.ts
@@ -1,0 +1,253 @@
+/**
+ * Documentation Service
+ * Loads and manages Terraform provider documentation
+ */
+
+import { readFileSync, existsSync, readdirSync } from 'fs';
+import { join, dirname, basename, extname } from 'path';
+import { fileURLToPath } from 'url';
+import type { ResourceDoc, SearchResult } from '../types.js';
+
+// Get the project root (parent of mcp-server)
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const PROJECT_ROOT = join(__dirname, '..', '..', '..');
+
+// Documentation paths relative to project root
+const DOCS_PATHS = {
+  resources: join(PROJECT_ROOT, 'docs', 'resources'),
+  dataSources: join(PROJECT_ROOT, 'docs', 'data-sources'),
+  functions: join(PROJECT_ROOT, 'docs', 'functions'),
+  guides: join(PROJECT_ROOT, 'docs', 'guides'),
+};
+
+// Cache for loaded documentation
+const docsCache = new Map<string, ResourceDoc>();
+let allDocs: ResourceDoc[] | null = null;
+
+/**
+ * Load all documentation files
+ */
+export function loadAllDocumentation(): ResourceDoc[] {
+  if (allDocs) {
+    return allDocs;
+  }
+
+  allDocs = [];
+
+  // Load resources
+  if (existsSync(DOCS_PATHS.resources)) {
+    const files = readdirSync(DOCS_PATHS.resources).filter(f => f.endsWith('.md'));
+    for (const file of files) {
+      allDocs.push({
+        name: basename(file, '.md'),
+        path: join(DOCS_PATHS.resources, file),
+        type: 'resource',
+      });
+    }
+  }
+
+  // Load data sources
+  if (existsSync(DOCS_PATHS.dataSources)) {
+    const files = readdirSync(DOCS_PATHS.dataSources).filter(f => f.endsWith('.md'));
+    for (const file of files) {
+      allDocs.push({
+        name: basename(file, '.md'),
+        path: join(DOCS_PATHS.dataSources, file),
+        type: 'data-source',
+      });
+    }
+  }
+
+  // Load functions
+  if (existsSync(DOCS_PATHS.functions)) {
+    const files = readdirSync(DOCS_PATHS.functions).filter(f => f.endsWith('.md'));
+    for (const file of files) {
+      allDocs.push({
+        name: basename(file, '.md'),
+        path: join(DOCS_PATHS.functions, file),
+        type: 'function',
+      });
+    }
+  }
+
+  // Load guides
+  if (existsSync(DOCS_PATHS.guides)) {
+    const files = readdirSync(DOCS_PATHS.guides).filter(f => f.endsWith('.md'));
+    for (const file of files) {
+      allDocs.push({
+        name: basename(file, '.md'),
+        path: join(DOCS_PATHS.guides, file),
+        type: 'guide',
+      });
+    }
+  }
+
+  return allDocs;
+}
+
+/**
+ * Get documentation content for a specific resource
+ */
+export function getDocumentation(name: string, type?: string): ResourceDoc | null {
+  const cacheKey = `${type || 'any'}:${name}`;
+
+  if (docsCache.has(cacheKey)) {
+    return docsCache.get(cacheKey)!;
+  }
+
+  const docs = loadAllDocumentation();
+  let doc = docs.find(d => {
+    const nameMatch = d.name === name || d.name === name.replace(/_/g, '-') || d.name === name.replace(/-/g, '_');
+    const typeMatch = !type || d.type === type;
+    return nameMatch && typeMatch;
+  });
+
+  if (doc && existsSync(doc.path)) {
+    const content = readFileSync(doc.path, 'utf-8');
+    doc = { ...doc, content };
+    docsCache.set(cacheKey, doc);
+    return doc;
+  }
+
+  return null;
+}
+
+/**
+ * List all available documentation
+ */
+export function listDocumentation(type?: string): ResourceDoc[] {
+  const docs = loadAllDocumentation();
+  if (type) {
+    return docs.filter(d => d.type === type);
+  }
+  return docs;
+}
+
+/**
+ * Search documentation content
+ */
+export function searchDocumentation(query: string, type?: string, limit: number = 20): SearchResult[] {
+  const docs = loadAllDocumentation();
+  const results: SearchResult[] = [];
+  const queryLower = query.toLowerCase();
+  const queryTerms = queryLower.split(/\s+/).filter(t => t.length > 0);
+
+  for (const doc of docs) {
+    if (type && doc.type !== type) {
+      continue;
+    }
+
+    // Check name match
+    const nameLower = doc.name.toLowerCase();
+    let score = 0;
+
+    // Exact name match
+    if (nameLower === queryLower) {
+      score += 100;
+    }
+    // Name contains query
+    else if (nameLower.includes(queryLower)) {
+      score += 50;
+    }
+    // Name contains any query term
+    else {
+      for (const term of queryTerms) {
+        if (nameLower.includes(term)) {
+          score += 20;
+        }
+      }
+    }
+
+    // Search content if file exists
+    if (existsSync(doc.path)) {
+      const content = readFileSync(doc.path, 'utf-8').toLowerCase();
+
+      // Count term occurrences in content
+      for (const term of queryTerms) {
+        const occurrences = (content.match(new RegExp(term, 'gi')) || []).length;
+        score += Math.min(occurrences * 2, 30); // Cap content score per term
+      }
+
+      if (score > 0) {
+        // Extract relevant snippet
+        const contentOriginal = readFileSync(doc.path, 'utf-8');
+        const snippet = extractSnippet(contentOriginal, queryTerms);
+
+        results.push({
+          name: doc.name,
+          type: doc.type,
+          path: doc.path,
+          snippet,
+          score,
+        });
+      }
+    } else if (score > 0) {
+      results.push({
+        name: doc.name,
+        type: doc.type,
+        path: doc.path,
+        snippet: `${doc.type}: ${doc.name}`,
+        score,
+      });
+    }
+  }
+
+  // Sort by score descending
+  results.sort((a, b) => b.score - a.score);
+
+  return results.slice(0, limit);
+}
+
+/**
+ * Extract a relevant snippet from content
+ */
+function extractSnippet(content: string, terms: string[], maxLength: number = 200): string {
+  const contentLower = content.toLowerCase();
+
+  // Find the first occurrence of any term
+  let firstIndex = content.length;
+  for (const term of terms) {
+    const index = contentLower.indexOf(term);
+    if (index !== -1 && index < firstIndex) {
+      firstIndex = index;
+    }
+  }
+
+  if (firstIndex === content.length) {
+    // No term found, return beginning of content
+    const lines = content.split('\n').filter(l => l.trim().length > 0);
+    return lines.slice(0, 3).join(' ').slice(0, maxLength) + '...';
+  }
+
+  // Extract snippet around the term
+  const start = Math.max(0, firstIndex - 50);
+  const end = Math.min(content.length, firstIndex + maxLength - 50);
+  let snippet = content.slice(start, end);
+
+  // Clean up snippet
+  snippet = snippet.replace(/\n+/g, ' ').replace(/\s+/g, ' ').trim();
+
+  if (start > 0) {
+    snippet = '...' + snippet;
+  }
+  if (end < content.length) {
+    snippet = snippet + '...';
+  }
+
+  return snippet;
+}
+
+/**
+ * Get resource categories summary
+ */
+export function getDocumentationSummary(): Record<string, number> {
+  const docs = loadAllDocumentation();
+  const summary: Record<string, number> = {};
+
+  for (const doc of docs) {
+    summary[doc.type] = (summary[doc.type] || 0) + 1;
+  }
+
+  return summary;
+}

--- a/mcp-server/src/types.ts
+++ b/mcp-server/src/types.ts
@@ -1,0 +1,97 @@
+/**
+ * Type definitions for F5 Distributed Cloud MCP Server
+ */
+
+export interface ResourceDoc {
+  name: string;
+  path: string;
+  type: 'resource' | 'data-source' | 'function' | 'guide';
+  content?: string;
+}
+
+export interface ApiSpec {
+  name: string;
+  path: string;
+  schemaName: string;
+  content?: OpenAPISpec;
+}
+
+export interface OpenAPISpec {
+  swagger?: string;
+  openapi?: string;
+  info?: {
+    title?: string;
+    description?: string;
+    version?: string;
+  };
+  paths?: Record<string, PathItem>;
+  definitions?: Record<string, SchemaDefinition>;
+  components?: {
+    schemas?: Record<string, SchemaDefinition>;
+  };
+}
+
+export interface PathItem {
+  get?: Operation;
+  post?: Operation;
+  put?: Operation;
+  delete?: Operation;
+  patch?: Operation;
+}
+
+export interface Operation {
+  summary?: string;
+  description?: string;
+  operationId?: string;
+  tags?: string[];
+  parameters?: Parameter[];
+  requestBody?: RequestBody;
+  responses?: Record<string, Response>;
+}
+
+export interface Parameter {
+  name: string;
+  in: 'path' | 'query' | 'header' | 'body';
+  description?: string;
+  required?: boolean;
+  type?: string;
+  schema?: SchemaDefinition;
+}
+
+export interface RequestBody {
+  description?: string;
+  required?: boolean;
+  content?: Record<string, { schema?: SchemaDefinition }>;
+}
+
+export interface Response {
+  description?: string;
+  schema?: SchemaDefinition;
+  content?: Record<string, { schema?: SchemaDefinition }>;
+}
+
+export interface SchemaDefinition {
+  type?: string;
+  description?: string;
+  properties?: Record<string, SchemaDefinition>;
+  items?: SchemaDefinition;
+  required?: string[];
+  enum?: string[];
+  $ref?: string;
+  allOf?: SchemaDefinition[];
+  oneOf?: SchemaDefinition[];
+  anyOf?: SchemaDefinition[];
+}
+
+export interface SearchResult {
+  name: string;
+  type: string;
+  path: string;
+  snippet: string;
+  score: number;
+}
+
+export enum ResponseFormat {
+  MARKDOWN = 'markdown',
+  JSON = 'json'
+}

--- a/mcp-server/tsconfig.json
+++ b/mcp-server/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "lib": ["ES2022"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "allowSyntheticDefaultImports": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary
Add Model Context Protocol (MCP) server that provides AI assistants with access to F5XC Terraform provider documentation and OpenAPI specifications.

## Related Issue
Closes #410

## Changes Made
- **MCP Server** (`mcp-server/`):
  - TypeScript MCP server using `@modelcontextprotocol/sdk`
  - 9 tools for documentation and API spec access
  - Zod input validation
  - npm package: `@robinmordasiewicz/f5xc-terraform-mcp`

- **CI/CD Integration**:
  - `_build-mcp-server.yml` - Reusable workflow for building/publishing
  - Updated `on-merge.yml` - Triggers MCP build on docs/specs changes
  - Updated `ci.yml` - Validates MCP server on PRs

## Tools Provided
| Tool | Purpose |
|------|---------|
| `f5xc_search_docs` | Search provider documentation |
| `f5xc_get_doc` | Get specific resource documentation |
| `f5xc_list_docs` | List all available docs |
| `f5xc_search_api_specs` | Search OpenAPI specifications |
| `f5xc_get_api_spec` | Get specific API spec |
| `f5xc_find_endpoints` | Find endpoints by URL pattern |
| `f5xc_get_schema_definition` | Get schema definition |
| `f5xc_list_definitions` | List all definitions in a spec |
| `f5xc_get_summary` | Overview of all docs and specs |

## Testing
- [x] MCP server builds successfully (`npm run build`)
- [x] MCP server starts on stdio (`node dist/index.js`)
- [x] Pre-commit hooks pass
- [x] NPM_TOKEN secret added to GitHub repository

## Usage (after merge and npm publish)
```json
{
  "mcpServers": {
    "f5xc-terraform": {
      "command": "npx",
      "args": ["-y", "@robinmordasiewicz/f5xc-terraform-mcp"]
    }
  }
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)