### PR TITLE
fix(mcp): enable MCP Registry publication via PR workflow

### DIFF
--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -182,18 +182,27 @@ jobs:
             echo "changed=true" >> $GITHUB_OUTPUT
           fi
 
-      - name: Commit and push
+      - name: Create Pull Request
         if: steps.check.outputs.changed == 'true'
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add mcp-server/server.json mcp-server/manifest.json
-          git commit -m "chore(mcp): update server.json and manifest.json to v${{ needs.build-mcpb.outputs.version }}"
-          git push
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.AUTO_MERGE_TOKEN }}
+          commit-message: "chore(mcp): update server.json to v${{ needs.build-mcpb.outputs.version }}"
+          branch: chore/mcp-server-json-${{ needs.build-mcpb.outputs.version }}
+          title: "chore(mcp): update server.json to v${{ needs.build-mcpb.outputs.version }}"
+          body: |
+            Automated update of server.json for MCP Registry publication.
+
+            **Version**: ${{ needs.build-mcpb.outputs.version }}
+            **SHA256**: `${{ needs.build-mcpb.outputs.sha256 }}`
+
+            This PR updates the server.json with the correct MCPB download URL and hash.
+          labels: automated,mcp
+          delete-branch: true
 
   publish-registry:
     name: Publish to MCP Registry
-    needs: [build-mcpb, update-server-json]
+    needs: [build-mcpb]
     runs-on: ubuntu-latest
     if: github.event_name == 'release'
     permissions:
@@ -232,7 +241,7 @@ jobs:
 
   summary:
     name: Summary
-    needs: [build-mcpb, update-server-json, publish-registry]
+    needs: [build-mcpb, upload-release-assets, update-server-json, publish-registry]
     runs-on: ubuntu-latest
     if: always()
 

--- a/mcp-server/manifest.json
+++ b/mcp-server/manifest.json
@@ -3,7 +3,7 @@
   "name": "f5xc-terraform-mcp",
   "displayName": "F5 Distributed Cloud Terraform Provider",
   "description": "MCP server providing AI assistants with access to F5 Distributed Cloud Terraform provider documentation, 270+ OpenAPI specifications, subscription tier information, and addon service activation workflows.",
-  "version": "2.4.3",
+  "version": "2.11.0",
   "author": {
     "name": "Robin Mordasiewicz",
     "url": "https://github.com/robinmordasiewicz"

--- a/mcp-server/server.json
+++ b/mcp-server/server.json
@@ -3,12 +3,12 @@
   "name": "io.github.robinmordasiewicz/f5xc-terraform-mcp",
   "title": "F5 Distributed Cloud Terraform Provider",
   "description": "MCP server providing AI assistants with access to F5 Distributed Cloud Terraform provider documentation, 270+ OpenAPI specifications, subscription tier information, and addon service activation workflows.",
-  "version": "2.4.3",
+  "version": "2.11.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@robinmordasiewicz/f5xc-terraform-mcp",
-      "version": "2.4.3",
+      "version": "2.11.0",
       "transport": {
         "type": "stdio"
       },
@@ -16,8 +16,8 @@
     },
     {
       "registryType": "mcpb",
-      "identifier": "https://github.com/robinmordasiewicz/terraform-provider-f5xc/releases/download/v2.4.3/f5xc-terraform-mcp-2.4.3.mcpb",
-      "version": "2.4.3",
+      "identifier": "https://github.com/robinmordasiewicz/terraform-provider-f5xc/releases/download/v2.11.0/f5xc-terraform-mcp-2.11.0.mcpb",
+      "version": "2.11.0",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Summary

Fixes the MCP server publication workflow to enable discovery in VSCode's `@MCP` search.

## Related Issue

Closes #511

## Problem

The `publish-mcp-registry.yml` workflow was failing because:
1. `update-server-json` job tried to push directly to `main` branch
2. Branch protection blocks direct pushes
3. `publish-registry` job depends on `update-server-json`, so it never ran
4. Server was never published to `registry.modelcontextprotocol.io`

## Changes Made

- Replace direct push with `peter-evans/create-pull-request@v6` action
- Remove `update-server-json` dependency from `publish-registry` job
- Update server.json and manifest.json versions to 2.11.0 (match npm)
- Add `upload-release-assets` to summary job dependencies

## How It Works Now

```
build-mcpb
    ├── upload-release-assets (if release)
    ├── update-server-json → Creates PR (doesn't block other jobs)
    └── publish-registry → Publishes to MCP Registry ✅
```

## Testing

After merge, trigger a new release to verify:
1. `publish-registry` job completes successfully
2. Server appears at `https://registry.modelcontextprotocol.io/v0/servers?search=f5xc`
3. VSCode `@MCP` search returns "f5xc" or "F5 Distributed Cloud"

🤖 Generated with [Claude Code](https://claude.com/claude-code)