### PR TITLE
chore(mcp): trigger initial npm publish

### DIFF
--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -6,6 +6,9 @@
  * - Terraform provider documentation (resources, data sources, functions, guides)
  * - F5 Distributed Cloud OpenAPI specifications (270+ specs)
  * - Search and query capabilities for both documentation and API specs
+ *
+ * Version is synced with the Terraform provider release version.
+ * @see https://github.com/robinmordasiewicz/terraform-provider-f5xc
  */
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';


### PR DESCRIPTION
## Summary
Trigger the MCP server build and npm publish workflow with a small documentation update.

## Related Issue
Closes #414

## Context
- PR #411 added the MCP server but the workflow skipped due to a bug
- PR #413 fixed the workflow logic
- This PR triggers the corrected workflow to publish the initial npm package

## Changes Made
- Added version sync documentation to the MCP server header comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)