### PR TITLE
fix(ci): include MCP changes in workflow proceed logic and sync versions

### DIFF
--- a/.github/workflows/_build-mcp-server.yml
+++ b/.github/workflows/_build-mcp-server.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
         with:
-          fetch-depth: 2
+          fetch-depth: 0  # Need full history for tags
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -56,12 +56,21 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Get version
+      - name: Sync version with provider
         id: version
         run: |
+          cd ..
+          # Get the latest provider version from git tags
+          PROVIDER_VERSION=$(git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//' || echo "0.0.0")
+          echo "Provider version from tag: $PROVIDER_VERSION"
+
+          # Update package.json with provider version
+          cd mcp-server
+          npm version "$PROVIDER_VERSION" --no-git-tag-version --allow-same-version
+
           VERSION=$(node -p "require('./package.json').version")
           echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "MCP Server version: $VERSION"
+          echo "MCP Server version synced to: $VERSION"
 
       - name: Check for changes
         id: check

--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -164,6 +164,7 @@ jobs:
           CODE="${{ steps.changes.outputs.code }}"
           TOOLS="${{ steps.changes.outputs.tools }}"
           FUNCTIONS="${{ steps.changes.outputs.functions }}"
+          MCP="${{ steps.changes.outputs.mcp }}"
 
           # Determine if regeneration would be needed
           NEEDS_REGEN="false"
@@ -172,11 +173,17 @@ jobs:
           fi
           echo "needs_regeneration=$NEEDS_REGEN" >> $GITHUB_OUTPUT
 
+          # Determine if MCP server build is needed (separate from regeneration)
+          NEEDS_MCP="false"
+          if [[ "$MCP" == "true" ]]; then
+            NEEDS_MCP="true"
+          fi
+
           if [[ "$IS_BOT" == "true" ]]; then
             # Bot commits (from regeneration PR merge) should proceed to tagging
             echo "Processing: Bot commit - will proceed to tag/release"
             echo "result=true" >> $GITHUB_OUTPUT
-          elif [[ "$NEEDS_REGEN" == "false" ]]; then
+          elif [[ "$NEEDS_REGEN" == "false" && "$NEEDS_MCP" == "false" ]]; then
             echo "Skipping: No relevant changes detected"
             echo "result=false" >> $GITHUB_OUTPUT
           else


### PR DESCRIPTION
## Summary
Fix the on-merge workflow to properly handle MCP server changes and sync MCP package version with provider releases.

## Related Issue
Closes #412

## Changes Made
- **on-merge.yml**: Include MCP server changes (`mcp-server/src/`) in the `should-process` determination so the workflow proceeds when only MCP files change
- **_build-mcp-server.yml**: 
  - Fetch full git history to access tags
  - Sync MCP server npm version with provider release version from latest git tag

## Testing
- [x] Pre-commit hooks pass
- [ ] CI checks pass

## Version Sync Behavior
When publishing to npm, the MCP server version will be synced from the latest provider git tag:
- Provider tag `v0.5.0` → MCP server npm version `0.5.0`
- This ensures version consistency between the provider and its MCP server

🤖 Generated with [Claude Code](https://claude.com/claude-code)