### PR TITLE
ci(acceptance-tests): refresh workflow file to force GitHub re-parse

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -1,6 +1,6 @@
 # Acceptance Tests Workflow
 #
-# This workflow runs comprehensive acceptance tests for the F5 XC Terraform Provider.
+# Comprehensive acceptance tests for the F5 XC Terraform Provider.
 # It supports both mock tests (fast, parallel) and real API tests, plus behavioral
 # consistency comparison between mock and real API results.
 #


### PR DESCRIPTION
## Summary

Minor comment update to force GitHub to re-parse the workflow file after updating repository secrets from VES_* to F5XC_* naming convention.

## Related Issue

Closes #426

## Changes Made

- Updated workflow comment to trigger GitHub re-parse
- Repository secrets have been updated separately:
  - Added: F5XC_API_URL, F5XC_API_TOKEN, F5XC_P12_PASSWORD, F5XC_P12_BASE64
  - Removed: VES_API_URL, VES_API_TOKEN, VES_P12_PASSWORD, VES_P12_BASE64

## Problem Context

The acceptance-tests workflow was experiencing issues:
1. Workflow showing as file path (`.github/workflows/acceptance-tests.yml`) instead of "Acceptance Tests" in GitHub UI
2. workflow_dispatch API returning 204 success but not creating workflow runs
3. All recent workflow runs failing immediately with "workflow file issue"

## Testing

After merging, will trigger workflow_dispatch to verify:
- [ ] Workflow runs are created successfully
- [ ] Mock tests execute properly
- [ ] Real API tests execute with new F5XC_* secrets

🤖 Generated with [Claude Code](https://claude.com/claude-code)