### PR TITLE
docs(mcp): clarify MCPB bundle contains self-contained runtime

### DIFF
--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -74,7 +74,7 @@ For corporate environments where Node.js cannot be installed. The MCPB bundle is
 
 **File**: `f5xc-terraform-mcp-X.Y.Z.mcpb`
 
--> **Note:** MCPB bundles are automatically built and attached to each GitHub Release. No npm or Node.js installation is required.
+> **Note:** MCPB bundles are automatically built and attached to each GitHub Release. No npm or Node.js installation is required. The bundle includes a self-contained Node.js runtime.
 
 ### From Source
 


### PR DESCRIPTION
## Summary

Minor documentation improvement to clarify MCPB bundle installation.

## Related Issue

Closes #518

## Changes Made

- Fixed markdown blockquote syntax (`->` to `>`)
- Added clarification that MCPB bundle includes a self-contained Node.js runtime

## Additional Purpose

This PR will also validate that the MCP Registry publication workflow fix (#516, #517) works correctly in the automated CI/CD pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)