### PR TITLE
feat(mcp-server): add property-level subscription tier indicators

### DIFF
--- a/mcp-server/src/schemas/index.ts
+++ b/mcp-server/src/schemas/index.ts
@@ -143,6 +143,17 @@ export const GetSubscriptionInfoSchema = z.object({
   response_format: ResponseFormatSchema,
 }).strict();
 
+// Get property subscription info schema
+export const GetPropertySubscriptionInfoSchema = z.object({
+  resource: z.string()
+    .min(1, 'Resource name is required')
+    .describe('Resource name (e.g., "http_loadbalancer", "app_firewall")'),
+  property: z.string()
+    .optional()
+    .describe('Property name to check (e.g., "enable_malicious_user_detection"). If omitted, returns all advanced features for the resource.'),
+  response_format: ResponseFormatSchema,
+}).strict();
+
 // Export type inference helpers
 export type SearchDocsInput = z.infer<typeof SearchDocsSchema>;
 export type GetDocInput = z.infer<typeof GetDocSchema>;
@@ -154,3 +165,4 @@ export type GetSchemaDefInput = z.infer<typeof GetSchemaDefSchema>;
 export type ListDefinitionsInput = z.infer<typeof ListDefinitionsSchema>;
 export type GetSummaryInput = z.infer<typeof GetSummarySchema>;
 export type GetSubscriptionInfoInput = z.infer<typeof GetSubscriptionInfoSchema>;
+export type GetPropertySubscriptionInfoInput = z.infer<typeof GetPropertySubscriptionInfoSchema>;


### PR DESCRIPTION
## Summary

Add a new MCP tool `f5xc_terraform_get_property_subscription_info` that allows LLMs to query whether a specific property within a resource requires an Advanced subscription tier.

This complements the documentation-based property tier indicators from PR #496 by making the same information programmatically accessible via the MCP server.

## Related Issue

Closes #498

## Changes Made

### New MCP Tool
- `f5xc_terraform_get_property_subscription_info` - Query property-level subscription requirements

### New Functions in `documentation.ts`
- `matchesAdvancedFeature(propertyName, featureName)` - Pattern matching for property-to-feature mapping
- `isAdvancedFeatureProperty(resourceName, propertyName)` - Check if property requires Advanced tier
- `getPropertySubscriptionInfo(resourceName, propertyName)` - Get full subscription info for a property
- `getResourceAdvancedProperties(resourceName)` - List all advanced features for a resource

### Pattern Matching
Supports common naming patterns:
- Exact match: `malicious_user_detection`
- Prefix patterns: `enable_*`, `disable_*`, `default_*`
- Suffix patterns: `*_settings`, `*_policy`, `*_config`, `*_advanced`, `*_configuration`
- Substring matching: Property contains feature name

## Example Usage

```json
// Query specific property
{
  "resource": "http_loadbalancer",
  "property": "enable_malicious_user_detection"
}
// Returns: { "requires_advanced": true, "matched_feature": "malicious_user_detection" }

// Query all advanced features for a resource
{
  "resource": "http_loadbalancer"
}
// Returns: { "advanced_features": ["api_discovery", "bot_defense", "malicious_user_detection", "sensitive_data_policy"] }
```

## Testing

- [x] Build succeeds (`npm run build`)
- [x] Manual testing with MCP server
- [x] Verified pattern matching works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)