### PR TITLE
fix(ci): resolve punycode warning and acceptance-tests workflow issue

### DIFF
--- a/.github/workflows/_build-test.yml
+++ b/.github/workflows/_build-test.yml
@@ -140,8 +140,11 @@ jobs:
           go-version-file: ${{ inputs.go-version-file }}
           cache: true
 
+      - name: Install golangci-lint
+        run: |
+          # Install golangci-lint binary directly (no Node.js dependencies)
+          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $(go env GOPATH)/bin
+          echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
+
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v9
-        with:
-          version: latest
-          args: --timeout=5m ./internal/... .
+        run: golangci-lint run --timeout=5m ./internal/... .


### PR DESCRIPTION
## Summary
Fixes two CI workflow issues:

### 1. Punycode Deprecation Warning - FIXED
Replaced `golangci/golangci-lint-action@v9` with direct binary installation of golangci-lint.

**Root Cause:** The action has a transitive dependency chain:
```
golangci-lint-action → eslint → ajv → uri-js → punycode
```
The punycode module is deprecated in Node.js 21+.

**Solution:** Install golangci-lint binary directly using the official install script, eliminating Node.js entirely.

### 2. Acceptance-Tests Workflow Registration - ATTEMPTED FIX
The workflow was triggering on `push` events despite not having a push trigger defined, due to stale GitHub metadata.

**Approach:** Complete delete and recreate of the workflow file in two commits to force GitHub to re-register.

## Related Issue
Closes #435

## Changes
- `.github/workflows/_build-test.yml`: Replace golangci-lint-action with direct binary install
- `.github/workflows/acceptance-tests.yml`: Delete and recreate to force re-registration

## Testing
- [x] Pre-commit hooks pass
- [ ] CI workflow runs without punycode warning
- [ ] Acceptance-tests workflow properly registered

🤖 Generated with [Claude Code](https://claude.com/claude-code)