### PR TITLE
fix(mcp): migrate server.json to current MCP Registry schema

### DIFF
--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -662,7 +662,7 @@ jobs:
               p.version = '$VERSION';
               if (p.registryType === 'mcpb') {
                 p.identifier = '$MCPB_URL';
-                p.file_sha256 = '$SHA256';
+                p.fileSha256 = '$SHA256';
               }
             });
           }

--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -171,7 +171,7 @@ jobs:
               p.version = '$VERSION';
               if (p.registryType === 'mcpb') {
                 p.identifier = '$MCPB_URL';
-                p.file_sha256 = '$SHA256';
+                p.fileSha256 = '$SHA256';
               }
             });
           }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -91,10 +91,6 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
-      "path": "detect_secrets.filters.common.is_baseline_file",
-      "filename": ".secrets.baseline"
-    },
-    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -124,13 +120,6 @@
     },
     {
       "path": "detect_secrets.filters.heuristic.is_templated_secret"
-    },
-    {
-      "path": "detect_secrets.filters.regex.should_exclude_file",
-      "pattern": [
-        "go\\.sum",
-        "\\.terraform"
-      ]
     }
   ],
   "results": {
@@ -662,6 +651,15 @@
         "line_number": 3104
       }
     ],
+    "mcp-server/server.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "mcp-server/server.json",
+        "hashed_secret": "93f77dc7a17f606b34fd6d2e0d6cf435411dffd0",
+        "is_verified": false,
+        "line_number": 24
+      }
+    ],
     "templates/index.md.tmpl": [
       {
         "type": "Secret Keyword",
@@ -681,5 +679,5 @@
       }
     ]
   },
-  "generated_at": "2025-12-17T04:24:01Z"
+  "generated_at": "2025-12-17T14:33:33Z"
 }

--- a/mcp-server/server.json
+++ b/mcp-server/server.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-07-09/server.schema.json",
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "io.github.robinmordasiewicz/f5xc-terraform-mcp",
   "title": "F5 Distributed Cloud Terraform Provider",
   "description": "MCP server providing AI assistants with access to F5 Distributed Cloud Terraform provider documentation, 270+ OpenAPI specifications, subscription tier information, and addon service activation workflows.",
@@ -21,7 +21,7 @@
       "transport": {
         "type": "stdio"
       },
-      "file_sha256": "b812b3aad2c09426fb8135ab3dc959f8b27be67a35580f548fde9eaae50af82e"
+      "fileSha256": "b812b3aad2c09426fb8135ab3dc959f8b27be67a35580f548fde9eaae50af82e"
     }
   ],
   "repository": {


### PR DESCRIPTION
## Summary

Fixes the MCP Registry publication failure caused by deprecated schema format.

## Related Issue

Closes #521

## Changes Made

- Updated `$schema` from `2025-07-09` to `2025-09-29`
- Changed `file_sha256` to `fileSha256` (camelCase migration per MCP Registry requirements)
- Updated both `on-merge.yml` and `publish-mcp-registry.yml` workflows to use new field name
- Updated secrets baseline (SHA256 hash is a file integrity checksum, not a secret)

## Error Fixed

```
Error: deprecated schema detected: https://static.modelcontextprotocol.io/schemas/2025-07-09/server.schema.json.
```

## References

- [MCP Registry Schema CHANGELOG](https://github.com/modelcontextprotocol/registry/blob/main/docs/reference/server-json/CHANGELOG.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)