### PR TITLE
feat: add dynamic subscription tier notes to documentation and MCP server

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -171,6 +171,23 @@ repos:
         files: \.go$
         pass_filenames: false
 
+  # =============================================================================
+  # Subscription Tier Metadata Update (Optional)
+  # =============================================================================
+  # Updates subscription tier metadata from F5 XC Catalog API when generator changes
+  # Skips gracefully if F5XC credentials are not available
+  - repo: local
+    hooks:
+      - id: update-subscription-metadata
+        name: Update subscription tier metadata
+        entry: scripts/update-subscription-metadata.sh
+        language: system
+        files: ^tools/generate-subscription-metadata\.go$
+        pass_filenames: false
+        stages: [pre-commit]
+        # This hook is advisory - it won't fail if credentials are unavailable
+        # When credentials are set, it updates tools/subscription-tiers.json
+
 # =============================================================================
 # CI Configuration
 # =============================================================================

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -161,15 +161,6 @@
         "line_number": 37
       }
     ],
-    "docs/resources/http_loadbalancer.md": [
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/resources/http_loadbalancer.md",
-        "hashed_secret": "0c5aa2932d2cec0a3f054674b7124b6b6af51cf5",
-        "is_verified": false,
-        "line_number": 2839
-      }
-    ],
     "docs/resources/virtual_host.md": [
       {
         "type": "Base64 High Entropy String",
@@ -722,5 +713,5 @@
       }
     ]
   },
-  "generated_at": "2025-12-12T01:53:26Z"
+  "generated_at": "2025-12-16T20:46:29Z"
 }

--- a/mcp-server/scripts/copy-docs.js
+++ b/mcp-server/scripts/copy-docs.js
@@ -71,6 +71,21 @@ for (const [key, source] of Object.entries(SOURCES)) {
 
 console.log(`\nBundled ${totalFiles} documentation files to dist/docs/`);
 
+// Copy subscription metadata if available
+const SUBSCRIPTION_METADATA_SRC = join(PROJECT_ROOT, 'tools', 'subscription-tiers.json');
+const SUBSCRIPTION_METADATA_DEST = join(MCP_ROOT, 'dist', 'subscription-tiers.json');
+
+if (existsSync(SUBSCRIPTION_METADATA_SRC)) {
+  try {
+    cpSync(SUBSCRIPTION_METADATA_SRC, SUBSCRIPTION_METADATA_DEST);
+    console.log('  [OK] subscription-tiers.json: Copied metadata file');
+  } catch (error) {
+    console.error(`  [ERROR] subscription-tiers.json: ${error.message}`);
+  }
+} else {
+  console.log('  [SKIP] subscription-tiers.json: Source not found (optional)');
+}
+
 /**
  * Count files in a directory recursively
  */

--- a/mcp-server/src/schemas/index.ts
+++ b/mcp-server/src/schemas/index.ts
@@ -132,6 +132,17 @@ export const GetSummarySchema = z.object({
   response_format: ResponseFormatSchema,
 }).strict();
 
+// Get subscription info schema
+export const GetSubscriptionInfoSchema = z.object({
+  resource: z.string()
+    .optional()
+    .describe('Resource name to check (omit to get all Advanced tier resources)'),
+  tier: z.enum(['STANDARD', 'ADVANCED'])
+    .optional()
+    .describe('Filter by subscription tier'),
+  response_format: ResponseFormatSchema,
+}).strict();
+
 // Export type inference helpers
 export type SearchDocsInput = z.infer<typeof SearchDocsSchema>;
 export type GetDocInput = z.infer<typeof GetDocSchema>;
@@ -142,3 +153,4 @@ export type FindEndpointsInput = z.infer<typeof FindEndpointsSchema>;
 export type GetSchemaDefInput = z.infer<typeof GetSchemaDefSchema>;
 export type ListDefinitionsInput = z.infer<typeof ListDefinitionsSchema>;
 export type GetSummaryInput = z.infer<typeof GetSummarySchema>;
+export type GetSubscriptionInfoInput = z.infer<typeof GetSubscriptionInfoSchema>;

--- a/mcp-server/src/types.ts
+++ b/mcp-server/src/types.ts
@@ -7,6 +7,45 @@ export interface ResourceDoc {
   path: string;
   type: 'resource' | 'data-source' | 'function' | 'guide';
   content?: string;
+  // Subscription tier fields
+  subscriptionTier?: SubscriptionTier;
+  addonService?: string;
+  advancedFeatures?: string[];
+}
+
+/**
+ * F5 Distributed Cloud subscription tiers
+ * Note: Only Standard and Advanced tiers are currently available
+ * NO_TIER indicates the feature is included in all subscriptions
+ */
+export type SubscriptionTier = 'NO_TIER' | 'STANDARD' | 'ADVANCED';
+
+/**
+ * Service information from F5 XC catalog
+ */
+export interface ServiceInfo {
+  tier: SubscriptionTier;
+  display_name: string;
+  group_name?: string;
+}
+
+/**
+ * Resource metadata including subscription requirements
+ */
+export interface ResourceMetadata {
+  service: string;
+  minimum_tier: SubscriptionTier;
+  advanced_features?: string[];
+}
+
+/**
+ * Full subscription metadata structure
+ */
+export interface SubscriptionMetadata {
+  generated_at: string;
+  source: string;
+  services: Record<string, ServiceInfo>;
+  resources: Record<string, ResourceMetadata>;
 }
 
 export interface ApiSpec {

--- a/scripts/update-subscription-metadata.sh
+++ b/scripts/update-subscription-metadata.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+# =============================================================================
+# Update Subscription Tier Metadata
+# =============================================================================
+# This script runs the subscription metadata generator to update
+# tools/subscription-tiers.json with the latest tier information from the
+# F5 XC Catalog API.
+#
+# The generated file is committed to the repository and changes trigger
+# documentation regeneration in CI/CD.
+#
+# Required Environment Variables:
+#   F5XC_API_URL      - F5 XC API URL (e.g., https://console.ves.volterra.io)
+#   F5XC_API_TOKEN    - API token (preferred for automation)
+#   OR
+#   F5XC_P12_FILE     - Path to P12 certificate file
+#   F5XC_P12_PASSWORD - Password for P12 file
+#
+# Usage:
+#   ./scripts/update-subscription-metadata.sh [--check]
+#
+# Options:
+#   --check  Only check if updates are needed, don't modify files (for CI)
+# =============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+METADATA_FILE="${REPO_ROOT}/tools/subscription-tiers.json"
+GENERATOR="${REPO_ROOT}/tools/generate-subscription-metadata.go"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+check_mode=false
+if [[ "${1:-}" == "--check" ]]; then
+    check_mode=true
+fi
+
+# Check if credentials are available
+has_credentials() {
+    if [[ -n "${F5XC_API_TOKEN:-}" && -n "${F5XC_API_URL:-}" ]]; then
+        return 0
+    elif [[ -n "${F5XC_P12_FILE:-}" && -n "${F5XC_P12_PASSWORD:-}" && -n "${F5XC_API_URL:-}" ]]; then
+        return 0
+    fi
+    return 1
+}
+
+# Main logic
+main() {
+    echo "=== Subscription Tier Metadata Update ==="
+
+    # Check for credentials
+    if ! has_credentials; then
+        echo -e "${YELLOW}SKIP: F5XC credentials not configured${NC}"
+        echo "Set F5XC_API_URL and either F5XC_API_TOKEN or F5XC_P12_FILE+F5XC_P12_PASSWORD"
+        echo "to enable subscription tier metadata generation."
+        exit 0
+    fi
+
+    # Check if generator exists
+    if [[ ! -f "${GENERATOR}" ]]; then
+        echo -e "${RED}ERROR: Generator not found: ${GENERATOR}${NC}"
+        exit 1
+    fi
+
+    # Store current file hash (if exists)
+    old_hash=""
+    if [[ -f "${METADATA_FILE}" ]]; then
+        old_hash=$(md5sum "${METADATA_FILE}" 2>/dev/null | cut -d' ' -f1 || echo "")
+    fi
+
+    # Run the generator
+    echo "Running subscription metadata generator..."
+    cd "${REPO_ROOT}"
+
+    if ! go run "${GENERATOR}"; then
+        echo -e "${RED}ERROR: Generator failed${NC}"
+        exit 1
+    fi
+
+    # Check if file was created/updated
+    if [[ ! -f "${METADATA_FILE}" ]]; then
+        echo -e "${RED}ERROR: Generator did not create ${METADATA_FILE}${NC}"
+        exit 1
+    fi
+
+    # Compare hashes
+    new_hash=$(md5sum "${METADATA_FILE}" 2>/dev/null | cut -d' ' -f1 || echo "")
+
+    if [[ "${old_hash}" == "${new_hash}" ]]; then
+        echo -e "${GREEN}No changes detected in subscription tier metadata${NC}"
+        exit 0
+    else
+        if [[ "${check_mode}" == "true" ]]; then
+            echo -e "${YELLOW}Changes detected in subscription tier metadata!${NC}"
+            echo "Run: ./scripts/update-subscription-metadata.sh"
+            echo "Then commit the updated tools/subscription-tiers.json"
+            exit 1
+        else
+            echo -e "${GREEN}Updated subscription tier metadata${NC}"
+            echo "Changes detected - please commit tools/subscription-tiers.json"
+
+            # Show summary of changes
+            if command -v jq &> /dev/null; then
+                echo ""
+                echo "Summary:"
+                services=$(jq '.services | length' "${METADATA_FILE}" 2>/dev/null || echo "?")
+                resources=$(jq '.resources | length' "${METADATA_FILE}" 2>/dev/null || echo "?")
+                advanced=$(jq '[.resources | to_entries[] | select(.value.minimum_tier == "ADVANCED")] | length' "${METADATA_FILE}" 2>/dev/null || echo "?")
+                echo "  Services: ${services}"
+                echo "  Resources: ${resources}"
+                echo "  Advanced tier resources: ${advanced}"
+            fi
+            exit 0
+        fi
+    fi
+}
+
+main "$@"

--- a/tools/generate-subscription-metadata.go
+++ b/tools/generate-subscription-metadata.go
@@ -1,0 +1,446 @@
+//go:build ignore
+// +build ignore
+
+// This tool queries the F5 Distributed Cloud catalog API to generate
+// subscription tier metadata for resources. This metadata is used by
+// documentation generators and the MCP server to indicate which resources
+// require Advanced subscription tiers.
+//
+// Usage:
+//   F5XC_API_URL="https://..." F5XC_P12_FILE="..." F5XC_P12_PASSWORD="..." go run tools/generate-subscription-metadata.go
+//
+// Environment Variables:
+//   F5XC_API_URL      - F5 XC API URL (e.g., https://console.ves.volterra.io)
+//   F5XC_P12_FILE     - Path to P12 certificate file
+//   F5XC_P12_PASSWORD - Password for P12 file
+//   F5XC_API_TOKEN    - API token (alternative to P12 auth)
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/f5xc/terraform-provider-f5xc/internal/client"
+)
+
+// CatalogListRequest is the request body for the catalog API
+type CatalogListRequest struct {
+	// Empty request to get full catalog
+}
+
+// CatalogListResponse is the response from the catalog API
+type CatalogListResponse struct {
+	AddonServices map[string]AddonServiceInfo `json:"addon_services"`
+	Services      map[string]ServiceInfo      `json:"services"`
+	Workspaces    map[string]WorkspaceInfo    `json:"workspaces"`
+	UseCases      map[string]UseCaseInfo      `json:"use_cases"`
+}
+
+// AddonServiceInfo contains addon service details from catalog
+type AddonServiceInfo struct {
+	Tier                    string `json:"tier"`
+	DisplayName             string `json:"display_name"`
+	AddonServiceGroupName   string `json:"addon_service_group_name"`
+}
+
+// ServiceInfo contains service details from catalog
+type ServiceInfo struct {
+	Name                   string   `json:"name"`
+	DisplayName            string   `json:"display_name"`
+	Description            string   `json:"description"`
+	Tier                   string   `json:"tier"`
+	AccessStatus           string   `json:"access_status"`
+	AddonServiceStatus     string   `json:"addon_service_status"`
+	AddonServiceGroupStatus string   `json:"addon_service_group_status"`
+	Tags                   []string `json:"tags"`
+}
+
+// WorkspaceInfo contains workspace details from catalog
+type WorkspaceInfo struct {
+	Name             string   `json:"name"`
+	DisplayName      string   `json:"display_name"`
+	Services         []string `json:"services"`
+	RequiredServices []string `json:"required_services"`
+	OptionalServices []string `json:"optional_services"`
+}
+
+// UseCaseInfo contains use case details from catalog
+type UseCaseInfo struct {
+	Name        string   `json:"name"`
+	DisplayName string   `json:"display_name"`
+	Workspaces  []string `json:"workspaces"`
+	Order       int      `json:"order"`
+}
+
+// SubscriptionMetadata is the output format for subscription tier metadata
+type SubscriptionMetadata struct {
+	GeneratedAt string                       `json:"generated_at"`
+	Source      string                       `json:"source"`
+	Services    map[string]ServiceMetadata   `json:"services"`
+	Resources   map[string]ResourceMetadata  `json:"resources"`
+}
+
+// ServiceMetadata contains metadata about an addon service
+type ServiceMetadata struct {
+	Tier        string `json:"tier"`
+	DisplayName string `json:"display_name"`
+	GroupName   string `json:"group_name,omitempty"`
+}
+
+// ResourceMetadata contains subscription metadata for a Terraform resource
+type ResourceMetadata struct {
+	Service         string   `json:"service"`
+	MinimumTier     string   `json:"minimum_tier"`
+	AdvancedFeatures []string `json:"advanced_features,omitempty"`
+}
+
+// resourceServiceMapping maps OpenAPI schema path patterns to service groups
+// This is based on the F5 XC API structure where resources are organized by service
+var resourceServiceMapping = map[string]string{
+	// WAAP (Web App & API Protection)
+	"views.http_loadbalancer":       "waap",
+	"views.tcp_loadbalancer":        "waap",
+	"views.udp_loadbalancer":        "waap",
+	"views.origin_pool":             "waap",
+	"app_firewall":                  "waap",
+	"waf":                           "waap",
+	"waf_exclusion_policy":          "waap",
+	"rate_limiter":                  "waap",
+	"views.rate_limiter_policy":     "waap",
+	"service_policy":                "waap",
+	"service_policy_rule":           "waap",
+	"service_policy_set":            "waap",
+	"malicious_user_mitigation":     "waap",
+	"user_identification":           "waap",
+	"views.api_definition":          "waap",
+	"api_sec.api_discovery":         "waap",
+	"api_sec.api_crawler":           "waap",
+	"api_sec.api_testing":           "waap",
+
+	// Bot Defense (part of WAAP Advanced)
+	"shape.bot_defense":                        "waap_advanced",
+	"shape.bot_defense.protected_application":  "waap_advanced",
+	"shape.bot_defense.bot_endpoint_policy":    "waap_advanced",
+	"shape.bot_defense.bot_infrastructure":     "waap_advanced",
+	"shape.bot_defense.bot_allowlist_policy":   "waap_advanced",
+	"shape.bot_defense.bot_network_policy":     "waap_advanced",
+	"shape.bot_defense.mobile_sdk":             "waap_advanced",
+	"shape.bot_defense.mobile_base_config":     "waap_advanced",
+	"shape_bot_defense_instance":               "waap_advanced",
+
+	// CDN (Content Delivery Network)
+	"views.cdn_loadbalancer":        "cdn",
+	"cdn_cache_rule":                "cdn",
+
+	// SecureMesh / Site Management
+	"views.securemesh_site":         "securemesh",
+	"views.securemesh_site_v2":      "securemesh",
+	"views.voltstack_site":          "securemesh",
+	"views.aws_vpc_site":            "site_management",
+	"views.azure_vnet_site":         "site_management",
+	"views.gcp_vpc_site":            "site_management",
+	"views.aws_tgw_site":            "site_management",
+
+	// Network Connect
+	"network_connector":             "network_connect",
+	"network_firewall":              "network_connect",
+	"network_policy":                "network_connect",
+	"network_policy_rule":           "network_connect",
+	"network_policy_set":            "network_connect",
+	"views.network_policy_view":     "network_connect",
+	"enhanced_firewall_policy":      "network_connect",
+	"fast_acl":                      "network_connect",
+	"fast_acl_rule":                 "network_connect",
+
+	// DNS Management
+	"dns_zone":                      "dns",
+	"dns_domain":                    "dns",
+	"dns_load_balancer":             "dns",
+	"dns_lb_health_check":           "dns",
+	"dns_lb_pool":                   "dns",
+
+	// App Stack
+	"k8s_cluster":                   "appstack",
+	"k8s_cluster_role":              "appstack",
+	"k8s_cluster_role_binding":      "appstack",
+	"k8s_pod_security_admission":    "appstack",
+	"k8s_pod_security_policy":       "appstack",
+	"virtual_k8s":                   "appstack",
+	"views.workload":                "appstack",
+
+	// Client Side Defense
+	"shape.client_side_defense":                "client_side_defense",
+	"shape.client_side_defense.allowed_domain": "client_side_defense",
+	"shape.client_side_defense.protected_domain": "client_side_defense",
+	"shape.client_side_defense.mitigated_domain": "client_side_defense",
+
+	// Observability / Synthetic Monitoring
+	"observability.synthetic_monitor":           "synthetic_monitoring",
+	"observability.synthetic_monitor.v1_dns_monitor": "synthetic_monitoring",
+	"observability.synthetic_monitor.v1_http_monitor": "synthetic_monitoring",
+
+	// Core/Common (no specific tier required)
+	"namespace":                     "core",
+	"healthcheck":                   "core",
+	"certificate":                   "core",
+	"certificate_chain":             "core",
+	"secret_policy":                 "core",
+	"secret_policy_rule":            "core",
+	"trusted_ca_list":               "core",
+	"virtual_site":                  "core",
+	"virtual_network":               "core",
+	"virtual_host":                  "core",
+	"cloud_credentials":             "core",
+	"discovery":                     "core",
+	"endpoint":                      "core",
+	"known_label":                   "core",
+	"known_label_key":               "core",
+	"ip_prefix_set":                 "core",
+	"bgp_asn_set":                   "core",
+	"geo_location_set":              "core",
+	"log_receiver":                  "core",
+	"global_log_receiver":           "core",
+	"alert_policy":                  "core",
+	"alert_receiver":                "core",
+}
+
+// serviceToTierMapping maps service groups to their tier requirements
+// This defines which features/resources require Advanced tier
+var serviceToTierMapping = map[string]string{
+	"waap":              "STANDARD",  // Basic WAAP is Standard
+	"waap_advanced":     "ADVANCED",  // Bot defense, API security is Advanced
+	"cdn":               "STANDARD",  // CDN has both Standard and Advanced
+	"securemesh":        "STANDARD",  // SecureMesh has both Standard and Advanced
+	"site_management":   "STANDARD",
+	"network_connect":   "STANDARD",
+	"dns":               "STANDARD",
+	"appstack":          "STANDARD",
+	"client_side_defense": "ADVANCED",  // CSD is part of advanced
+	"synthetic_monitoring": "STANDARD",
+	"core":              "NO_TIER",   // Core resources don't require specific tier
+}
+
+// advancedFeaturesList lists features that are only in Advanced tier
+var advancedFeaturesList = map[string][]string{
+	"http_loadbalancer": {"api_discovery", "bot_defense", "malicious_user_detection", "sensitive_data_policy"},
+	"app_firewall":      {"advanced_detection_settings", "ai_bot_defense"},
+	"cdn_loadbalancer":  {"advanced_caching", "edge_compute"},
+}
+
+func main() {
+	// Get credentials from environment
+	apiURL := os.Getenv("F5XC_API_URL")
+	p12File := os.Getenv("F5XC_P12_FILE")
+	p12Password := os.Getenv("F5XC_P12_PASSWORD")
+	apiToken := os.Getenv("F5XC_API_TOKEN")
+
+	if apiURL == "" {
+		fmt.Fprintln(os.Stderr, "Error: F5XC_API_URL environment variable is required")
+		os.Exit(1)
+	}
+
+	var apiClient *client.Client
+	var err error
+
+	// Try P12 authentication first, then fall back to token
+	if p12File != "" && p12Password != "" {
+		apiClient, err = client.NewClientWithP12(apiURL, p12File, p12Password)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error creating client with P12: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Println("Using P12 certificate authentication")
+	} else if apiToken != "" {
+		apiClient = client.NewClient(apiURL, apiToken)
+		fmt.Println("Using API token authentication")
+	} else {
+		fmt.Fprintln(os.Stderr, "Error: Either F5XC_P12_FILE+F5XC_P12_PASSWORD or F5XC_API_TOKEN is required")
+		os.Exit(1)
+	}
+
+	// Query the catalog API
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	var catalogResp CatalogListResponse
+	err = apiClient.Put(ctx, "/api/web/namespaces/system/catalogs", CatalogListRequest{}, &catalogResp)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error querying catalog API: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("Retrieved catalog with %d addon services, %d services, %d workspaces\n",
+		len(catalogResp.AddonServices), len(catalogResp.Services), len(catalogResp.Workspaces))
+
+	// Build subscription metadata
+	metadata := buildSubscriptionMetadata(catalogResp)
+
+	// Write output file
+	outputPath := "tools/subscription-tiers.json"
+
+	// Check if existing file has same content (ignoring timestamp)
+	// to avoid unnecessary changes during pre-commit hooks
+	if existingData, err := os.ReadFile(outputPath); err == nil {
+		var existingMeta SubscriptionMetadata
+		if json.Unmarshal(existingData, &existingMeta) == nil {
+			// Compare content without timestamps
+			existingMeta.GeneratedAt = ""
+			metadataCompare := metadata
+			metadataCompare.GeneratedAt = ""
+
+			existingJSON, _ := json.Marshal(existingMeta)
+			newJSON, _ := json.Marshal(metadataCompare)
+
+			if string(existingJSON) == string(newJSON) {
+				fmt.Printf("No changes detected in %s (keeping existing file)\n", outputPath)
+				fmt.Printf("Existing file has %d services and %d resources\n",
+					len(existingMeta.Services), len(existingMeta.Resources))
+				return
+			}
+		}
+	}
+
+	outputData, err := json.MarshalIndent(metadata, "", "  ")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error marshaling metadata: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Add trailing newline for POSIX compliance
+	outputData = append(outputData, '\n')
+
+	if err := os.WriteFile(outputPath, outputData, 0644); err != nil {
+		fmt.Fprintf(os.Stderr, "Error writing output file: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("Generated %s with %d services and %d resources\n",
+		outputPath, len(metadata.Services), len(metadata.Resources))
+}
+
+func buildSubscriptionMetadata(catalog CatalogListResponse) SubscriptionMetadata {
+	metadata := SubscriptionMetadata{
+		GeneratedAt: time.Now().UTC().Format(time.RFC3339),
+		Source:      "F5 XC Catalog API",
+		Services:    make(map[string]ServiceMetadata),
+		Resources:   make(map[string]ResourceMetadata),
+	}
+
+	// Extract service tier information from catalog
+	for name, svc := range catalog.AddonServices {
+		metadata.Services[name] = ServiceMetadata{
+			Tier:        svc.Tier,
+			DisplayName: svc.DisplayName,
+			GroupName:   svc.AddonServiceGroupName,
+		}
+	}
+
+	// Also extract from services if addon_services is empty
+	for name, svc := range catalog.Services {
+		if _, exists := metadata.Services[name]; !exists {
+			metadata.Services[name] = ServiceMetadata{
+				Tier:        svc.Tier,
+				DisplayName: svc.DisplayName,
+			}
+		}
+	}
+
+	// Map resources to services based on OpenAPI spec files
+	specDir := "docs/specifications/api"
+	files, err := filepath.Glob(filepath.Join(specDir, "*.json"))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: Could not scan OpenAPI specs: %v\n", err)
+		return metadata
+	}
+
+	// Pattern: docs-cloud-f5-com.XXXX.public.ves.io.schema.{path}.ves-swagger.json
+	specRegex := regexp.MustCompile(`docs-cloud-f5-com\.\d+\.public\.ves\.io\.schema\.(.+)\.ves-swagger\.json`)
+
+	for _, file := range files {
+		base := filepath.Base(file)
+		matches := specRegex.FindStringSubmatch(base)
+		if matches == nil || len(matches) < 2 {
+			continue
+		}
+
+		schemaPath := matches[1]
+		resourceName := getResourceName(schemaPath)
+
+		// Skip non-resource schemas
+		if shouldSkipSchema(schemaPath) {
+			continue
+		}
+
+		// Find matching service
+		service := findServiceForSchema(schemaPath)
+		tier := serviceToTierMapping[service]
+		if tier == "" {
+			tier = "STANDARD" // Default to standard if unknown
+		}
+
+		// Get advanced features if any
+		advFeatures := advancedFeaturesList[resourceName]
+
+		metadata.Resources[resourceName] = ResourceMetadata{
+			Service:         service,
+			MinimumTier:     tier,
+			AdvancedFeatures: advFeatures,
+		}
+	}
+
+	return metadata
+}
+
+// getResourceName extracts the resource name from a schema path
+func getResourceName(schemaPath string) string {
+	parts := strings.Split(schemaPath, ".")
+	return parts[len(parts)-1]
+}
+
+// findServiceForSchema finds the service group for a schema path
+func findServiceForSchema(schemaPath string) string {
+	// Try exact match first
+	if service, ok := resourceServiceMapping[schemaPath]; ok {
+		return service
+	}
+
+	// Try prefix matching for nested schemas
+	for pattern, service := range resourceServiceMapping {
+		if strings.HasPrefix(schemaPath, pattern) {
+			return service
+		}
+	}
+
+	// Default to core for unknown schemas
+	return "core"
+}
+
+// shouldSkipSchema returns true for schemas that shouldn't be mapped to resources
+func shouldSkipSchema(schemaPath string) bool {
+	skipPatterns := []string{
+		"operate.",      // Operational APIs, not resources
+		"graph.",        // Graph/visualization APIs
+		"usage.",        // Usage tracking
+		"billing.",      // Billing
+		"signup.",       // Signup flow
+		"pbac.",         // Permission-based access control internals
+		"tenant_management.", // Tenant management (MSP only)
+		"marketplace.",  // Marketplace
+		"user.setting",  // User settings
+		"ui.",           // UI components
+	}
+
+	for _, pattern := range skipPatterns {
+		if strings.Contains(schemaPath, pattern) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/tools/subscription-tiers.json
+++ b/tools/subscription-tiers.json
@@ -1,0 +1,1165 @@
+{
+  "generated_at": "2025-12-16T21:47:06Z",
+  "source": "F5 XC Catalog API",
+  "services": {
+    "client-side-defense": {
+      "tier": "NO_TIER",
+      "display_name": "Client-Side Defense"
+    },
+    "data-intelligence": {
+      "tier": "NO_TIER",
+      "display_name": "Data Intelligence"
+    },
+    "f5xc-ai-assistant": {
+      "tier": "NO_TIER",
+      "display_name": "AI Assistant"
+    },
+    "f5xc-ai-assistant-standard": {
+      "tier": "STANDARD",
+      "display_name": "F5XC AI Assistant Standard",
+      "group_name": "f5xc-ai-assistant"
+    },
+    "f5xc-application-traffic-insight": {
+      "tier": "NO_TIER",
+      "display_name": "Application Traffic Insight"
+    },
+    "f5xc-application-traffic-insight-standard": {
+      "tier": "NO_TIER",
+      "display_name": "Application Traffic Insight",
+      "group_name": "f5xc-application-traffic-insight"
+    },
+    "f5xc-appstack": {
+      "tier": "NO_TIER",
+      "display_name": "App Stack"
+    },
+    "f5xc-appstack-standard": {
+      "tier": "NO_TIER",
+      "display_name": "App Stack",
+      "group_name": "f5xc-appstack"
+    },
+    "f5xc-big-ip-irule": {
+      "tier": "NO_TIER",
+      "display_name": "iRules"
+    },
+    "f5xc-big-ip-irule-standard": {
+      "tier": "NO_TIER",
+      "display_name": "iRules",
+      "group_name": "f5xc-big-ip-irule"
+    },
+    "f5xc-bigip-utilities": {
+      "tier": "NO_TIER",
+      "display_name": "iHealth"
+    },
+    "f5xc-bigip-utilities-standard": {
+      "tier": "NO_TIER",
+      "display_name": "BIG-IP Utilities",
+      "group_name": "f5xc-bigip-utilities"
+    },
+    "f5xc-bot-defense": {
+      "tier": "NO_TIER",
+      "display_name": "Bot Defense"
+    },
+    "f5xc-bot-defense-advanced": {
+      "tier": "ADVANCED",
+      "display_name": "Bot Defense Advanced (coming soon)",
+      "group_name": "f5xc-bot-defense"
+    },
+    "f5xc-bot-defense-standard": {
+      "tier": "STANDARD",
+      "display_name": "Bot Defense Standard",
+      "group_name": "f5xc-bot-defense"
+    },
+    "f5xc-client-side-defense-standard": {
+      "tier": "NO_TIER",
+      "display_name": "Client-Side Defense (Preview)",
+      "group_name": "client-side-defense"
+    },
+    "f5xc-console-advanced": {
+      "tier": "ADVANCED",
+      "display_name": "F5XC Console Advanced",
+      "group_name": "f5xc-console-base"
+    },
+    "f5xc-console-base": {
+      "tier": "ADVANCED",
+      "display_name": "Console"
+    },
+    "f5xc-console-basic": {
+      "tier": "BASIC",
+      "display_name": "F5XC Console Basic",
+      "group_name": "f5xc-console-base"
+    },
+    "f5xc-console-standard": {
+      "tier": "STANDARD",
+      "display_name": "F5XC Console Standard",
+      "group_name": "f5xc-console-base"
+    },
+    "f5xc-content-delivery-network-standard": {
+      "tier": "STANDARD",
+      "display_name": "Content Delivery Network",
+      "group_name": "lilac-cdn"
+    },
+    "f5xc-core-platform-services": {
+      "tier": "ADVANCED",
+      "display_name": "Core Platform Services"
+    },
+    "f5xc-core-platform-services-advanced": {
+      "tier": "ADVANCED",
+      "display_name": "F5XC Core Platform Services Advanced",
+      "group_name": "f5xc-core-platform-services"
+    },
+    "f5xc-core-platform-services-standard": {
+      "tier": "STANDARD",
+      "display_name": "F5XC Core Platform Services Standard",
+      "group_name": "f5xc-core-platform-services"
+    },
+    "f5xc-data-intelligence-standard": {
+      "tier": "NO_TIER",
+      "display_name": "Data Intelligence",
+      "group_name": "data-intelligence"
+    },
+    "f5xc-delegated-access-standard": {
+      "tier": "NO_TIER",
+      "display_name": "Delegated Access",
+      "group_name": "ves-io-tenant-management"
+    },
+    "f5xc-dns": {
+      "tier": "NO_TIER",
+      "display_name": "DNS"
+    },
+    "f5xc-dns-standard": {
+      "tier": "NO_TIER",
+      "display_name": "DNS Management",
+      "group_name": "f5xc-dns"
+    },
+    "f5xc-malware-protection": {
+      "tier": "NO_TIER",
+      "display_name": "Malware Protection"
+    },
+    "f5xc-malware-protection-standard": {
+      "tier": "STANDARD",
+      "display_name": "Malware Protection",
+      "group_name": "f5xc-malware-protection"
+    },
+    "f5xc-mobile-app-shield": {
+      "tier": "NO_TIER",
+      "display_name": "Mobile App Shield"
+    },
+    "f5xc-mobile-app-shield-standard": {
+      "tier": "STANDARD",
+      "display_name": "Mobile App Shield",
+      "group_name": "f5xc-mobile-app-shield"
+    },
+    "f5xc-mobile-integrator": {
+      "tier": "NO_TIER",
+      "display_name": "Mobile Integrator"
+    },
+    "f5xc-mobile-integrator-standard": {
+      "tier": "STANDARD",
+      "display_name": "Mobile SDK Integrator",
+      "group_name": "f5xc-mobile-integrator"
+    },
+    "f5xc-nginx-one-standard": {
+      "tier": "STANDARD",
+      "display_name": "NGINX One Console",
+      "group_name": "nginx-one"
+    },
+    "f5xc-routed-ddos": {
+      "tier": "NO_TIER",
+      "display_name": "Routed DDoS"
+    },
+    "f5xc-routed-ddos-standard": {
+      "tier": "NO_TIER",
+      "display_name": "Routed DDoS",
+      "group_name": "f5xc-routed-ddos"
+    },
+    "f5xc-securemesh": {
+      "tier": "ADVANCED",
+      "display_name": "Secure Mesh"
+    },
+    "f5xc-securemesh-advanced": {
+      "tier": "ADVANCED",
+      "display_name": "Secure Mesh Advanced",
+      "group_name": "f5xc-securemesh"
+    },
+    "f5xc-securemesh-standard": {
+      "tier": "STANDARD",
+      "display_name": "Secure Mesh Standard",
+      "group_name": "f5xc-securemesh"
+    },
+    "f5xc-site-management": {
+      "tier": "NO_TIER",
+      "display_name": "Site Management"
+    },
+    "f5xc-site-management-standard": {
+      "tier": "NO_TIER",
+      "display_name": "Site Management Standard",
+      "group_name": "f5xc-site-management"
+    },
+    "f5xc-synthetic-monitoring-standard": {
+      "tier": "NO_TIER",
+      "display_name": "Synthetic Monitoring",
+      "group_name": "synthetic-monitor"
+    },
+    "f5xc-waap": {
+      "tier": "ADVANCED",
+      "display_name": "Web App \u0026 API Protection"
+    },
+    "f5xc-waap-advanced": {
+      "tier": "ADVANCED",
+      "display_name": "Web Application and API Protection (WAAP) Advanced",
+      "group_name": "f5xc-waap"
+    },
+    "f5xc-waap-standard": {
+      "tier": "STANDARD",
+      "display_name": "Web Application and API Protection (WAAP) Standard",
+      "group_name": "f5xc-waap"
+    },
+    "f5xc-web-app-scanning": {
+      "tier": "NO_TIER",
+      "display_name": "Web App Scanning"
+    },
+    "f5xc-web-app-scanning-standard": {
+      "tier": "STANDARD",
+      "display_name": "Web App Scanning Standard",
+      "group_name": "f5xc-web-app-scanning"
+    },
+    "lilac-cdn": {
+      "tier": "NO_TIER",
+      "display_name": "Content Delivery Network"
+    },
+    "nginx-one": {
+      "tier": "NO_TIER",
+      "display_name": "NGINX One Console"
+    },
+    "safeap": {
+      "tier": "NO_TIER",
+      "display_name": "Account Protection",
+      "group_name": "safeap"
+    },
+    "shape-recognize": {
+      "tier": "NO_TIER",
+      "display_name": "Authentication Intelligence",
+      "group_name": "shape-recognize"
+    },
+    "synthetic-monitor": {
+      "tier": "NO_TIER",
+      "display_name": "Synthetic Monitoring"
+    },
+    "ves-io-tenant-management": {
+      "tier": "NO_TIER",
+      "display_name": "Delegated Access"
+    }
+  },
+  "resources": {
+    "address_allocator": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "advertise_policy": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "ai_assistant": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "alert": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "alert_gen_policy": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "alert_policy": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "alert_receiver": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "alert_template": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "allowed_domain": {
+      "service": "client_side_defense",
+      "minimum_tier": "ADVANCED"
+    },
+    "api_crawler": {
+      "service": "waap",
+      "minimum_tier": "STANDARD"
+    },
+    "api_credential": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "api_definition": {
+      "service": "waap",
+      "minimum_tier": "STANDARD"
+    },
+    "api_discovery": {
+      "service": "waap",
+      "minimum_tier": "STANDARD"
+    },
+    "api_group": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "api_group_element": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "api_testing": {
+      "service": "waap",
+      "minimum_tier": "STANDARD"
+    },
+    "apm": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "app_api_group": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "app_firewall": {
+      "service": "waap",
+      "minimum_tier": "STANDARD",
+      "advanced_features": [
+        "advanced_detection_settings",
+        "ai_bot_defense"
+      ]
+    },
+    "app_security": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "app_setting": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "app_type": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "authentication": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "aws_tgw_site": {
+      "service": "site_management",
+      "minimum_tier": "STANDARD"
+    },
+    "aws_vpc_site": {
+      "service": "site_management",
+      "minimum_tier": "STANDARD"
+    },
+    "azure_vnet_site": {
+      "service": "site_management",
+      "minimum_tier": "STANDARD"
+    },
+    "bfdp": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "bgp": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "bgp_asn_set": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "bgp_routing_policy": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "bigip_irule": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "bigip_virtual_server": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "bot_allowlist_policy": {
+      "service": "waap_advanced",
+      "minimum_tier": "ADVANCED"
+    },
+    "bot_defense_app_infrastructure": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "bot_detection_rule": {
+      "service": "waap_advanced",
+      "minimum_tier": "ADVANCED"
+    },
+    "bot_detection_update": {
+      "service": "waap_advanced",
+      "minimum_tier": "ADVANCED"
+    },
+    "bot_endpoint_policy": {
+      "service": "waap_advanced",
+      "minimum_tier": "ADVANCED"
+    },
+    "bot_infrastructure": {
+      "service": "waap_advanced",
+      "minimum_tier": "ADVANCED"
+    },
+    "bot_network_policy": {
+      "service": "waap_advanced",
+      "minimum_tier": "ADVANCED"
+    },
+    "cdn_cache_rule": {
+      "service": "cdn",
+      "minimum_tier": "STANDARD"
+    },
+    "cdn_loadbalancer": {
+      "service": "cdn",
+      "minimum_tier": "STANDARD",
+      "advanced_features": [
+        "advanced_caching",
+        "edge_compute"
+      ]
+    },
+    "certificate": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "certificate_chain": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "certified_hardware": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "client_side_defense": {
+      "service": "client_side_defense",
+      "minimum_tier": "ADVANCED"
+    },
+    "cloud_connect": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "cloud_credentials": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "cloud_elastic_ip": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "cloud_link": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "cloud_region": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "cluster": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "cminstance": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "code_base_integration": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "contact": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "container_registry": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "crl": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "customer_support": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "data_delivery": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "data_group": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "data_type": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "dc_cluster_group": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "device_id": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "discovered_service": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "discovery": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "dns_compliance_checks": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "dns_domain": {
+      "service": "dns",
+      "minimum_tier": "STANDARD"
+    },
+    "dns_lb_health_check": {
+      "service": "dns",
+      "minimum_tier": "STANDARD"
+    },
+    "dns_lb_pool": {
+      "service": "dns",
+      "minimum_tier": "STANDARD"
+    },
+    "dns_load_balancer": {
+      "service": "dns",
+      "minimum_tier": "STANDARD"
+    },
+    "dns_zone": {
+      "service": "dns",
+      "minimum_tier": "STANDARD"
+    },
+    "endpoint": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "enhanced_firewall_policy": {
+      "service": "network_connect",
+      "minimum_tier": "STANDARD"
+    },
+    "external_connector": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "fast_acl": {
+      "service": "network_connect",
+      "minimum_tier": "STANDARD"
+    },
+    "fast_acl_rule": {
+      "service": "network_connect",
+      "minimum_tier": "STANDARD"
+    },
+    "filter_set": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "fleet": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "flow": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "flow_anomaly": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "forward_proxy_policy": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "forwarding_class": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "gcp_vpc_site": {
+      "service": "site_management",
+      "minimum_tier": "STANDARD"
+    },
+    "geo_config": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "geo_location_set": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "gia": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "global_log_receiver": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "healthcheck": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "http_loadbalancer": {
+      "service": "waap",
+      "minimum_tier": "STANDARD",
+      "advanced_features": [
+        "api_discovery",
+        "bot_defense",
+        "malicious_user_detection",
+        "sensitive_data_policy"
+      ]
+    },
+    "ike1": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "ike2": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "ike_phase1_profile": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "ike_phase2_profile": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "implicit_label": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "infraprotect": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "infraprotect_asn": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "infraprotect_asn_prefix": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "infraprotect_deny_list_rule": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "infraprotect_firewall_rule": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "infraprotect_firewall_rule_group": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "infraprotect_firewall_ruleset": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "infraprotect_information": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "infraprotect_internet_prefix_advertisement": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "infraprotect_tunnel": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "ip_prefix_set": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "irule": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "k8s_cluster": {
+      "service": "appstack",
+      "minimum_tier": "STANDARD"
+    },
+    "k8s_cluster_role": {
+      "service": "appstack",
+      "minimum_tier": "STANDARD"
+    },
+    "k8s_cluster_role_binding": {
+      "service": "appstack",
+      "minimum_tier": "STANDARD"
+    },
+    "k8s_pod_security_admission": {
+      "service": "appstack",
+      "minimum_tier": "STANDARD"
+    },
+    "k8s_pod_security_policy": {
+      "service": "appstack",
+      "minimum_tier": "STANDARD"
+    },
+    "known_label": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "known_label_key": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "lma_region": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "log": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "log_receiver": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "maintenance_status": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "malicious_user_mitigation": {
+      "service": "waap",
+      "minimum_tier": "STANDARD"
+    },
+    "mitigated_domain": {
+      "service": "client_side_defense",
+      "minimum_tier": "ADVANCED"
+    },
+    "mobile_base_config": {
+      "service": "waap_advanced",
+      "minimum_tier": "ADVANCED"
+    },
+    "mobile_sdk": {
+      "service": "waap_advanced",
+      "minimum_tier": "ADVANCED"
+    },
+    "module_management": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "namespace": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "namespace_role": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "nat_policy": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "network_connector": {
+      "service": "network_connect",
+      "minimum_tier": "STANDARD"
+    },
+    "network_firewall": {
+      "service": "network_connect",
+      "minimum_tier": "STANDARD"
+    },
+    "network_interface": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "network_policy": {
+      "service": "network_connect",
+      "minimum_tier": "STANDARD"
+    },
+    "network_policy_rule": {
+      "service": "network_connect",
+      "minimum_tier": "STANDARD"
+    },
+    "network_policy_set": {
+      "service": "network_connect",
+      "minimum_tier": "STANDARD"
+    },
+    "network_policy_view": {
+      "service": "network_connect",
+      "minimum_tier": "STANDARD"
+    },
+    "nfv_service": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "nginx_csg": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "nginx_instance": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "nginx_server": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "nginx_service_discovery": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "oidc_provider": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "origin_pool": {
+      "service": "waap",
+      "minimum_tier": "STANDARD"
+    },
+    "policer": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "policy_based_routing": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "protected_application": {
+      "service": "waap_advanced",
+      "minimum_tier": "ADVANCED"
+    },
+    "protected_domain": {
+      "service": "client_side_defense",
+      "minimum_tier": "ADVANCED"
+    },
+    "protocol_inspection": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "protocol_policer": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "proxy": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "public_ip": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "quota": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "rate_limiter": {
+      "service": "waap",
+      "minimum_tier": "STANDARD"
+    },
+    "rate_limiter_policy": {
+      "service": "waap",
+      "minimum_tier": "STANDARD"
+    },
+    "rbac_policy": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "receiver": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "recognize": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "registration": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "report": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "report_config": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "reporting": {
+      "service": "waap_advanced",
+      "minimum_tier": "ADVANCED"
+    },
+    "role": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "route": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "rrset": {
+      "service": "dns",
+      "minimum_tier": "STANDARD"
+    },
+    "rule_suggestion": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "safe": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "safeap": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "scim": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "secret_management": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "secret_management_access": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "secret_policy": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "secret_policy_rule": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "securemesh_site": {
+      "service": "securemesh",
+      "minimum_tier": "STANDARD"
+    },
+    "securemesh_site_v2": {
+      "service": "securemesh",
+      "minimum_tier": "STANDARD"
+    },
+    "segment": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "segment_connection": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "sensitive_data_policy": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "service_policy": {
+      "service": "waap",
+      "minimum_tier": "STANDARD"
+    },
+    "service_policy_rule": {
+      "service": "waap",
+      "minimum_tier": "STANDARD"
+    },
+    "service_policy_set": {
+      "service": "waap",
+      "minimum_tier": "STANDARD"
+    },
+    "shape_bot_defense_instance": {
+      "service": "waap_advanced",
+      "minimum_tier": "ADVANCED"
+    },
+    "signup": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "site": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "site_mesh_group": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "srv6_network_slice": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "status_at_site": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "stored_object": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "subnet": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "subscription": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "synthetic_monitor": {
+      "service": "synthetic_monitoring",
+      "minimum_tier": "STANDARD"
+    },
+    "tcp_loadbalancer": {
+      "service": "waap",
+      "minimum_tier": "STANDARD"
+    },
+    "tenant": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "tenant_configuration": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "tenant_management": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "terraform_parameters": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "third_party_application": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "ticket_tracking_system": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "token": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "topology": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "tpm_api_key": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "tpm_category": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "tpm_manager": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "tpm_provision": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "trusted_ca_list": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "tunnel": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "udp_loadbalancer": {
+      "service": "waap",
+      "minimum_tier": "STANDARD"
+    },
+    "upgrade_status": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "usage": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "usb_policy": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "user": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "user_group": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "user_identification": {
+      "service": "waap",
+      "minimum_tier": "STANDARD"
+    },
+    "user_token": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "v1_dns_monitor": {
+      "service": "synthetic_monitoring",
+      "minimum_tier": "STANDARD"
+    },
+    "v1_http_monitor": {
+      "service": "synthetic_monitoring",
+      "minimum_tier": "STANDARD"
+    },
+    "view_internal": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "virtual_appliance": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "virtual_host": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "virtual_k8s": {
+      "service": "appstack",
+      "minimum_tier": "STANDARD"
+    },
+    "virtual_network": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "virtual_site": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "voltshare": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "voltshare_admin_policy": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    },
+    "voltstack_site": {
+      "service": "securemesh",
+      "minimum_tier": "STANDARD"
+    },
+    "waf": {
+      "service": "waap",
+      "minimum_tier": "STANDARD"
+    },
+    "waf_exclusion_policy": {
+      "service": "waap",
+      "minimum_tier": "STANDARD"
+    },
+    "waf_signatures_changelog": {
+      "service": "waap",
+      "minimum_tier": "STANDARD"
+    },
+    "workload": {
+      "service": "appstack",
+      "minimum_tier": "STANDARD"
+    },
+    "workload_flavor": {
+      "service": "core",
+      "minimum_tier": "NO_TIER"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Implements dynamic subscription tier information extraction from F5 XC catalog API and integrates it into:
1. Terraform provider documentation (adds callout notes for resources requiring Advanced subscription)
2. MCP server (new tool to query subscription requirements)

## Related Issue

Closes #492

## Changes Made

### New Files
- `tools/generate-subscription-metadata.go` - Queries F5 XC catalog API and generates metadata
- `tools/subscription-tiers.json` - Generated metadata file (54 services, 224 resources)
- `scripts/update-subscription-metadata.sh` - Helper script for metadata regeneration

### Modified Files
- `tools/transform-docs.go` - Injects subscription notes into docs during generation
- `mcp-server/src/types.ts` - Added SubscriptionTier types
- `mcp-server/src/services/documentation.ts` - Added metadata loading and enrichment
- `mcp-server/src/schemas/index.ts` - Added GetSubscriptionInfoSchema
- `mcp-server/src/index.ts` - Added `f5xc_terraform_get_subscription_info` tool
- `mcp-server/scripts/copy-docs.js` - Auto-copies subscription-tiers.json to dist/
- `.pre-commit-config.yaml` - Added hook for metadata generation

## Testing

- [x] Pre-commit hooks pass
- [x] E2E tests pass for MCP subscription info tool
- [x] Generator correctly detects no-op scenarios (avoids unnecessary file changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)