### PR TITLE
feat(mcp): enhance VSCode installation with MCPB package and improved docs

### DIFF
--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -145,14 +145,22 @@ jobs:
         run: |
           cd mcp-server
           VERSION="${{ needs.build-mcpb.outputs.version }}"
+          SHA256="${{ needs.build-mcpb.outputs.sha256 }}"
+          MCPB_URL="https://github.com/robinmordasiewicz/terraform-provider-f5xc/releases/download/v${VERSION}/f5xc-terraform-mcp-${VERSION}.mcpb"
 
-          # Update version in server.json
+          # Update version in server.json (both npm and mcpb packages)
           node -e "
           const fs = require('fs');
           const serverJson = JSON.parse(fs.readFileSync('server.json', 'utf8'));
           serverJson.version = '$VERSION';
           if (serverJson.packages) {
-            serverJson.packages.forEach(p => p.version = '$VERSION');
+            serverJson.packages.forEach(p => {
+              p.version = '$VERSION';
+              if (p.registryType === 'mcpb') {
+                p.identifier = '$MCPB_URL';
+                p.file_sha256 = '$SHA256';
+              }
+            });
           }
           fs.writeFileSync('server.json', JSON.stringify(serverJson, null, 2) + '\n');
           "

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -16,20 +16,31 @@ Choose the installation method that best fits your environment:
 
 | Method | Best For | Requirements |
 |--------|----------|--------------|
-| [VSCode MCP Gallery](#vscode-mcp-gallery) | VSCode users with Node.js | VSCode 1.99+, Node.js |
+| [VSCode MCP Gallery](#vscode-mcp-gallery) | VSCode users (easiest) | VSCode 1.99+ |
 | [npx (Recommended)](#from-npm) | Developers with Node.js | Node.js 18+ |
-| [MCPB Bundle](#mcpb-bundle-no-nodejs-required) | Corporate laptops | None |
+| [MCPB Bundle](#mcpb-bundle-no-nodejs-required) | Corporate laptops (no Node.js) | None |
 | [From Source](#from-source) | Contributors | Node.js 18+, npm |
 
 ### VSCode MCP Gallery
 
-The easiest way to install if you're using VSCode with GitHub Copilot:
+The easiest way to install for VSCode users. Choose from multiple options:
+
+**Option A: MCP Gallery Search (Recommended for VSCode 1.105+)**
+
+1. Open VSCode
+2. Open the Extensions view (`Ctrl+Shift+X` / `Cmd+Shift+X`)
+3. Type `@MCP` in the search box to filter MCP servers
+4. Search for `f5xc` or `F5 Distributed Cloud`
+5. Click **Install**
+
+**Option B: Command Palette**
 
 1. Open VSCode
 2. Press `Ctrl+Shift+P` / `Cmd+Shift+P` to open Command Palette
 3. Run `MCP: Add Server`
-4. Search for `f5xc` or `@robinmordasiewicz/f5xc-terraform-mcp`
-5. Click Install
+4. Select `npm package`
+5. Enter: `@robinmordasiewicz/f5xc-terraform-mcp`
+6. Choose scope: **Global** (all workspaces) or **Workspace** (this project only)
 
 ### From npm
 
@@ -45,13 +56,25 @@ npx @robinmordasiewicz/f5xc-terraform-mcp
 
 ### MCPB Bundle (No Node.js Required)
 
-For corporate environments where Node.js cannot be installed:
+For corporate environments where Node.js cannot be installed. The MCPB bundle is fully self-contained with all dependencies included.
+
+**For VSCode:**
 
 1. Download the latest `.mcpb` file from [GitHub Releases](https://github.com/robinmordasiewicz/terraform-provider-f5xc/releases)
-2. Double-click the file to install, or drag it into Claude Desktop / VSCode
-3. The bundle includes everything needed - no external dependencies
+2. In VSCode, press `Ctrl+Shift+P` / `Cmd+Shift+P`
+3. Run `MCP: Add Server`
+4. Drag and drop the `.mcpb` file, or select it when prompted
+5. Run `MCP: List Servers` to verify installation
+
+**For Claude Desktop:**
+
+1. Download the latest `.mcpb` file from [GitHub Releases](https://github.com/robinmordasiewicz/terraform-provider-f5xc/releases)
+2. Double-click the file to install, or drag it into Claude Desktop
+3. Restart Claude Desktop to activate
 
 **File**: `f5xc-terraform-mcp-X.Y.Z.mcpb`
+
+-> **Note:** MCPB bundles are automatically built and attached to each GitHub Release. No npm or Node.js installation is required.
 
 ### From Source
 
@@ -173,6 +196,18 @@ To make the MCP server available across all workspaces, add to your VS Code user
   }
 }
 ```
+
+**Verify VSCode Installation:**
+
+1. Press `Ctrl+Shift+P` / `Cmd+Shift+P`
+2. Run `MCP: List Servers`
+3. Look for `f5xc-terraform` with a green status indicator
+
+**Troubleshooting VSCode:**
+
+- **Server not appearing**: Restart VSCode after adding the server configuration
+- **Connection issues**: Check the Output panel (`View > Output`) and select "MCP" from the dropdown
+- **Node.js not found**: Use the [MCPB Bundle](#mcpb-bundle-no-nodejs-required) method instead
 
 ## Available Tools
 

--- a/mcp-server/server.json
+++ b/mcp-server/server.json
@@ -13,6 +13,15 @@
         "type": "stdio"
       },
       "runtimeHint": "npx"
+    },
+    {
+      "registryType": "mcpb",
+      "identifier": "https://github.com/robinmordasiewicz/terraform-provider-f5xc/releases/download/v2.4.3/f5xc-terraform-mcp-2.4.3.mcpb",
+      "version": "2.4.3",
+      "transport": {
+        "type": "stdio"
+      },
+      "file_sha256": "pending"
     }
   ],
   "repository": {

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -198,7 +198,26 @@ You should see `f5xc-terraform` listed with a `✓ Connected` status.
 
 ### Quick Setup for Visual Studio Code
 
-VS Code 1.99+ supports MCP servers through GitHub Copilot. Create a `.vscode/mcp.json` file in your workspace:
+VS Code 1.99+ supports MCP servers through GitHub Copilot. Choose the installation method that best fits your environment:
+
+#### Option 1: VSCode MCP Gallery (Easiest)
+
+1. Open the Extensions view (`Ctrl+Shift+X` / `Cmd+Shift+X`)
+2. Type `@MCP` in the search box to filter MCP servers
+3. Search for `f5xc` or `F5 Distributed Cloud`
+4. Click **Install**
+
+#### Option 2: Command Palette
+
+1. Press `Ctrl+Shift+P` / `Cmd+Shift+P`
+2. Run `MCP: Add Server`
+3. Select `npm package`
+4. Enter: `@robinmordasiewicz/f5xc-terraform-mcp`
+5. Choose scope: **Global** (all workspaces) or **Workspace** (this project)
+
+#### Option 3: Workspace Configuration
+
+Create a `.vscode/mcp.json` file in your workspace:
 
 ```json
 {
@@ -211,7 +230,20 @@ VS Code 1.99+ supports MCP servers through GitHub Copilot. Create a `.vscode/mcp
 }
 ```
 
-Or use the Command Palette (`Ctrl+Shift+P` / `Cmd+Shift+P`) and run `MCP: Add Server`, then select `npm package` and enter `@robinmordasiewicz/f5xc-terraform-mcp`.
+#### Option 4: Corporate Environments (No Node.js Required)
+
+For environments where npm/Node.js cannot be installed:
+
+1. Download the latest `.mcpb` bundle from [GitHub Releases](https://github.com/robinmordasiewicz/terraform-provider-f5xc/releases)
+2. In VSCode, press `Ctrl+Shift+P` / `Cmd+Shift+P`
+3. Run `MCP: Add Server`
+4. Drag and drop the `.mcpb` file, or select it when prompted
+
+#### Verify Installation
+
+1. Press `Ctrl+Shift+P` / `Cmd+Shift+P`
+2. Run `MCP: List Servers`
+3. Look for `f5xc-terraform` with a green status indicator
 
 For complete MCP server documentation including all available tools and advanced configuration options, see the [NPM package page](https://www.npmjs.com/package/@robinmordasiewicz/f5xc-terraform-mcp).
 


### PR DESCRIPTION
## Summary

Streamline MCP server installation for VSCode users, including those on corporate laptops who cannot install Node.js dependencies.

## Changes Made

1. **Add MCPB package to server.json** - Added second package entry for MCPB bundles so the MCP Registry can show both npm and MCPB installation options

2. **Update publish-mcp-registry.yml** - Modified workflow to automatically populate MCPB download URL and SHA256 hash on each release

3. **Enhance provider documentation** (`templates/index.md.tmpl`) - Added four VSCode installation options:
   - VSCode MCP Gallery (search `@MCP` in Extensions)
   - Command Palette method
   - Workspace configuration (`.vscode/mcp.json`)
   - MCPB bundle for corporate environments (no Node.js)

4. **Enhance mcp-server/README.md** - More detailed VSCode instructions with verification and troubleshooting guidance

## Related Issue

Closes #508

## Testing

- [x] Pre-commit hooks pass
- [x] Markdown linting passes
- [ ] VSCode MCP Gallery installation (requires manual testing)
- [ ] MCPB bundle installation (requires manual testing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)