### PR TITLE
fix(workflow): ensure releases trigger on any substantive change

### DIFF
--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -15,10 +15,16 @@
 #   - Human commit NOT needing regeneration -> Tag immediately (content complete)
 #   - Bot commit (regeneration merged) -> Tag now (content complete)
 #
+# FIX FOR MISSING RELEASES (Issue #484) - TAG ON ANY CHANGE:
+# Previously, only changes that triggered regeneration would create releases.
+# Now, ANY substantive change (code, docs, README, etc.) triggers a release.
+# Only workflow file and .gitignore changes are excluded from tagging.
+#
 # FLOW:
 # Human PR merges -> detect-changes -> build-test -> regenerate?
 #   -> If regeneration needed: Create PR, skip tagging (wait for PR to merge)
-#   -> If no regeneration: Tag and release immediately
+#   -> If no regeneration BUT has substantive changes: Tag and release immediately
+#   -> If only workflow/gitignore changes: Skip (no release needed)
 # Bot commit (regeneration PR merged) -> Tag and release
 #
 # REPLACED WORKFLOWS:
@@ -31,11 +37,8 @@ on:
   push:
     branches:
       - main
-    paths-ignore:
-      - '*.md'
-      # Note: Don't ignore workflow files - changes to on-merge.yml itself
-      # should be testable via CI, but won't trigger regeneration anyway
-      # since the detect-changes job filters by actual code changes.
+    # Note: No paths-ignore - all changes should trigger workflow
+    # Specific path filtering happens in detect-changes job
 
 permissions:
   contents: write
@@ -59,6 +62,7 @@ jobs:
       functions-changed: ${{ steps.changes.outputs.functions }}
       mcp-changed: ${{ steps.changes.outputs.mcp }}
       docs-changed: ${{ steps.changes.outputs.docs }}
+      has-any-changes: ${{ steps.changes.outputs.has_any_changes }}
       is-bot-commit: ${{ steps.check-author.outputs.is_bot }}
       should-process: ${{ steps.should-process.outputs.result }}
       needs-regeneration: ${{ steps.should-process.outputs.needs_regeneration }}
@@ -156,6 +160,16 @@ jobs:
             echo "docs=false" >> $GITHUB_OUTPUT
           fi
 
+          # Check for ANY substantive changes (for tagging even without regeneration)
+          # Exclude only workflow files and gitignore - everything else is substantive
+          SUBSTANTIVE_CHANGES=$(echo "$CHANGED" | grep -vE '^\.github/workflows/|^\.gitignore' || true)
+          if [ -n "$SUBSTANTIVE_CHANGES" ]; then
+            echo "has_any_changes=true" >> $GITHUB_OUTPUT
+            echo "Substantive changes detected (will trigger tagging)"
+          else
+            echo "has_any_changes=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Determine if processing should proceed
         id: should-process
         run: |
@@ -165,6 +179,7 @@ jobs:
           TOOLS="${{ steps.changes.outputs.tools }}"
           FUNCTIONS="${{ steps.changes.outputs.functions }}"
           MCP="${{ steps.changes.outputs.mcp }}"
+          HAS_ANY_CHANGES="${{ steps.changes.outputs.has_any_changes }}"
 
           # Determine if regeneration would be needed
           NEEDS_REGEN="false"
@@ -184,10 +199,16 @@ jobs:
             echo "Processing: Bot commit - will proceed to tag/release"
             echo "result=true" >> $GITHUB_OUTPUT
           elif [[ "$NEEDS_REGEN" == "false" && "$NEEDS_MCP" == "false" ]]; then
-            echo "Skipping: No relevant changes detected"
-            echo "result=false" >> $GITHUB_OUTPUT
+            # No regeneration needed - check if there are any substantive changes for tagging
+            if [[ "$HAS_ANY_CHANGES" == "true" ]]; then
+              echo "Processing: Substantive changes without regeneration - will tag"
+              echo "result=true" >> $GITHUB_OUTPUT
+            else
+              echo "Skipping: No relevant changes detected"
+              echo "result=false" >> $GITHUB_OUTPUT
+            fi
           else
-            echo "Processing: Human commit with relevant changes"
+            echo "Processing: Human commit with regeneration/MCP changes"
             echo "result=true" >> $GITHUB_OUTPUT
           fi
 
@@ -497,12 +518,14 @@ jobs:
   # ===========================================================================
   # CRITICAL: Tags are ONLY created when content is definitively complete:
   #   1. Bot commit (regeneration PR was merged) -> Tag now, content is complete
-  #   2. Human commit that didn't need regeneration -> Tag now, content is complete
+  #   2. Human commit with substantive changes (no regen) -> Tag now, content is complete
   #   3. Human commit that created regeneration PR -> DON'T tag, wait for PR merge
+  #   4. Human commit with only workflow/gitignore changes -> Skip (no release needed)
   # Tagging conditions (comments cannot be inside if expressions):
   # - Case 1: Bot commit -> Tag immediately (regeneration is complete)
-  # - Case 2: Human commit without regeneration -> Tag immediately (PR job was skipped)
+  # - Case 2: Human commit with substantive changes, no regen -> Tag immediately (build passed)
   # - Case 3: Human commit WITH regeneration -> DON'T tag (wait for regen PR to merge)
+  # - Case 4: Only workflow/gitignore changes -> Skip (not substantive)
   tag-release:
     name: Tag and Release
     needs: [detect-changes, build-test, create-regeneration-pr]


### PR DESCRIPTION
## Summary
Fixes the on-merge workflow to create releases for ANY substantive change, not just changes that trigger regeneration or MCP rebuild.

## Related Issue
Closes #484

## Problem
Two issues prevented proper release tagging:

### Issue 1: Markdown Files Blocked
```yaml
paths-ignore:
  - '*.md'  # Prevented workflow from running at all
```
- PR #481 (README.md) → Workflow didn't run
- Result: No release created

### Issue 2: Narrow Change Detection
```
main.go changed → Not in monitored paths
Result: Workflow ran but skipped tagging
```
- PR #483 (main.go comment) → Workflow ran but skipped everything
- Result: No release created

**Evidence**: Latest release is v2.6.2 (commit 508c15c2). PRs #481 and #483 merged but didn't create v2.6.3 or v2.6.4.

## Changes Made

### 1. Removed Restrictive paths-ignore (line 34-35)
**Before:**
```yaml
paths-ignore:
  - '*.md'
```

**After:**
```yaml
# Note: No paths-ignore - all changes should trigger workflow
# Specific path filtering happens in detect-changes job
```

### 2. Added has-any-changes Detection (lines 157-165)
New detection that catches ANY substantive change:
```bash
SUBSTANTIVE_CHANGES=$(echo "$CHANGED" | grep -vE '^\.github/workflows/|^\.gitignore' || true)
```
- Excludes only: workflow files and .gitignore
- Includes: code, docs, README, config, any tracked file

### 3. Updated should-process Logic (lines 195-203)
**Before:**
```bash
elif [[ "$NEEDS_REGEN" == "false" && "$NEEDS_MCP" == "false" ]]; then
  echo "Skipping: No relevant changes detected"  # ❌ Skipped tagging!
  echo "result=false"
```

**After:**
```bash
elif [[ "$NEEDS_REGEN" == "false" && "$NEEDS_MCP" == "false" ]]; then
  if [[ "$HAS_ANY_CHANGES" == "true" ]]; then
    echo "Processing: Substantive changes without regeneration - will tag"  # ✅ Tags!
    echo "result=true"
  else
    echo "Skipping: No relevant changes detected"
    echo "result=false"
  fi
```

### 4. Updated Documentation
- Added Issue #484 fix notes in header
- Updated FLOW description
- Updated tag-release job comments with new cases

## New Workflow Behavior

### Triggers Release (Creates Tag):
- ✅ Code changes (Go files, internal/)
- ✅ Documentation (README.md, docs/)
- ✅ Configuration files
- ✅ Any tracked file except workflow/gitignore

### Skips Release (No Tag):
- ⏭️ Only workflow file changes (.github/workflows/)
- ⏭️ Only .gitignore changes

## Testing Plan

1. **CI Validation**: Standard checks pass
2. **End-to-End Test**: After merge, this workflow change itself will trigger:
   - Detect changes (workflow file changed → skip tagging as designed)
   - Verify proper skip message in logs

3. **Follow-up Test**: Create small change (e.g., update README)
   - Should trigger tag creation
   - Verifies fix works for Markdown files

## Expected Impact

### Immediate:
- This PR merges → Workflow runs → Skips tagging (workflow-only change) ✅

### After Fix Active:
- Any code/doc change → Creates release
- Complete semantic versioning history
- No more missing releases

### Version Bumps:
- `chore:`, `docs:`, `style:`, `refactor:` → Patch (e.g., v2.6.3)
- `feat:` → Minor (e.g., v2.7.0)
- `BREAKING CHANGE:` or `feat!:` → Major (e.g., v3.0.0)

## Verification Commands

After merge, check workflow behavior:
```bash
# View workflow run for this PR
gh run list --workflow=on-merge.yml --limit 1

# Check detect-changes logs
gh run view <run-id> --log | grep -A20 "Detect Changes"

# Verify skip message
# Should see: "Skipping: No relevant changes detected" (workflow-only)
```

## Rollback Plan
If issues occur:
1. Revert this commit
2. Workflow returns to previous behavior
3. Missing releases can be manually created with `gh release create`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>