### PR TITLE
fix(generator): nested ObjectType definitions for blocks with sub-blocks only

### DIFF
--- a/tools/generate-all-schemas.go
+++ b/tools/generate-all-schemas.go
@@ -3432,20 +3432,13 @@ func renderNestedModelTypes(resourceTitleCase string, attrs []TerraformAttribute
 				continue
 			}
 
-			// Check if this nested block is empty (has no non-block attributes)
-			// A block is considered "empty" if it has no nested attributes OR all nested attributes are blocks themselves
+			// Check if this nested block is empty (has no nested content)
+			// If NestedAttributes has any content (blocks or attributes), a model with
+			// AttrTypes is generated and should be referenced. Only truly empty blocks
+			// should use inline empty maps.
+			// Fix for Issue #452: Blocks containing only sub-blocks are NOT empty -
+			// they need to reference their model's AttrTypes to avoid Value Conversion Errors.
 			isNestedEmpty := len(attr.NestedAttributes) == 0
-			if !isNestedEmpty {
-				hasNonBlockAttrs := false
-				for _, nested := range attr.NestedAttributes {
-					if !nested.IsBlock {
-						hasNonBlockAttrs = true
-						break
-					}
-				}
-				// If there are no non-block attributes, treat as empty (uses EmptyModel)
-				isNestedEmpty = !hasNonBlockAttrs
-			}
 
 			if isNestedEmpty {
 				// Empty nested block - use inline empty map


### PR DESCRIPTION
## Summary

Fix for Issue #452 - CRITICAL regression in f5xc_origin_pool causing Value Conversion Errors.

## Root Cause

The `isNestedEmpty` check in `renderNestedModelTypes()` incorrectly treated blocks containing only nested sub-blocks (no direct attributes) as "empty". This caused the generator to output:

```go
"site_locator": types.ObjectType{AttrTypes: map[string]attr.Type{}}  // WRONG
```

Instead of:

```go
"site_locator": types.ObjectType{AttrTypes: OriginPoolOriginServersConsulServiceSiteLocatorModelAttrTypes}  // CORRECT
```

## Affected Nested Objects (10 total)

- `consul_service.site_locator`, `consul_service.snat_pool`
- `k8s_service.site_locator`, `k8s_service.snat_pool`
- `private_ip.site_locator`, `private_ip.snat_pool`
- `private_name.site_locator`, `private_name.snat_pool`
- `custom_endpoint_object`

## Fix

Simplified the empty check to only consider blocks with zero nested attributes as truly empty. Blocks with any nested content (sub-blocks or attributes) will now correctly reference their model's AttrTypes variable.

**Removed**: The `hasNonBlockAttrs` loop that incorrectly classified block-only parents as empty.

## Testing

- [x] Generator builds successfully
- [x] Pre-commit hooks pass (including golangci-lint, go build, go vet)
- [ ] CI/CD will regenerate all resources after merge
- [ ] origin_pool CRUD operations work without Value Conversion Error

## Related

This is similar to Issue #1 (data_guard_rules) fixed in v2.4.6, which addressed types.List handling for top-level ListNestedBlocks. This fix addresses the same pattern for deeply nested SingleNestedBlocks.

Fixes #452

🤖 Generated with [Claude Code](https://claude.com/claude-code)