### PR TITLE
docs(mcp): document version synchronization in source header

### DIFF
--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -7,8 +7,12 @@
  * - F5 Distributed Cloud OpenAPI specifications (270+ specs)
  * - Search and query capabilities for both documentation and API specs
  *
- * Version is synced with the Terraform provider release version.
+ * Version Synchronization:
+ * The npm package version is automatically synced with GitHub releases via CI/CD.
+ * Both the Terraform provider and MCP server always share the same version number.
+ *
  * @see https://github.com/robinmordasiewicz/terraform-provider-f5xc
+ * @see https://www.npmjs.com/package/@robinmordasiewicz/f5xc-terraform-mcp
  */
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';


### PR DESCRIPTION
## Summary

Update the MCP server source header comment to document the version synchronization mechanism between npm and GitHub releases.

## Related Issue

Closes #446

## Changes

- Add "Version Synchronization" section explaining the automated sync
- Add npm package URL reference
- Documents the CI/CD workflow behavior implemented in #442 and #445

## Purpose

This change triggers a new release to sync the current version mismatch:
- **Before**: npm 2.4.3, GitHub v2.4.4
- **After**: Both synced to v2.4.5

## Testing

- [ ] CI checks pass
- [ ] MCP server builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)