### PR TITLE
docs: add MCP Configuration section to provider documentation

### DIFF
--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -146,6 +146,30 @@ resource "f5xc_http_loadbalancer" "example" {
 }
 ```
 
+## MCP Configuration
+
+This provider includes a Model Context Protocol (MCP) server that enables AI assistants like Claude to interact with F5 Distributed Cloud resources. The MCP server provides schema information, documentation, and example configurations.
+
+### Quick Setup for Claude Desktop
+
+Add the following to your Claude Desktop configuration file:
+
+**macOS:** `~/Library/Application Support/Claude/claude_desktop_config.json`
+**Windows:** `%APPDATA%\Claude\claude_desktop_config.json`
+
+```json
+{
+  "mcpServers": {
+    "f5xc-terraform": {
+      "command": "npx",
+      "args": ["@robinmordasiewicz/f5xc-terraform-mcp"]
+    }
+  }
+}
+```
+
+For complete MCP server documentation including all available tools and advanced configuration options, see the [NPM package page](https://www.npmjs.com/package/@robinmordasiewicz/f5xc-terraform-mcp).
+
 ## Resources and Data Sources
 
 Browse the documentation sidebar for the complete list of resources and data sources organized by category.


### PR DESCRIPTION
## Summary

Add brief MCP server configuration instructions to the provider documentation with a link to the complete NPM documentation.

## Related Issue

Closes #430

## Changes Made

- Added "MCP Configuration" section below "Getting Started" in `templates/index.md.tmpl`
- Includes configuration file paths for macOS and Windows
- Provides JSON snippet for Claude Desktop configuration
- Links to NPM package for complete documentation

## Preview

The new section explains how to configure the MCP server with Claude Desktop and directs users to the NPM package page for complete documentation:
- [NPM package: @robinmordasiewicz/f5xc-terraform-mcp](https://www.npmjs.com/package/@robinmordasiewicz/f5xc-terraform-mcp)

## Testing

- [x] Template file validates as correct markdown
- [x] Pre-commit hooks pass
- [ ] Documentation will be regenerated on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)