### PR TITLE
fix(ci): add persist-credentials to MCP Registry workflow checkout

### DIFF
--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -591,6 +591,7 @@ jobs:
           ref: main
           fetch-depth: 0
           token: ${{ secrets.AUTO_MERGE_TOKEN }}
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -147,6 +147,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           token: ${{ secrets.AUTO_MERGE_TOKEN }}
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary

Fixes the "Duplicate header: Authorization" error in the Publish MCP Registry job by adding `persist-credentials: false` to checkout steps.

## Related Issue

Closes #516

## Changes Made

- Added `persist-credentials: false` to checkout step in `on-merge.yml` (publish-mcp-registry job)
- Added `persist-credentials: false` to checkout step in `publish-mcp-registry.yml` (update-server-json job)

## Root Cause

The `actions/checkout` with a `token` parameter persists git credentials. When `peter-evans/create-pull-request` then tries to configure its own authentication, a duplicate Authorization header is created, causing HTTP 400 errors.

## Testing

This fix follows the documented solution from peter-evans/create-pull-request for handling authentication with checkout tokens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)