### PR TITLE
fix(ci): use step output instead of secrets in if condition

### DIFF
--- a/.github/workflows/acc-tests.yml
+++ b/.github/workflows/acc-tests.yml
@@ -371,9 +371,28 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
           cache: true
 
+      - name: Check authentication method
+        id: check-auth
+        env:
+          F5XC_API_TOKEN: ${{ secrets.F5XC_API_TOKEN }}
+          F5XC_P12_BASE64: ${{ secrets.F5XC_P12_BASE64 }}
+          F5XC_P12_PASSWORD: ${{ secrets.F5XC_P12_PASSWORD }}
+        run: |
+          # Determine which authentication method is configured
+          if [ -n "$F5XC_API_TOKEN" ]; then
+            echo "✓ Using API Token authentication"
+            echo "auth_method=token" >> $GITHUB_OUTPUT
+          elif [ -n "$F5XC_P12_BASE64" ] && [ -n "$F5XC_P12_PASSWORD" ]; then
+            echo "✓ Using P12 certificate authentication"
+            echo "auth_method=p12" >> $GITHUB_OUTPUT
+          else
+            echo "::warning::No authentication configured for cleanup"
+            echo "auth_method=none" >> $GITHUB_OUTPUT
+          fi
+
       - name: Setup P12 certificate (if using P12 auth)
         id: setup-p12
-        if: ${{ secrets.F5XC_P12_BASE64 != '' }}
+        if: steps.check-auth.outputs.auth_method == 'p12'
         env:
           F5XC_P12_BASE64: ${{ secrets.F5XC_P12_BASE64 }}
         run: |


### PR DESCRIPTION
## Summary

Fixes invalid workflow file error in acc-tests.yml caused by using secrets directly in a step-level `if` condition.

## Related Issue
Fixes #461

## Changes Made

- Added `check-auth` step in cleanup job to determine authentication method via environment variables
- The step checks for both API Token and P12 certificate authentication
- Uses step output `auth_method` in the `if` condition instead of directly referencing secrets
- Follows the same pattern already used in the `real-api-tests` job's `verify-creds` step

## Root Cause

GitHub Actions does not allow using `secrets` context directly in step-level `if` conditions. The expression `secrets.F5XC_P12_BASE64 != ''` at line 376 was invalid.

## Testing

- [x] Workflow file passes YAML validation
- [x] Pre-commit hooks pass
- [x] Pattern matches existing `verify-creds` step in real-api-tests job

🤖 Generated with [Claude Code](https://claude.com/claude-code)