### PR TITLE
fix(generator): Handle unknown values in ListNestedBlock, tenant drift, and system labels

### DIFF
--- a/internal/provider/provider_helpers.go
+++ b/internal/provider/provider_helpers.go
@@ -30,3 +30,16 @@ func normalizeAPIURL(url string) (string, bool) {
 
 	return url, url != original
 }
+
+// filterSystemLabels removes F5 XC system-managed labels (ves.io/*) from the label map.
+// These labels are injected by the platform and should not be managed by Terraform.
+// nolint:unused // Used by generated resource/data source Read methods
+func filterSystemLabels(labels map[string]string) map[string]string {
+	filtered := make(map[string]string)
+	for k, v := range labels {
+		if !strings.HasPrefix(k, "ves.io/") {
+			filtered[k] = v
+		}
+	}
+	return filtered
+}


### PR DESCRIPTION
## Summary

This PR fixes three systematic bugs affecting the generated provider code:

### Issue 1 (HIGH): ListNestedBlock Unknown Values
- Changed top-level ListNestedBlock fields from Go slices to `types.List`
- Go slices cannot represent "unknown" state during planning, causing errors like:
  ```
  Error: Value Conversion Error
  Received unknown value, however the target type cannot handle unknown values
  ```
- Added `AttrTypes` generation for all nested models
- Updated marshal/unmarshal code to use `types.ListValueFrom`/`ElementsAs`
- Preserves empty block state during Read operations

### Issue 2 (MEDIUM): Tenant Attribute Perpetual Drift
- Added `UseStateForUnknown` plan modifier to nested tenant/uid/kind attributes
- These API-computed fields now preserve state between apply cycles
- Prevents "known after apply" drift on every plan:
  ```hcl
  ~ tenant = "nferreira-cuxnbbdn" -> (known after apply)
  ```

### Issue 3 (LOW): System Label Drift
- Added `filterSystemLabels()` helper in `provider_helpers.go`
- Filters out `ves.io/*` labels injected by F5 XC platform
- Applied during Read operations for both resources and data sources
- Prevents drift from server-managed labels:
  ```hcl
  - "ves.io/app_type" = "ves-io-default-test-app-lb" -> null
  ```

## Related Issue

Closes #448

## Changes Made

- `tools/generate-all-schemas.go`:
  - Added `HasBlocks` field to track if resources have nested models
  - Added `hasNestedModelsWithAttrTypes()` function for conditional `attr` import
  - Changed top-level ListNestedBlock model fields to use `types.List`
  - Added AttrTypes generation for all nested models
  - Updated marshal code to extract types.List to Go slice
  - Updated unmarshal code to convert Go slice back to types.List
  - Added `UseStateForUnknown` plan modifier for tenant/uid/kind in nested blocks
  - Added `filterSystemLabels()` call in Read templates

- `internal/provider/provider_helpers.go`:
  - Added `filterSystemLabels()` helper function

## Testing

- [x] Generator builds successfully (`go build ./...`)
- [x] All unit tests pass (`go test ./...`)
- [x] Pre-commit hooks pass
- [x] Generated code compiles (verified with `go run tools/generate-all-schemas.go && go build ./...`)

## Note

The generated provider code will be automatically regenerated by CI/CD on merge via the `on-merge.yml` workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)