### PR TITLE
chore(deps): update GitHub Actions to latest major versions

### DIFF
--- a/.github/workflows/_build-mcp-server.yml
+++ b/.github/workflows/_build-mcp-server.yml
@@ -35,12 +35,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0  # Need full history for tags
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/_build-test.yml
+++ b/.github/workflows/_build-test.yml
@@ -30,7 +30,7 @@ jobs:
       success: ${{ steps.result.outputs.success }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.ref || github.ref }}
           fetch-depth: 0
@@ -130,7 +130,7 @@ jobs:
     if: inputs.run-lint
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.ref || github.ref }}
 
@@ -141,7 +141,7 @@ jobs:
           cache: true
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v8
+        uses: golangci/golangci-lint-action@v9
         with:
           version: latest
           args: --timeout=5m ./internal/... .

--- a/.github/workflows/_generate-docs.yml
+++ b/.github/workflows/_generate-docs.yml
@@ -22,7 +22,7 @@ jobs:
       changed: ${{ steps.check.outputs.changed }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.ref || github.ref }}
           fetch-depth: 0

--- a/.github/workflows/_generate-provider.yml
+++ b/.github/workflows/_generate-provider.yml
@@ -26,7 +26,7 @@ jobs:
       changed: ${{ steps.check.outputs.changed }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.ref || github.ref }}
           fetch-depth: 0

--- a/.github/workflows/_tag-release.yml
+++ b/.github/workflows/_tag-release.yml
@@ -37,7 +37,7 @@ jobs:
       created: ${{ steps.create.outputs.created }}
     steps:
       - name: Checkout latest main
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           # Fetch the LATEST main HEAD, not github.sha
           # This ensures we tag the commit that includes regeneration

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -121,7 +121,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Set up Go
         uses: actions/setup-go@v6
@@ -168,7 +168,7 @@ jobs:
           echo "failed=$FAILED" >> $GITHUB_OUTPUT
 
       - name: Upload mock test reports
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: always()
         with:
           name: mock-test-reports
@@ -176,7 +176,7 @@ jobs:
           retention-days: 30
 
       - name: Publish JUnit Results
-        uses: mikepenz/action-junit-report@v4
+        uses: mikepenz/action-junit-report@v6
         if: always()
         with:
           report_paths: 'test-reports/mock-tests.xml'
@@ -215,7 +215,7 @@ jobs:
           echo "Verifying F5 XC API connectivity..."
 
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Set up Go
         uses: actions/setup-go@v6
@@ -334,7 +334,7 @@ jobs:
           fi
 
       - name: Upload real API test reports
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: always()
         with:
           name: real-api-test-reports
@@ -342,7 +342,7 @@ jobs:
           retention-days: 30
 
       - name: Publish JUnit Results
-        uses: mikepenz/action-junit-report@v4
+        uses: mikepenz/action-junit-report@v6
         if: always()
         with:
           report_paths: 'test-reports/real-tests.xml'
@@ -363,7 +363,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Set up Go
         uses: actions/setup-go@v6
@@ -461,7 +461,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Set up Go
         uses: actions/setup-go@v6
@@ -470,13 +470,13 @@ jobs:
           cache: true
 
       - name: Download mock test reports
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: mock-test-reports
           path: mock-reports/
 
       - name: Download real API test reports
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: real-api-test-reports
           path: real-reports/
@@ -532,7 +532,7 @@ jobs:
           fi
 
       - name: Upload comparison reports
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: steps.compare.outputs.available == 'true'
         with:
           name: comparison-reports
@@ -562,7 +562,7 @@ jobs:
 
     steps:
       - name: Download all reports
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: all-reports/
         continue-on-error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
       github.head_ref != 'openapi-update'
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -157,7 +157,7 @@ jobs:
     if: github.event_name == 'pull_request'
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -257,7 +257,7 @@ jobs:
     if: github.event_name == 'pull_request'
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Check if mock fixture regeneration needed
         id: check
@@ -335,7 +335,7 @@ jobs:
         working-directory: mcp-server
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -356,7 +356,7 @@ jobs:
 
       - name: Setup Node.js
         if: steps.check.outputs.needs_validation == 'true'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'

--- a/.github/workflows/discover-defaults.yml
+++ b/.github/workflows/discover-defaults.yml
@@ -84,7 +84,7 @@ jobs:
           # This step validates we can reach the staging environment
 
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           token: ${{ secrets.AUTO_MERGE_TOKEN }}
@@ -249,7 +249,7 @@ jobs:
 
       - name: Upload discovery log
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: discovery-log
           path: discovery.log

--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -64,7 +64,7 @@ jobs:
       needs-regeneration: ${{ steps.should-process.outputs.needs_regeneration }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 2
 
@@ -285,7 +285,7 @@ jobs:
       pr-number: ${{ steps.create-pr.outputs.pr_number }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           token: ${{ secrets.AUTO_MERGE_TOKEN }}

--- a/.github/workflows/sync-openapi.yml
+++ b/.github/workflows/sync-openapi.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -94,7 +94,7 @@ jobs:
 
       - name: Setup Node.js for validation
         if: steps.changes.outputs.changed == 'true'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
 
@@ -153,7 +153,7 @@ jobs:
       - name: Find or create tracking issue
         if: steps.changes.outputs.changed == 'true'
         id: issue
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const issueTitle = "OpenAPI Spec Update Available";


### PR DESCRIPTION
## Summary
Updates all GitHub Actions to their latest major versions for security patches and new features.

## Updates
| Action | Previous | Updated |
|--------|----------|---------|
| actions/checkout | v5 | v6 |
| actions/setup-node | v4 | v6 |
| actions/upload-artifact | v4 | v6 |
| actions/download-artifact | v4 | v7 |
| actions/github-script | v7 | v8 |
| golangci/golangci-lint-action | v8 | v9 |
| mikepenz/action-junit-report | v4 | v6 |

## Related Issue
Closes #433

## Testing
- [x] All YAML files validated
- [x] Go build passes
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)