### PR TITLE
chore(mcp): update server.json to v2.12.4

### DIFF
--- a/mcp-server/manifest.json
+++ b/mcp-server/manifest.json
@@ -3,7 +3,7 @@
   "name": "f5xc-terraform-mcp",
   "displayName": "F5 Distributed Cloud Terraform Provider",
   "description": "MCP server providing AI assistants with access to F5 Distributed Cloud Terraform provider documentation, 270+ OpenAPI specifications, subscription tier information, and addon service activation workflows.",
-  "version": "2.12.1",
+  "version": "2.12.4",
   "author": {
     "name": "Robin Mordasiewicz",
     "url": "https://github.com/robinmordasiewicz"

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robinmordasiewicz/f5xc-terraform-mcp",
-  "version": "2.4.3",
+  "version": "2.12.4",
   "description": "MCP server for F5 Distributed Cloud Terraform provider - provides documentation and API specification access for AI assistants",
   "type": "module",
   "main": "dist/index.js",

--- a/mcp-server/server.json
+++ b/mcp-server/server.json
@@ -3,12 +3,12 @@
   "name": "io.github.robinmordasiewicz/f5xc-terraform-mcp",
   "title": "F5 Distributed Cloud Terraform Provider",
   "description": "MCP server providing AI assistants with access to F5 Distributed Cloud Terraform provider documentation, 270+ OpenAPI specifications, subscription tier information, and addon service activation workflows.",
-  "version": "2.12.1",
+  "version": "2.12.4",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@robinmordasiewicz/f5xc-terraform-mcp",
-      "version": "2.12.1",
+      "version": "2.12.4",
       "transport": {
         "type": "stdio"
       },
@@ -16,12 +16,12 @@
     },
     {
       "registryType": "mcpb",
-      "identifier": "https://github.com/robinmordasiewicz/terraform-provider-f5xc/releases/download/v2.12.1/f5xc-terraform-mcp-2.12.1.mcpb",
-      "version": "2.12.1",
+      "identifier": "https://github.com/robinmordasiewicz/terraform-provider-f5xc/releases/download/v2.12.4/f5xc-terraform-mcp-2.12.4.mcpb",
+      "version": "2.12.4",
       "transport": {
         "type": "stdio"
       },
-      "fileSha256": "b812b3aad2c09426fb8135ab3dc959f8b27be67a35580f548fde9eaae50af82e"
+      "fileSha256": "83433005131763e57780efe1a1fed27fb36cb9413cc485407710456a966b734d"
     }
   ],
   "repository": {


### PR DESCRIPTION
Automated update of server.json for MCP Registry publication.

**Version**: 2.12.4
**SHA256**: `83433005131763e57780efe1a1fed27fb36cb9413cc485407710456a966b734d`

This PR updates the server.json with the correct MCPB download URL and hash.