### PR TITLE
fix: resolve GoReleaser archives.format deprecation warning

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -40,7 +40,8 @@ builds:
     binary: '{{ .ProjectName }}_v{{ .Version }}'
 
 archives:
-  - format: zip
+  - formats:
+      - zip
     name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
 
 checksum:


### PR DESCRIPTION
## Summary

Updates `.goreleaser.yml` to use the new `formats` array syntax instead of the deprecated `format` string field.

## Related Issue

Closes #524

## Changes Made

- Changed `format: zip` to `formats: [zip]` per GoReleaser v2 deprecation notice

## Testing

- Pre-commit hooks pass
- Next release workflow will confirm deprecation warning is resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)