### PR TITLE
fix: remove Paths field from OpenAPISpec to fix JSON parsing errors

### DIFF
--- a/tools/enrich-descriptions.go
+++ b/tools/enrich-descriptions.go
@@ -72,9 +72,9 @@ type SchemaDefinition struct {
 
 // OpenAPISpec represents the top-level OpenAPI document
 type OpenAPISpec struct {
-	Info       SpecInfo                      `json:"info"`
-	Components SpecComponents                `json:"components"`
-	Paths      map[string]map[string]PathOp  `json:"paths"`
+	Info       SpecInfo       `json:"info"`
+	Components SpecComponents `json:"components"`
+	// Paths is not unmarshaled - we only need schemas, and some specs have non-standard path values
 }
 
 // SpecInfo contains API metadata
@@ -86,12 +86,6 @@ type SpecInfo struct {
 // SpecComponents contains schema definitions
 type SpecComponents struct {
 	Schemas map[string]SchemaDefinition `json:"schemas"`
-}
-
-// PathOp represents a path operation
-type PathOp struct {
-	Summary     string `json:"summary"`
-	Description string `json:"description"`
 }
 
 // DescriptionContext holds all context for a description


### PR DESCRIPTION
## Summary
Fixes JSON parsing errors in `enrich-descriptions.go` caused by non-standard `paths` field values in some F5 XC OpenAPI spec files.

## Related Issue
Closes #459

## Changes Made
- Removed the `Paths` field from `OpenAPISpec` struct since we only need the `components.schemas` section for description enrichment
- Some spec files have `paths` values that are strings (documentation references) instead of path operation objects, causing unmarshal errors

## Testing
- [x] Local dry-run test confirms 269 spec files are now parsed successfully
- [x] 31,722 descriptions extracted (2,143 needing enrichment)
- [x] Pre-commit hooks pass
- [x] Go build and vet pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)