### PR TITLE
test: add unit tests for packages with no test files

### DIFF
--- a/internal/errors/errors_test.go
+++ b/internal/errors/errors_test.go
@@ -1,0 +1,469 @@
+// Copyright (c) F5XC Community
+// SPDX-License-Identifier: MPL-2.0
+
+package errors
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+)
+
+func TestF5XCErrorError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      *F5XCError
+		contains []string
+	}{
+		{
+			name: "basic error",
+			err: &F5XCError{
+				Code:    ErrCodeNotFound,
+				Message: "resource not found",
+			},
+			contains: []string{"NOT_FOUND", "resource not found"},
+		},
+		{
+			name: "error with resource",
+			err: &F5XCError{
+				Code:     ErrCodeNotFound,
+				Message:  "not found",
+				Resource: "namespace",
+			},
+			contains: []string{"resource: namespace"},
+		},
+		{
+			name: "error with operation",
+			err: &F5XCError{
+				Code:      ErrCodeTimeout,
+				Message:   "timeout",
+				Operation: "create",
+			},
+			contains: []string{"operation: create"},
+		},
+		{
+			name: "error with status code",
+			err: &F5XCError{
+				Code:       ErrCodeServerError,
+				Message:    "server error",
+				StatusCode: 500,
+			},
+			contains: []string{"status: 500"},
+		},
+		{
+			name: "error with wrapped error",
+			err: &F5XCError{
+				Code:    ErrCodeNetworkError,
+				Message: "network error",
+				Wrapped: errors.New("connection refused"),
+			},
+			contains: []string{"connection refused"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errStr := tt.err.Error()
+			for _, s := range tt.contains {
+				if !strings.Contains(errStr, s) {
+					t.Errorf("Error() = %q, expected to contain %q", errStr, s)
+				}
+			}
+		})
+	}
+}
+
+func TestF5XCErrorUnwrap(t *testing.T) {
+	innerErr := errors.New("inner error")
+	err := &F5XCError{
+		Code:    ErrCodeServerError,
+		Message: "outer error",
+		Wrapped: innerErr,
+	}
+
+	unwrapped := err.Unwrap()
+	if unwrapped != innerErr {
+		t.Errorf("Unwrap() = %v, expected %v", unwrapped, innerErr)
+	}
+
+	// Test with nil wrapped
+	errNoWrap := &F5XCError{
+		Code:    ErrCodeNotFound,
+		Message: "no wrap",
+	}
+	if errNoWrap.Unwrap() != nil {
+		t.Error("Unwrap() should return nil when no wrapped error")
+	}
+}
+
+func TestF5XCErrorIsRetryable(t *testing.T) {
+	tests := []struct {
+		code     ErrorCode
+		expected bool
+	}{
+		{ErrCodeRateLimit, true},
+		{ErrCodeTimeout, true},
+		{ErrCodeNetworkError, true},
+		{ErrCodeServerError, true},
+		{ErrCodeNotFound, false},
+		{ErrCodeUnauthorized, false},
+		{ErrCodeForbidden, false},
+		{ErrCodeConflict, false},
+		{ErrCodeBadRequest, false},
+		{ErrCodeValidation, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.code), func(t *testing.T) {
+			err := &F5XCError{Code: tt.code}
+			if err.IsRetryable() != tt.expected {
+				t.Errorf("IsRetryable() for %s = %v, expected %v", tt.code, err.IsRetryable(), tt.expected)
+			}
+		})
+	}
+}
+
+func TestF5XCErrorIsNotFound(t *testing.T) {
+	tests := []struct {
+		code     ErrorCode
+		expected bool
+	}{
+		{ErrCodeNotFound, true},
+		{ErrCodeUnauthorized, false},
+		{ErrCodeServerError, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.code), func(t *testing.T) {
+			err := &F5XCError{Code: tt.code}
+			if err.IsNotFound() != tt.expected {
+				t.Errorf("IsNotFound() for %s = %v, expected %v", tt.code, err.IsNotFound(), tt.expected)
+			}
+		})
+	}
+}
+
+func TestNewAPIError(t *testing.T) {
+	tests := []struct {
+		name         string
+		statusCode   int
+		body         []byte
+		resource     string
+		operation    string
+		expectedCode ErrorCode
+	}{
+		{
+			name:         "not found",
+			statusCode:   http.StatusNotFound,
+			body:         nil,
+			resource:     "namespace",
+			operation:    "read",
+			expectedCode: ErrCodeNotFound,
+		},
+		{
+			name:         "unauthorized",
+			statusCode:   http.StatusUnauthorized,
+			body:         nil,
+			resource:     "namespace",
+			operation:    "create",
+			expectedCode: ErrCodeUnauthorized,
+		},
+		{
+			name:         "forbidden",
+			statusCode:   http.StatusForbidden,
+			body:         nil,
+			resource:     "namespace",
+			operation:    "delete",
+			expectedCode: ErrCodeForbidden,
+		},
+		{
+			name:         "conflict",
+			statusCode:   http.StatusConflict,
+			body:         nil,
+			resource:     "namespace",
+			operation:    "create",
+			expectedCode: ErrCodeConflict,
+		},
+		{
+			name:         "rate limit",
+			statusCode:   http.StatusTooManyRequests,
+			body:         nil,
+			resource:     "namespace",
+			operation:    "list",
+			expectedCode: ErrCodeRateLimit,
+		},
+		{
+			name:         "bad request",
+			statusCode:   http.StatusBadRequest,
+			body:         nil,
+			resource:     "namespace",
+			operation:    "create",
+			expectedCode: ErrCodeBadRequest,
+		},
+		{
+			name:         "server error",
+			statusCode:   http.StatusInternalServerError,
+			body:         nil,
+			resource:     "namespace",
+			operation:    "read",
+			expectedCode: ErrCodeServerError,
+		},
+		{
+			name:         "with JSON body",
+			statusCode:   http.StatusBadRequest,
+			body:         []byte(`{"code": "INVALID_ARGUMENT", "message": "field is required"}`),
+			resource:     "namespace",
+			operation:    "create",
+			expectedCode: ErrCodeBadRequest,
+		},
+		{
+			name:         "with invalid JSON body",
+			statusCode:   http.StatusBadRequest,
+			body:         []byte(`not json`),
+			resource:     "namespace",
+			operation:    "create",
+			expectedCode: ErrCodeBadRequest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := NewAPIError(tt.statusCode, tt.body, tt.resource, tt.operation)
+
+			if err.Code != tt.expectedCode {
+				t.Errorf("NewAPIError() code = %v, expected %v", err.Code, tt.expectedCode)
+			}
+			if err.Resource != tt.resource {
+				t.Errorf("NewAPIError() resource = %v, expected %v", err.Resource, tt.resource)
+			}
+			if err.Operation != tt.operation {
+				t.Errorf("NewAPIError() operation = %v, expected %v", err.Operation, tt.operation)
+			}
+			if err.StatusCode != tt.statusCode {
+				t.Errorf("NewAPIError() statusCode = %v, expected %v", err.StatusCode, tt.statusCode)
+			}
+		})
+	}
+}
+
+func TestNewNotFoundError(t *testing.T) {
+	err := NewNotFoundError("namespace", "test-ns", "system")
+
+	if err.Code != ErrCodeNotFound {
+		t.Errorf("NewNotFoundError() code = %v, expected %v", err.Code, ErrCodeNotFound)
+	}
+	if !strings.Contains(err.Message, "test-ns") {
+		t.Errorf("NewNotFoundError() message should contain name, got %v", err.Message)
+	}
+	if !strings.Contains(err.Message, "system") {
+		t.Errorf("NewNotFoundError() message should contain namespace, got %v", err.Message)
+	}
+}
+
+func TestNewValidationError(t *testing.T) {
+	err := NewValidationError("namespace", "name", "must not be empty")
+
+	if err.Code != ErrCodeValidation {
+		t.Errorf("NewValidationError() code = %v, expected %v", err.Code, ErrCodeValidation)
+	}
+	if !strings.Contains(err.Message, "name") {
+		t.Errorf("NewValidationError() message should contain field name, got %v", err.Message)
+	}
+}
+
+func TestNewTimeoutError(t *testing.T) {
+	wrapped := errors.New("context deadline exceeded")
+	err := NewTimeoutError("namespace", "create", wrapped)
+
+	if err.Code != ErrCodeTimeout {
+		t.Errorf("NewTimeoutError() code = %v, expected %v", err.Code, ErrCodeTimeout)
+	}
+	if err.Wrapped != wrapped {
+		t.Error("NewTimeoutError() should wrap the original error")
+	}
+}
+
+func TestNewNetworkError(t *testing.T) {
+	wrapped := errors.New("connection refused")
+	err := NewNetworkError(wrapped)
+
+	if err.Code != ErrCodeNetworkError {
+		t.Errorf("NewNetworkError() code = %v, expected %v", err.Code, ErrCodeNetworkError)
+	}
+	if err.Wrapped != wrapped {
+		t.Error("NewNetworkError() should wrap the original error")
+	}
+}
+
+func TestNewConfigurationError(t *testing.T) {
+	err := NewConfigurationError("API URL is required")
+
+	if err.Code != ErrCodeConfiguration {
+		t.Errorf("NewConfigurationError() code = %v, expected %v", err.Code, ErrCodeConfiguration)
+	}
+	if err.Message != "API URL is required" {
+		t.Errorf("NewConfigurationError() message = %v, expected %v", err.Message, "API URL is required")
+	}
+}
+
+func TestAddError(t *testing.T) {
+	var diags diag.Diagnostics
+	err := &F5XCError{
+		Code:    ErrCodeNotFound,
+		Message: "resource not found",
+	}
+
+	AddError(&diags, err)
+
+	if !diags.HasError() {
+		t.Error("AddError() should add an error to diagnostics")
+	}
+	if len(diags.Errors()) != 1 {
+		t.Errorf("AddError() should add exactly one error, got %d", len(diags.Errors()))
+	}
+}
+
+func TestAddWarning(t *testing.T) {
+	var diags diag.Diagnostics
+
+	AddWarning(&diags, "Warning Title", "Warning detail")
+
+	if diags.HasError() {
+		t.Error("AddWarning() should not add an error")
+	}
+	if len(diags.Warnings()) != 1 {
+		t.Errorf("AddWarning() should add exactly one warning, got %d", len(diags.Warnings()))
+	}
+}
+
+func TestAddAttributeError(t *testing.T) {
+	var diags diag.Diagnostics
+
+	AddAttributeError(&diags, "name", "Invalid Value", "Name must not be empty")
+
+	if !diags.HasError() {
+		t.Error("AddAttributeError() should add an error")
+	}
+}
+
+func TestCreateDiagnostic(t *testing.T) {
+	t.Run("with F5XCError", func(t *testing.T) {
+		f5xcErr := &F5XCError{
+			Code:    ErrCodeNotFound,
+			Message: "not found",
+		}
+
+		diags := CreateDiagnostic("reading", "namespace", f5xcErr)
+
+		if !diags.HasError() {
+			t.Error("CreateDiagnostic() should create error diagnostic")
+		}
+	})
+
+	t.Run("with standard error", func(t *testing.T) {
+		stdErr := errors.New("standard error")
+
+		diags := CreateDiagnostic("creating", "namespace", stdErr)
+
+		if !diags.HasError() {
+			t.Error("CreateDiagnostic() should create error diagnostic")
+		}
+	})
+}
+
+func TestWrapError(t *testing.T) {
+	t.Run("wrap standard error", func(t *testing.T) {
+		stdErr := errors.New("original error")
+
+		wrapped := WrapError(stdErr, "namespace", "create")
+
+		if wrapped.Resource != "namespace" {
+			t.Errorf("WrapError() resource = %v, expected namespace", wrapped.Resource)
+		}
+		if wrapped.Operation != "create" {
+			t.Errorf("WrapError() operation = %v, expected create", wrapped.Operation)
+		}
+		if wrapped.Wrapped != stdErr {
+			t.Error("WrapError() should preserve original error")
+		}
+	})
+
+	t.Run("wrap F5XCError", func(t *testing.T) {
+		f5xcErr := &F5XCError{
+			Code:    ErrCodeNotFound,
+			Message: "not found",
+		}
+
+		wrapped := WrapError(f5xcErr, "namespace", "read")
+
+		if wrapped.Resource != "namespace" {
+			t.Errorf("WrapError() should update resource, got %v", wrapped.Resource)
+		}
+		if wrapped.Operation != "read" {
+			t.Errorf("WrapError() should update operation, got %v", wrapped.Operation)
+		}
+		if wrapped.Code != ErrCodeNotFound {
+			t.Error("WrapError() should preserve original code")
+		}
+	})
+}
+
+func TestAPIErrorResponseParsing(t *testing.T) {
+	jsonBody := `{
+		"code": "INVALID_ARGUMENT",
+		"message": "Field validation failed",
+		"details": [
+			{
+				"@type": "type.googleapis.com/google.rpc.BadRequest",
+				"reason": "name is required",
+				"domain": "f5xc.io"
+			}
+		]
+	}`
+
+	var apiErr APIErrorResponse
+	if err := json.Unmarshal([]byte(jsonBody), &apiErr); err != nil {
+		t.Fatalf("Failed to unmarshal APIErrorResponse: %v", err)
+	}
+
+	if apiErr.Code != "INVALID_ARGUMENT" {
+		t.Errorf("APIErrorResponse.Code = %v, expected INVALID_ARGUMENT", apiErr.Code)
+	}
+	if apiErr.Message != "Field validation failed" {
+		t.Errorf("APIErrorResponse.Message = %v, expected Field validation failed", apiErr.Message)
+	}
+	if len(apiErr.Details) != 1 {
+		t.Errorf("APIErrorResponse.Details length = %d, expected 1", len(apiErr.Details))
+	}
+}
+
+func TestErrorCodeConstants(t *testing.T) {
+	// Verify error codes are distinct
+	codes := []ErrorCode{
+		ErrCodeNotFound,
+		ErrCodeUnauthorized,
+		ErrCodeForbidden,
+		ErrCodeConflict,
+		ErrCodeRateLimit,
+		ErrCodeServerError,
+		ErrCodeBadRequest,
+		ErrCodeTimeout,
+		ErrCodeNetworkError,
+		ErrCodeValidation,
+		ErrCodeStateRead,
+		ErrCodeStateWrite,
+		ErrCodeConfiguration,
+	}
+
+	seen := make(map[ErrorCode]bool)
+	for _, code := range codes {
+		if seen[code] {
+			t.Errorf("Duplicate error code: %v", code)
+		}
+		seen[code] = true
+	}
+}

--- a/internal/planmodifiers/planmodifiers_test.go
+++ b/internal/planmodifiers/planmodifiers_test.go
@@ -1,0 +1,422 @@
+// Copyright (c) F5XC Community
+// SPDX-License-Identifier: MPL-2.0
+
+package planmodifiers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+func TestWarnIfUnknown(t *testing.T) {
+	ctx := context.Background()
+	modifier := WarnIfUnknown("test_attribute")
+
+	t.Run("description", func(t *testing.T) {
+		desc := modifier.Description(ctx)
+		if desc == "" {
+			t.Error("Description() should return non-empty string")
+		}
+	})
+
+	t.Run("markdown description", func(t *testing.T) {
+		mdDesc := modifier.MarkdownDescription(ctx)
+		if mdDesc == "" {
+			t.Error("MarkdownDescription() should return non-empty string")
+		}
+	})
+
+	t.Run("warns when unknown", func(t *testing.T) {
+		req := planmodifier.StringRequest{
+			PlanValue: types.StringUnknown(),
+		}
+		resp := &planmodifier.StringResponse{}
+
+		modifier.PlanModifyString(ctx, req, resp)
+
+		if len(resp.Diagnostics.Warnings()) != 1 {
+			t.Errorf("Expected 1 warning, got %d", len(resp.Diagnostics.Warnings()))
+		}
+	})
+
+	t.Run("no warning when known", func(t *testing.T) {
+		req := planmodifier.StringRequest{
+			PlanValue: types.StringValue("known-value"),
+		}
+		resp := &planmodifier.StringResponse{}
+
+		modifier.PlanModifyString(ctx, req, resp)
+
+		if len(resp.Diagnostics.Warnings()) != 0 {
+			t.Errorf("Expected 0 warnings, got %d", len(resp.Diagnostics.Warnings()))
+		}
+	})
+}
+
+func TestWarnIfUnknownInt64(t *testing.T) {
+	ctx := context.Background()
+	modifier := WarnIfUnknownInt64("test_int")
+
+	t.Run("description", func(t *testing.T) {
+		desc := modifier.Description(ctx)
+		if desc == "" {
+			t.Error("Description() should return non-empty string")
+		}
+	})
+
+	t.Run("warns when unknown", func(t *testing.T) {
+		req := planmodifier.Int64Request{
+			PlanValue: types.Int64Unknown(),
+		}
+		resp := &planmodifier.Int64Response{}
+
+		modifier.PlanModifyInt64(ctx, req, resp)
+
+		if len(resp.Diagnostics.Warnings()) != 1 {
+			t.Errorf("Expected 1 warning, got %d", len(resp.Diagnostics.Warnings()))
+		}
+	})
+
+	t.Run("no warning when known", func(t *testing.T) {
+		req := planmodifier.Int64Request{
+			PlanValue: types.Int64Value(42),
+		}
+		resp := &planmodifier.Int64Response{}
+
+		modifier.PlanModifyInt64(ctx, req, resp)
+
+		if len(resp.Diagnostics.Warnings()) != 0 {
+			t.Errorf("Expected 0 warnings, got %d", len(resp.Diagnostics.Warnings()))
+		}
+	})
+}
+
+func TestWarnIfUnknownBool(t *testing.T) {
+	ctx := context.Background()
+	modifier := WarnIfUnknownBool("test_bool")
+
+	t.Run("description", func(t *testing.T) {
+		desc := modifier.Description(ctx)
+		if desc == "" {
+			t.Error("Description() should return non-empty string")
+		}
+	})
+
+	t.Run("warns when unknown", func(t *testing.T) {
+		req := planmodifier.BoolRequest{
+			PlanValue: types.BoolUnknown(),
+		}
+		resp := &planmodifier.BoolResponse{}
+
+		modifier.PlanModifyBool(ctx, req, resp)
+
+		if len(resp.Diagnostics.Warnings()) != 1 {
+			t.Errorf("Expected 1 warning, got %d", len(resp.Diagnostics.Warnings()))
+		}
+	})
+
+	t.Run("no warning when known", func(t *testing.T) {
+		req := planmodifier.BoolRequest{
+			PlanValue: types.BoolValue(true),
+		}
+		resp := &planmodifier.BoolResponse{}
+
+		modifier.PlanModifyBool(ctx, req, resp)
+
+		if len(resp.Diagnostics.Warnings()) != 0 {
+			t.Errorf("Expected 0 warnings, got %d", len(resp.Diagnostics.Warnings()))
+		}
+	})
+}
+
+func TestRequiresReplaceIfConfigured(t *testing.T) {
+	ctx := context.Background()
+	modifier := RequiresReplaceIfConfigured()
+
+	t.Run("description", func(t *testing.T) {
+		desc := modifier.Description(ctx)
+		if desc == "" {
+			t.Error("Description() should return non-empty string")
+		}
+	})
+
+	t.Run("no replace when config is null", func(t *testing.T) {
+		schema := tftypes.Object{
+			AttributeTypes: map[string]tftypes.Type{
+				"test": tftypes.String,
+			},
+		}
+		stateValue := tftypes.NewValue(schema, map[string]tftypes.Value{
+			"test": tftypes.NewValue(tftypes.String, "old-value"),
+		})
+
+		req := planmodifier.StringRequest{
+			StateValue:  types.StringValue("old-value"),
+			PlanValue:   types.StringValue("new-value"),
+			ConfigValue: types.StringNull(),
+			State: tfsdk.State{
+				Raw: stateValue,
+			},
+		}
+		resp := &planmodifier.StringResponse{}
+
+		modifier.PlanModifyString(ctx, req, resp)
+
+		if resp.RequiresReplace {
+			t.Error("Should not require replace when config is null")
+		}
+	})
+
+	t.Run("no replace when state is null (create)", func(t *testing.T) {
+		req := planmodifier.StringRequest{
+			StateValue:  types.StringNull(),
+			PlanValue:   types.StringValue("new-value"),
+			ConfigValue: types.StringValue("new-value"),
+			State: tfsdk.State{
+				Raw: tftypes.NewValue(tftypes.Object{}, nil),
+			},
+		}
+		resp := &planmodifier.StringResponse{}
+
+		modifier.PlanModifyString(ctx, req, resp)
+
+		if resp.RequiresReplace {
+			t.Error("Should not require replace during create")
+		}
+	})
+
+	t.Run("no replace when values equal", func(t *testing.T) {
+		schema := tftypes.Object{
+			AttributeTypes: map[string]tftypes.Type{
+				"test": tftypes.String,
+			},
+		}
+		stateValue := tftypes.NewValue(schema, map[string]tftypes.Value{
+			"test": tftypes.NewValue(tftypes.String, "same-value"),
+		})
+
+		req := planmodifier.StringRequest{
+			StateValue:  types.StringValue("same-value"),
+			PlanValue:   types.StringValue("same-value"),
+			ConfigValue: types.StringValue("same-value"),
+			State: tfsdk.State{
+				Raw: stateValue,
+			},
+		}
+		resp := &planmodifier.StringResponse{}
+
+		modifier.PlanModifyString(ctx, req, resp)
+
+		if resp.RequiresReplace {
+			t.Error("Should not require replace when values are equal")
+		}
+	})
+
+	t.Run("requires replace when configured value changes", func(t *testing.T) {
+		schema := tftypes.Object{
+			AttributeTypes: map[string]tftypes.Type{
+				"test": tftypes.String,
+			},
+		}
+		stateValue := tftypes.NewValue(schema, map[string]tftypes.Value{
+			"test": tftypes.NewValue(tftypes.String, "old-value"),
+		})
+
+		req := planmodifier.StringRequest{
+			StateValue:  types.StringValue("old-value"),
+			PlanValue:   types.StringValue("new-value"),
+			ConfigValue: types.StringValue("new-value"),
+			State: tfsdk.State{
+				Raw: stateValue,
+			},
+		}
+		resp := &planmodifier.StringResponse{}
+
+		modifier.PlanModifyString(ctx, req, resp)
+
+		if !resp.RequiresReplace {
+			t.Error("Should require replace when configured value changes")
+		}
+	})
+}
+
+func TestDefaultValue(t *testing.T) {
+	ctx := context.Background()
+	defaultVal := "default-value"
+	modifier := DefaultValue(defaultVal)
+
+	t.Run("description", func(t *testing.T) {
+		desc := modifier.Description(ctx)
+		if desc == "" {
+			t.Error("Description() should return non-empty string")
+		}
+	})
+
+	t.Run("sets default when config is null", func(t *testing.T) {
+		req := planmodifier.StringRequest{
+			ConfigValue: types.StringNull(),
+			StateValue:  types.StringNull(),
+			PlanValue:   types.StringNull(),
+			State: tfsdk.State{
+				Raw: tftypes.NewValue(tftypes.Object{}, nil),
+			},
+		}
+		resp := &planmodifier.StringResponse{
+			PlanValue: types.StringNull(),
+		}
+
+		modifier.PlanModifyString(ctx, req, resp)
+
+		if resp.PlanValue.ValueString() != defaultVal {
+			t.Errorf("Expected default value %q, got %q", defaultVal, resp.PlanValue.ValueString())
+		}
+	})
+
+	t.Run("does not override configured value", func(t *testing.T) {
+		configuredVal := "configured-value"
+		req := planmodifier.StringRequest{
+			ConfigValue: types.StringValue(configuredVal),
+			StateValue:  types.StringNull(),
+			PlanValue:   types.StringValue(configuredVal),
+			State: tfsdk.State{
+				Raw: tftypes.NewValue(tftypes.Object{}, nil),
+			},
+		}
+		resp := &planmodifier.StringResponse{
+			PlanValue: types.StringValue(configuredVal),
+		}
+
+		modifier.PlanModifyString(ctx, req, resp)
+
+		if resp.PlanValue.ValueString() != configuredVal {
+			t.Errorf("Should not override configured value, got %q", resp.PlanValue.ValueString())
+		}
+	})
+
+	t.Run("preserves state value on update", func(t *testing.T) {
+		schema := tftypes.Object{
+			AttributeTypes: map[string]tftypes.Type{
+				"test": tftypes.String,
+			},
+		}
+		stateValue := tftypes.NewValue(schema, map[string]tftypes.Value{
+			"test": tftypes.NewValue(tftypes.String, "existing-value"),
+		})
+
+		req := planmodifier.StringRequest{
+			ConfigValue: types.StringNull(),
+			StateValue:  types.StringValue("existing-value"),
+			PlanValue:   types.StringNull(),
+			State: tfsdk.State{
+				Raw: stateValue,
+			},
+		}
+		resp := &planmodifier.StringResponse{
+			PlanValue: types.StringNull(),
+		}
+
+		modifier.PlanModifyString(ctx, req, resp)
+
+		// Should preserve state value, not override with default
+		if resp.PlanValue.ValueString() == defaultVal {
+			t.Error("Should not override existing state value with default")
+		}
+	})
+}
+
+func TestPreserveUnknownOnCreate(t *testing.T) {
+	ctx := context.Background()
+	modifier := PreserveUnknownOnCreate()
+
+	t.Run("description", func(t *testing.T) {
+		desc := modifier.Description(ctx)
+		if desc == "" {
+			t.Error("Description() should return non-empty string")
+		}
+	})
+
+	t.Run("preserves unknown during create", func(t *testing.T) {
+		req := planmodifier.StringRequest{
+			StateValue: types.StringNull(),
+			PlanValue:  types.StringUnknown(),
+			State: tfsdk.State{
+				Raw: tftypes.NewValue(tftypes.Object{}, nil),
+			},
+		}
+		resp := &planmodifier.StringResponse{
+			PlanValue: types.StringUnknown(),
+		}
+
+		modifier.PlanModifyString(ctx, req, resp)
+
+		if !resp.PlanValue.IsUnknown() {
+			t.Error("Should preserve unknown value during create")
+		}
+	})
+
+	t.Run("uses state value during update when plan is unknown", func(t *testing.T) {
+		schema := tftypes.Object{
+			AttributeTypes: map[string]tftypes.Type{
+				"test": tftypes.String,
+			},
+		}
+		stateValue := tftypes.NewValue(schema, map[string]tftypes.Value{
+			"test": tftypes.NewValue(tftypes.String, "state-value"),
+		})
+
+		req := planmodifier.StringRequest{
+			StateValue: types.StringValue("state-value"),
+			PlanValue:  types.StringUnknown(),
+			State: tfsdk.State{
+				Raw: stateValue,
+			},
+		}
+		resp := &planmodifier.StringResponse{
+			PlanValue: types.StringUnknown(),
+		}
+
+		modifier.PlanModifyString(ctx, req, resp)
+
+		if resp.PlanValue.ValueString() != "state-value" {
+			t.Errorf("Should use state value during update, got %q", resp.PlanValue.ValueString())
+		}
+	})
+}
+
+func TestModifierDescriptions(t *testing.T) {
+	ctx := context.Background()
+
+	modifiers := []struct {
+		name     string
+		modifier interface {
+			Description(context.Context) string
+			MarkdownDescription(context.Context) string
+		}
+	}{
+		{"WarnIfUnknown", WarnIfUnknown("attr")},
+		{"WarnIfUnknownInt64", WarnIfUnknownInt64("attr")},
+		{"WarnIfUnknownBool", WarnIfUnknownBool("attr")},
+		{"RequiresReplaceIfConfigured", RequiresReplaceIfConfigured()},
+		{"DefaultValue", DefaultValue("default")},
+		{"PreserveUnknownOnCreate", PreserveUnknownOnCreate()},
+	}
+
+	for _, m := range modifiers {
+		t.Run(m.name, func(t *testing.T) {
+			desc := m.modifier.Description(ctx)
+			mdDesc := m.modifier.MarkdownDescription(ctx)
+
+			if desc == "" {
+				t.Errorf("%s.Description() returned empty string", m.name)
+			}
+			if mdDesc == "" {
+				t.Errorf("%s.MarkdownDescription() returned empty string", m.name)
+			}
+		})
+	}
+}

--- a/internal/privatestate/privatestate_test.go
+++ b/internal/privatestate/privatestate_test.go
@@ -1,0 +1,366 @@
+// Copyright (c) F5XC Community
+// SPDX-License-Identifier: MPL-2.0
+
+package privatestate
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestKeyConstants(t *testing.T) {
+	// Verify key constants are non-empty and distinct
+	keys := []string{
+		KeyAPIMetadata,
+		KeyResourceUID,
+		KeyLastModified,
+		KeyETag,
+		KeyResourceVersion,
+	}
+
+	seen := make(map[string]bool)
+	for _, key := range keys {
+		if key == "" {
+			t.Error("Key constant should not be empty")
+		}
+		if seen[key] {
+			t.Errorf("Duplicate key constant: %q", key)
+		}
+		seen[key] = true
+	}
+}
+
+func TestNewPrivateStateData(t *testing.T) {
+	psd := NewPrivateStateData()
+
+	if psd == nil {
+		t.Fatal("NewPrivateStateData() returned nil")
+	}
+	if psd.Metadata.Custom == nil {
+		t.Error("NewPrivateStateData() should initialize Custom map")
+	}
+}
+
+func TestPrivateStateDataSetters(t *testing.T) {
+	psd := NewPrivateStateData()
+
+	// Test method chaining
+	result := psd.
+		SetUID("test-uid").
+		SetResourceVersion("v1").
+		SetETag("etag-123").
+		SetGeneration(5).
+		SetSpecHash("abc123")
+
+	if result != psd {
+		t.Error("Setter methods should return the same instance for chaining")
+	}
+
+	if psd.Metadata.UID != "test-uid" {
+		t.Errorf("SetUID() = %q, expected test-uid", psd.Metadata.UID)
+	}
+	if psd.Metadata.ResourceVersion != "v1" {
+		t.Errorf("SetResourceVersion() = %q, expected v1", psd.Metadata.ResourceVersion)
+	}
+	if psd.Metadata.ETag != "etag-123" {
+		t.Errorf("SetETag() = %q, expected etag-123", psd.Metadata.ETag)
+	}
+	if psd.Metadata.Generation != 5 {
+		t.Errorf("SetGeneration() = %d, expected 5", psd.Metadata.Generation)
+	}
+	if psd.Metadata.SpecHash != "abc123" {
+		t.Errorf("SetSpecHash() = %q, expected abc123", psd.Metadata.SpecHash)
+	}
+}
+
+func TestSetLastModified(t *testing.T) {
+	psd := NewPrivateStateData()
+	now := time.Now()
+
+	psd.SetLastModified(now)
+
+	if !psd.Metadata.LastModified.Equal(now) {
+		t.Errorf("SetLastModified() = %v, expected %v", psd.Metadata.LastModified, now)
+	}
+}
+
+func TestSetCustom(t *testing.T) {
+	psd := NewPrivateStateData()
+
+	psd.SetCustom("key1", "value1").SetCustom("key2", "value2")
+
+	if psd.Metadata.Custom["key1"] != "value1" {
+		t.Errorf("SetCustom() key1 = %q, expected value1", psd.Metadata.Custom["key1"])
+	}
+	if psd.Metadata.Custom["key2"] != "value2" {
+		t.Errorf("SetCustom() key2 = %q, expected value2", psd.Metadata.Custom["key2"])
+	}
+}
+
+func TestSetCustomInitializesMap(t *testing.T) {
+	// Create instance without Custom map initialized
+	psd := &PrivateStateData{
+		Metadata: APIMetadata{
+			Custom: nil,
+		},
+	}
+
+	psd.SetCustom("key", "value")
+
+	if psd.Metadata.Custom == nil {
+		t.Error("SetCustom() should initialize Custom map if nil")
+	}
+	if psd.Metadata.Custom["key"] != "value" {
+		t.Error("SetCustom() should set the value")
+	}
+}
+
+func TestToJSONAndFromJSON(t *testing.T) {
+	psd := NewPrivateStateData()
+	now := time.Now().UTC().Truncate(time.Second) // Truncate for JSON precision
+
+	psd.
+		SetUID("uid-123").
+		SetResourceVersion("v2").
+		SetETag("etag-456").
+		SetGeneration(10).
+		SetSpecHash("hash-789").
+		SetLastModified(now).
+		SetCustom("custom_key", "custom_value")
+
+	// Serialize to JSON
+	data, err := psd.ToJSON()
+	if err != nil {
+		t.Fatalf("ToJSON() error: %v", err)
+	}
+
+	// Deserialize from JSON
+	psd2 := NewPrivateStateData()
+	if err := psd2.FromJSON(data); err != nil {
+		t.Fatalf("FromJSON() error: %v", err)
+	}
+
+	// Verify all fields
+	if psd2.Metadata.UID != "uid-123" {
+		t.Errorf("FromJSON() UID = %q, expected uid-123", psd2.Metadata.UID)
+	}
+	if psd2.Metadata.ResourceVersion != "v2" {
+		t.Errorf("FromJSON() ResourceVersion = %q, expected v2", psd2.Metadata.ResourceVersion)
+	}
+	if psd2.Metadata.ETag != "etag-456" {
+		t.Errorf("FromJSON() ETag = %q, expected etag-456", psd2.Metadata.ETag)
+	}
+	if psd2.Metadata.Generation != 10 {
+		t.Errorf("FromJSON() Generation = %d, expected 10", psd2.Metadata.Generation)
+	}
+	if psd2.Metadata.SpecHash != "hash-789" {
+		t.Errorf("FromJSON() SpecHash = %q, expected hash-789", psd2.Metadata.SpecHash)
+	}
+	if psd2.Metadata.Custom["custom_key"] != "custom_value" {
+		t.Errorf("FromJSON() Custom[custom_key] = %q, expected custom_value", psd2.Metadata.Custom["custom_key"])
+	}
+}
+
+func TestDetectDrift(t *testing.T) {
+	tests := []struct {
+		name             string
+		setup            func(*PrivateStateData)
+		apiUID           string
+		apiSpecHash      string
+		apiGeneration    int64
+		expectDrift      bool
+		expectUIDChange  bool
+		expectSpecChange bool
+		expectGenChange  bool
+	}{
+		{
+			name:          "no drift - empty metadata",
+			setup:         func(psd *PrivateStateData) {},
+			apiUID:        "uid-123",
+			apiSpecHash:   "hash-456",
+			apiGeneration: 1,
+			expectDrift:   false,
+		},
+		{
+			name: "UID changed",
+			setup: func(psd *PrivateStateData) {
+				psd.SetUID("old-uid")
+			},
+			apiUID:          "new-uid",
+			apiSpecHash:     "",
+			apiGeneration:   0,
+			expectDrift:     true,
+			expectUIDChange: true,
+		},
+		{
+			name: "spec hash changed",
+			setup: func(psd *PrivateStateData) {
+				psd.SetSpecHash("old-hash")
+			},
+			apiUID:           "",
+			apiSpecHash:      "new-hash",
+			apiGeneration:    0,
+			expectDrift:      true,
+			expectSpecChange: true,
+		},
+		{
+			name: "generation changed",
+			setup: func(psd *PrivateStateData) {
+				psd.SetGeneration(5)
+			},
+			apiUID:          "",
+			apiSpecHash:     "",
+			apiGeneration:   10,
+			expectDrift:     true,
+			expectGenChange: true,
+		},
+		{
+			name: "no drift - same values",
+			setup: func(psd *PrivateStateData) {
+				psd.SetUID("uid-123").SetSpecHash("hash-456").SetGeneration(5)
+			},
+			apiUID:        "uid-123",
+			apiSpecHash:   "hash-456",
+			apiGeneration: 5,
+			expectDrift:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			psd := NewPrivateStateData()
+			tt.setup(psd)
+
+			drift := psd.DetectDrift(tt.apiUID, tt.apiSpecHash, tt.apiGeneration)
+
+			if drift.HasDrift != tt.expectDrift {
+				t.Errorf("DetectDrift() HasDrift = %v, expected %v", drift.HasDrift, tt.expectDrift)
+			}
+			if drift.UIDChanged != tt.expectUIDChange {
+				t.Errorf("DetectDrift() UIDChanged = %v, expected %v", drift.UIDChanged, tt.expectUIDChange)
+			}
+			if drift.SpecChanged != tt.expectSpecChange {
+				t.Errorf("DetectDrift() SpecChanged = %v, expected %v", drift.SpecChanged, tt.expectSpecChange)
+			}
+			if drift.GenerationChanged != tt.expectGenChange {
+				t.Errorf("DetectDrift() GenerationChanged = %v, expected %v", drift.GenerationChanged, tt.expectGenChange)
+			}
+		})
+	}
+}
+
+func TestDriftInfoAsWarning(t *testing.T) {
+	t.Run("with drift", func(t *testing.T) {
+		drift := &DriftInfo{
+			HasDrift: true,
+			Details:  []string{"UID changed", "Spec changed"},
+		}
+
+		diags := drift.AsWarning()
+
+		if len(diags.Warnings()) != 1 {
+			t.Errorf("AsWarning() returned %d warnings, expected 1", len(diags.Warnings()))
+		}
+	})
+
+	t.Run("without drift", func(t *testing.T) {
+		drift := &DriftInfo{
+			HasDrift: false,
+		}
+
+		diags := drift.AsWarning()
+
+		if len(diags.Warnings()) != 0 {
+			t.Errorf("AsWarning() returned %d warnings, expected 0", len(diags.Warnings()))
+		}
+	})
+}
+
+func TestHashSpec(t *testing.T) {
+	t.Run("consistent hashing", func(t *testing.T) {
+		spec := map[string]string{
+			"name":      "test",
+			"namespace": "default",
+		}
+
+		hash1, err1 := HashSpec(spec)
+		hash2, err2 := HashSpec(spec)
+
+		if err1 != nil || err2 != nil {
+			t.Fatalf("HashSpec() error: %v, %v", err1, err2)
+		}
+
+		if hash1 != hash2 {
+			t.Error("HashSpec() should return consistent hash for same input")
+		}
+	})
+
+	t.Run("different specs different hashes", func(t *testing.T) {
+		spec1 := map[string]string{"name": "test1"}
+		spec2 := map[string]string{"name": "test2"}
+
+		hash1, _ := HashSpec(spec1)
+		hash2, _ := HashSpec(spec2)
+
+		if hash1 == hash2 {
+			t.Error("HashSpec() should return different hashes for different inputs")
+		}
+	})
+
+	t.Run("non-empty hash", func(t *testing.T) {
+		spec := map[string]string{"key": "value"}
+
+		hash, err := HashSpec(spec)
+		if err != nil {
+			t.Fatalf("HashSpec() error: %v", err)
+		}
+
+		if hash == "" {
+			t.Error("HashSpec() should return non-empty hash")
+		}
+	})
+}
+
+func TestAPIMetadataJSONSerialization(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+
+	metadata := APIMetadata{
+		UID:             "test-uid",
+		ResourceVersion: "v1",
+		ETag:            "etag-123",
+		LastModified:    now,
+		Generation:      5,
+		SpecHash:        "hash-abc",
+		CreatedAt:       now,
+		ModifiedAt:      now,
+		Owner:           "test-owner",
+		LabelsHash:      "labels-hash",
+		Custom: map[string]string{
+			"key": "value",
+		},
+	}
+
+	// Serialize
+	data, err := json.Marshal(metadata)
+	if err != nil {
+		t.Fatalf("json.Marshal() error: %v", err)
+	}
+
+	// Deserialize
+	var metadata2 APIMetadata
+	if err := json.Unmarshal(data, &metadata2); err != nil {
+		t.Fatalf("json.Unmarshal() error: %v", err)
+	}
+
+	// Verify
+	if metadata2.UID != metadata.UID {
+		t.Errorf("UID mismatch: got %q, expected %q", metadata2.UID, metadata.UID)
+	}
+	if metadata2.Generation != metadata.Generation {
+		t.Errorf("Generation mismatch: got %d, expected %d", metadata2.Generation, metadata.Generation)
+	}
+	if metadata2.Owner != metadata.Owner {
+		t.Errorf("Owner mismatch: got %q, expected %q", metadata2.Owner, metadata.Owner)
+	}
+}

--- a/internal/stateupgraders/stateupgraders_test.go
+++ b/internal/stateupgraders/stateupgraders_test.go
@@ -1,0 +1,339 @@
+// Copyright (c) F5XC Community
+// SPDX-License-Identifier: MPL-2.0
+
+package stateupgraders
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+)
+
+func TestSchemaVersionConstant(t *testing.T) {
+	if SchemaVersion < 1 {
+		t.Errorf("SchemaVersion = %d, expected >= 1", SchemaVersion)
+	}
+}
+
+func TestNewUpgradeResourceState(t *testing.T) {
+	upgrader := NewUpgradeResourceState(2)
+
+	if upgrader.CurrentVersion != 2 {
+		t.Errorf("CurrentVersion = %d, expected 2", upgrader.CurrentVersion)
+	}
+	if upgrader.UpgradeFuncs == nil {
+		t.Error("UpgradeFuncs should not be nil")
+	}
+}
+
+func TestRegisterUpgrade(t *testing.T) {
+	upgrader := NewUpgradeResourceState(2)
+
+	// Register an upgrade function
+	upgrader.RegisterUpgrade(0, func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+		// Test function body
+	})
+
+	if _, exists := upgrader.UpgradeFuncs[0]; !exists {
+		t.Error("RegisterUpgrade should add function to UpgradeFuncs map")
+	}
+}
+
+func TestStateUpgraders(t *testing.T) {
+	upgrader := NewUpgradeResourceState(2)
+
+	// Register upgrade functions for versions 0 and 1
+	upgrader.RegisterUpgrade(0, func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {})
+	upgrader.RegisterUpgrade(1, func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {})
+
+	stateUpgraders := upgrader.StateUpgraders()
+
+	if len(stateUpgraders) != 2 {
+		t.Errorf("StateUpgraders() returned %d upgraders, expected 2", len(stateUpgraders))
+	}
+
+	if _, exists := stateUpgraders[0]; !exists {
+		t.Error("StateUpgraders() should include version 0")
+	}
+	if _, exists := stateUpgraders[1]; !exists {
+		t.Error("StateUpgraders() should include version 1")
+	}
+}
+
+func TestNewBaseResourceUpgrader(t *testing.T) {
+	upgrader := NewBaseResourceUpgrader("namespace")
+
+	if upgrader.ResourceType != "namespace" {
+		t.Errorf("ResourceType = %q, expected namespace", upgrader.ResourceType)
+	}
+	if upgrader.Upgrader == nil {
+		t.Error("Upgrader should not be nil")
+	}
+	if upgrader.Upgrader.CurrentVersion != SchemaVersion {
+		t.Errorf("Upgrader.CurrentVersion = %d, expected %d", upgrader.Upgrader.CurrentVersion, SchemaVersion)
+	}
+}
+
+func TestMigrateLabelsFormat(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    map[string]interface{}
+		expected map[string]string
+	}{
+		{
+			name:     "empty labels",
+			input:    map[string]interface{}{},
+			expected: map[string]string{},
+		},
+		{
+			name: "string values",
+			input: map[string]interface{}{
+				"app":  "myapp",
+				"env":  "prod",
+				"team": "platform",
+			},
+			expected: map[string]string{
+				"app":  "myapp",
+				"env":  "prod",
+				"team": "platform",
+			},
+		},
+		{
+			name: "non-string values ignored",
+			input: map[string]interface{}{
+				"app":   "myapp",
+				"count": 42, // non-string, should be ignored
+			},
+			expected: map[string]string{
+				"app": "myapp",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := MigrateLabelsFormat(tt.input)
+
+			if len(result) != len(tt.expected) {
+				t.Errorf("MigrateLabelsFormat() returned %d labels, expected %d", len(result), len(tt.expected))
+			}
+
+			for k, v := range tt.expected {
+				if result[k] != v {
+					t.Errorf("MigrateLabelsFormat()[%q] = %q, expected %q", k, result[k], v)
+				}
+			}
+		})
+	}
+}
+
+func TestAddDefaultIfMissing(t *testing.T) {
+	tests := []struct {
+		name         string
+		initial      map[string]interface{}
+		key          string
+		defaultValue interface{}
+		expected     interface{}
+	}{
+		{
+			name:         "add missing key",
+			initial:      map[string]interface{}{},
+			key:          "new_field",
+			defaultValue: "default",
+			expected:     "default",
+		},
+		{
+			name: "don't override existing",
+			initial: map[string]interface{}{
+				"existing": "original",
+			},
+			key:          "existing",
+			defaultValue: "default",
+			expected:     "original",
+		},
+		{
+			name:         "add int default",
+			initial:      map[string]interface{}{},
+			key:          "count",
+			defaultValue: 10,
+			expected:     10,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			AddDefaultIfMissing(tt.initial, tt.key, tt.defaultValue)
+
+			if tt.initial[tt.key] != tt.expected {
+				t.Errorf("AddDefaultIfMissing() set %q = %v, expected %v", tt.key, tt.initial[tt.key], tt.expected)
+			}
+		})
+	}
+}
+
+func TestRemoveDeprecatedField(t *testing.T) {
+	tests := []struct {
+		name    string
+		initial map[string]interface{}
+		key     string
+		exists  bool
+	}{
+		{
+			name: "remove existing field",
+			initial: map[string]interface{}{
+				"old_field": "value",
+				"keep":      "this",
+			},
+			key:    "old_field",
+			exists: false,
+		},
+		{
+			name: "remove non-existent field (no-op)",
+			initial: map[string]interface{}{
+				"keep": "this",
+			},
+			key:    "missing",
+			exists: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			RemoveDeprecatedField(tt.initial, tt.key)
+
+			_, exists := tt.initial[tt.key]
+			if exists != tt.exists {
+				t.Errorf("RemoveDeprecatedField() field %q exists = %v, expected %v", tt.key, exists, tt.exists)
+			}
+		})
+	}
+}
+
+func TestRenameField(t *testing.T) {
+	tests := []struct {
+		name          string
+		initial       map[string]interface{}
+		oldKey        string
+		newKey        string
+		expectedValue interface{}
+		oldExists     bool
+		newExists     bool
+	}{
+		{
+			name: "rename existing field",
+			initial: map[string]interface{}{
+				"old_name": "value",
+			},
+			oldKey:        "old_name",
+			newKey:        "new_name",
+			expectedValue: "value",
+			oldExists:     false,
+			newExists:     true,
+		},
+		{
+			name: "rename non-existent field (no-op)",
+			initial: map[string]interface{}{
+				"other": "value",
+			},
+			oldKey:    "missing",
+			newKey:    "new_name",
+			oldExists: false,
+			newExists: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			RenameField(tt.initial, tt.oldKey, tt.newKey)
+
+			_, oldExists := tt.initial[tt.oldKey]
+			if oldExists != tt.oldExists {
+				t.Errorf("RenameField() old key %q exists = %v, expected %v", tt.oldKey, oldExists, tt.oldExists)
+			}
+
+			newVal, newExists := tt.initial[tt.newKey]
+			if newExists != tt.newExists {
+				t.Errorf("RenameField() new key %q exists = %v, expected %v", tt.newKey, newExists, tt.newExists)
+			}
+
+			if tt.newExists && newVal != tt.expectedValue {
+				t.Errorf("RenameField() new value = %v, expected %v", newVal, tt.expectedValue)
+			}
+		})
+	}
+}
+
+func TestTransformField(t *testing.T) {
+	tests := []struct {
+		name          string
+		initial       map[string]interface{}
+		key           string
+		transform     func(interface{}) interface{}
+		expectedValue interface{}
+	}{
+		{
+			name: "transform string to uppercase",
+			initial: map[string]interface{}{
+				"name": "lowercase",
+			},
+			key: "name",
+			transform: func(v interface{}) interface{} {
+				if _, ok := v.(string); ok {
+					return "UPPERCASE"
+				}
+				return v
+			},
+			expectedValue: "UPPERCASE",
+		},
+		{
+			name: "transform int",
+			initial: map[string]interface{}{
+				"count": 5,
+			},
+			key: "count",
+			transform: func(v interface{}) interface{} {
+				if i, ok := v.(int); ok {
+					return i * 2
+				}
+				return v
+			},
+			expectedValue: 10,
+		},
+		{
+			name: "transform non-existent field (no-op)",
+			initial: map[string]interface{}{
+				"other": "value",
+			},
+			key: "missing",
+			transform: func(v interface{}) interface{} {
+				return "transformed"
+			},
+			expectedValue: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			TransformField(tt.initial, tt.key, tt.transform)
+
+			if tt.expectedValue != nil {
+				if tt.initial[tt.key] != tt.expectedValue {
+					t.Errorf("TransformField() value = %v, expected %v", tt.initial[tt.key], tt.expectedValue)
+				}
+			}
+		})
+	}
+}
+
+func TestCommonV0Schema(t *testing.T) {
+	schema := CommonV0Schema()
+
+	expectedFields := []string{"id", "name", "namespace", "labels", "annotations"}
+
+	for _, field := range expectedFields {
+		if _, exists := schema[field]; !exists {
+			t.Errorf("CommonV0Schema() missing expected field %q", field)
+		}
+	}
+}

--- a/internal/timeouts/timeouts_test.go
+++ b/internal/timeouts/timeouts_test.go
@@ -1,0 +1,218 @@
+// Copyright (c) F5XC Community
+// SPDX-License-Identifier: MPL-2.0
+
+package timeouts
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestDefaultConstants(t *testing.T) {
+	tests := []struct {
+		name     string
+		constant time.Duration
+		expected time.Duration
+	}{
+		{"DefaultCreate", DefaultCreate, 10 * time.Minute},
+		{"DefaultRead", DefaultRead, 5 * time.Minute},
+		{"DefaultUpdate", DefaultUpdate, 10 * time.Minute},
+		{"DefaultDelete", DefaultDelete, 10 * time.Minute},
+		{"LongRunningCreate", LongRunningCreate, 30 * time.Minute},
+		{"LongRunningDelete", LongRunningDelete, 30 * time.Minute},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.constant != tt.expected {
+				t.Errorf("%s = %v, expected %v", tt.name, tt.constant, tt.expected)
+			}
+		})
+	}
+}
+
+func TestDefaultConfig(t *testing.T) {
+	cfg := DefaultConfig()
+
+	if cfg.Create != DefaultCreate {
+		t.Errorf("DefaultConfig().Create = %v, expected %v", cfg.Create, DefaultCreate)
+	}
+	if cfg.Read != DefaultRead {
+		t.Errorf("DefaultConfig().Read = %v, expected %v", cfg.Read, DefaultRead)
+	}
+	if cfg.Update != DefaultUpdate {
+		t.Errorf("DefaultConfig().Update = %v, expected %v", cfg.Update, DefaultUpdate)
+	}
+	if cfg.Delete != DefaultDelete {
+		t.Errorf("DefaultConfig().Delete = %v, expected %v", cfg.Delete, DefaultDelete)
+	}
+}
+
+func TestLongRunningConfig(t *testing.T) {
+	cfg := LongRunningConfig()
+
+	if cfg.Create != LongRunningCreate {
+		t.Errorf("LongRunningConfig().Create = %v, expected %v", cfg.Create, LongRunningCreate)
+	}
+	if cfg.Read != DefaultRead {
+		t.Errorf("LongRunningConfig().Read = %v, expected %v", cfg.Read, DefaultRead)
+	}
+	if cfg.Update != LongRunningCreate {
+		t.Errorf("LongRunningConfig().Update = %v, expected %v", cfg.Update, LongRunningCreate)
+	}
+	if cfg.Delete != LongRunningDelete {
+		t.Errorf("LongRunningConfig().Delete = %v, expected %v", cfg.Delete, LongRunningDelete)
+	}
+}
+
+func TestConfigForResourceType(t *testing.T) {
+	tests := []struct {
+		name         string
+		resourceType ResourceType
+		expectedCfg  Config
+	}{
+		{
+			name:         "Standard resource",
+			resourceType: Standard,
+			expectedCfg:  DefaultConfig(),
+		},
+		{
+			name:         "LongRunning resource",
+			resourceType: LongRunning,
+			expectedCfg:  LongRunningConfig(),
+		},
+		{
+			name:         "Critical resource",
+			resourceType: Critical,
+			expectedCfg: Config{
+				Create: 20 * time.Minute,
+				Read:   DefaultRead,
+				Update: 20 * time.Minute,
+				Delete: 20 * time.Minute,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := ConfigForResourceType(tt.resourceType)
+			if cfg != tt.expectedCfg {
+				t.Errorf("ConfigForResourceType(%v) = %+v, expected %+v", tt.resourceType, cfg, tt.expectedCfg)
+			}
+		})
+	}
+}
+
+func TestIsLongRunning(t *testing.T) {
+	tests := []struct {
+		resourceType string
+		expected     bool
+	}{
+		{"aws_vpc_site", true},
+		{"azure_vnet_site", true},
+		{"gcp_vpc_site", true},
+		{"aws_tgw_site", true},
+		{"voltstack_site", true},
+		{"securemesh_site", true},
+		{"securemesh_site_v2", true},
+		{"k8s_cluster", true},
+		{"virtual_k8s", true},
+		{"namespace", false},
+		{"http_loadbalancer", false},
+		{"origin_pool", false},
+		{"unknown_resource", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.resourceType, func(t *testing.T) {
+			result := IsLongRunning(tt.resourceType)
+			if result != tt.expected {
+				t.Errorf("IsLongRunning(%q) = %v, expected %v", tt.resourceType, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestWithContext(t *testing.T) {
+	ctx := context.Background()
+	timeout := 5 * time.Second
+
+	newCtx, cancel := WithContext(ctx, timeout)
+	defer cancel()
+
+	if newCtx == nil {
+		t.Error("WithContext returned nil context")
+	}
+
+	deadline, ok := newCtx.Deadline()
+	if !ok {
+		t.Error("WithContext did not set deadline")
+	}
+
+	// Deadline should be approximately timeout from now
+	expectedDeadline := time.Now().Add(timeout)
+	if deadline.Before(expectedDeadline.Add(-1*time.Second)) || deadline.After(expectedDeadline.Add(1*time.Second)) {
+		t.Errorf("Deadline %v not within expected range around %v", deadline, expectedDeadline)
+	}
+}
+
+func TestLongRunningResourceTypes(t *testing.T) {
+	// Verify the map is populated
+	if len(LongRunningResourceTypes) == 0 {
+		t.Error("LongRunningResourceTypes map is empty")
+	}
+
+	// Verify known resources are in the map
+	expectedResources := []string{
+		"aws_vpc_site",
+		"azure_vnet_site",
+		"gcp_vpc_site",
+		"k8s_cluster",
+		"virtual_k8s",
+	}
+
+	for _, resource := range expectedResources {
+		if !LongRunningResourceTypes[resource] {
+			t.Errorf("Expected %q to be in LongRunningResourceTypes", resource)
+		}
+	}
+}
+
+func TestResourceTypeConstants(t *testing.T) {
+	// Verify resource type constants are distinct
+	if Standard == LongRunning {
+		t.Error("Standard and LongRunning should be distinct values")
+	}
+	if Standard == Critical {
+		t.Error("Standard and Critical should be distinct values")
+	}
+	if LongRunning == Critical {
+		t.Error("LongRunning and Critical should be distinct values")
+	}
+}
+
+func TestBlock(t *testing.T) {
+	cfg := DefaultConfig()
+	block := Block(cfg)
+
+	if block == nil {
+		t.Error("Block() returned nil")
+	}
+}
+
+func TestStandardBlock(t *testing.T) {
+	block := StandardBlock()
+
+	if block == nil {
+		t.Error("StandardBlock() returned nil")
+	}
+}
+
+func TestLongRunningBlock(t *testing.T) {
+	block := LongRunningBlock()
+
+	if block == nil {
+		t.Error("LongRunningBlock() returned nil")
+	}
+}

--- a/internal/validators/validators_test.go
+++ b/internal/validators/validators_test.go
@@ -1,0 +1,352 @@
+// Copyright (c) F5XC Community
+// SPDX-License-Identifier: MPL-2.0
+
+package validators
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestNamePattern(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		matches bool
+	}{
+		{"valid simple name", "myname", true},
+		{"valid with hyphens", "my-resource-name", true},
+		{"valid with numbers", "my-resource-123", true},
+		{"valid single char", "a", true},
+		{"valid two chars", "ab", true},
+		{"invalid starts with number", "1name", false},
+		{"invalid starts with hyphen", "-name", false},
+		{"invalid ends with hyphen", "name-", false},
+		{"invalid uppercase", "MyName", false},
+		{"invalid spaces", "my name", false},
+		{"invalid underscores", "my_name", false},
+		{"empty string", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := NamePattern.MatchString(tt.input)
+			if result != tt.matches {
+				t.Errorf("NamePattern.MatchString(%q) = %v, expected %v", tt.input, result, tt.matches)
+			}
+		})
+	}
+}
+
+func TestNamespacePattern(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		matches bool
+	}{
+		{"valid system namespace", "system", true},
+		{"valid custom namespace", "my-namespace", true},
+		{"valid with numbers", "namespace-123", true},
+		{"invalid uppercase", "System", false},
+		{"invalid starts with hyphen", "-namespace", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := NamespacePattern.MatchString(tt.input)
+			if result != tt.matches {
+				t.Errorf("NamespacePattern.MatchString(%q) = %v, expected %v", tt.input, result, tt.matches)
+			}
+		})
+	}
+}
+
+func TestDomainPattern(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		matches bool
+	}{
+		{"valid domain", "example.com", true},
+		{"valid subdomain", "sub.example.com", true},
+		{"valid wildcard", "*.example.com", true},
+		{"valid with hyphens", "my-site.example.com", true},
+		{"invalid double dot", "example..com", false},
+		{"invalid starts with dot", ".example.com", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := DomainPattern.MatchString(tt.input)
+			if result != tt.matches {
+				t.Errorf("DomainPattern.MatchString(%q) = %v, expected %v", tt.input, result, tt.matches)
+			}
+		})
+	}
+}
+
+func TestNameValidator(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		expectError bool
+	}{
+		{"valid name", "my-resource", false},
+		{"valid single char", "a", false},
+		{"invalid too long", string(make([]byte, 65)), true},
+		{"invalid format", "Invalid_Name", true},
+		{"null value", "", false}, // null values are allowed
+	}
+
+	ctx := context.Background()
+	v := NameValidator()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := validator.StringRequest{
+				Path:        path.Root("name"),
+				ConfigValue: types.StringValue(tt.input),
+			}
+			if tt.input == "" {
+				req.ConfigValue = types.StringNull()
+			}
+
+			resp := &validator.StringResponse{}
+			v.ValidateString(ctx, req, resp)
+
+			hasError := resp.Diagnostics.HasError()
+			if hasError != tt.expectError {
+				t.Errorf("NameValidator for %q: hasError = %v, expected %v", tt.input, hasError, tt.expectError)
+				if hasError {
+					for _, d := range resp.Diagnostics.Errors() {
+						t.Logf("Error: %s - %s", d.Summary(), d.Detail())
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestNamespaceValidator(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		expectError bool
+	}{
+		{"valid system", "system", false},
+		{"valid custom", "my-namespace", false},
+		{"invalid uppercase", "System", true},
+	}
+
+	ctx := context.Background()
+	v := NamespaceValidator()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := validator.StringRequest{
+				Path:        path.Root("namespace"),
+				ConfigValue: types.StringValue(tt.input),
+			}
+
+			resp := &validator.StringResponse{}
+			v.ValidateString(ctx, req, resp)
+
+			hasError := resp.Diagnostics.HasError()
+			if hasError != tt.expectError {
+				t.Errorf("NamespaceValidator for %q: hasError = %v, expected %v", tt.input, hasError, tt.expectError)
+			}
+		})
+	}
+}
+
+func TestDomainValidator(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		expectError bool
+	}{
+		{"valid domain", "example.com", false},
+		{"valid wildcard", "*.example.com", false},
+		{"invalid format", "not a domain", true},
+	}
+
+	ctx := context.Background()
+	v := DomainValidator()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := validator.StringRequest{
+				Path:        path.Root("domain"),
+				ConfigValue: types.StringValue(tt.input),
+			}
+
+			resp := &validator.StringResponse{}
+			v.ValidateString(ctx, req, resp)
+
+			hasError := resp.Diagnostics.HasError()
+			if hasError != tt.expectError {
+				t.Errorf("DomainValidator for %q: hasError = %v, expected %v", tt.input, hasError, tt.expectError)
+			}
+		})
+	}
+}
+
+func TestPortValidator(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       int64
+		expectError bool
+	}{
+		{"valid port 80", 80, false},
+		{"valid port 443", 443, false},
+		{"valid port 1", 1, false},
+		{"valid port 65535", 65535, false},
+		{"invalid port 0", 0, true},
+		{"invalid port negative", -1, true},
+		{"invalid port too high", 65536, true},
+	}
+
+	ctx := context.Background()
+	v := PortValidator()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := validator.Int64Request{
+				Path:        path.Root("port"),
+				ConfigValue: types.Int64Value(tt.input),
+			}
+
+			resp := &validator.Int64Response{}
+			v.ValidateInt64(ctx, req, resp)
+
+			hasError := resp.Diagnostics.HasError()
+			if hasError != tt.expectError {
+				t.Errorf("PortValidator for %d: hasError = %v, expected %v", tt.input, hasError, tt.expectError)
+			}
+		})
+	}
+}
+
+func TestNonEmptyStringValidator(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		expectError bool
+	}{
+		{"valid string", "hello", false},
+		{"valid with spaces", "hello world", false},
+		{"invalid empty", "", true},
+		{"invalid whitespace only", "   ", true},
+		{"invalid tabs only", "\t\t", true},
+	}
+
+	ctx := context.Background()
+	v := NonEmptyStringValidator()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := validator.StringRequest{
+				Path:        path.Root("value"),
+				ConfigValue: types.StringValue(tt.input),
+			}
+
+			resp := &validator.StringResponse{}
+			v.ValidateString(ctx, req, resp)
+
+			hasError := resp.Diagnostics.HasError()
+			if hasError != tt.expectError {
+				t.Errorf("NonEmptyStringValidator for %q: hasError = %v, expected %v", tt.input, hasError, tt.expectError)
+			}
+		})
+	}
+}
+
+func TestLabelKeyValidator(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		expectError bool
+	}{
+		{"valid simple key", "app", false},
+		{"valid with prefix", "kubernetes.io/name", false},
+		{"valid with dots", "app.kubernetes.io/name", false},
+		{"invalid too long", string(make([]byte, 254)), true},
+	}
+
+	ctx := context.Background()
+	v := LabelKeyValidator()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := validator.StringRequest{
+				Path:        path.Root("label_key"),
+				ConfigValue: types.StringValue(tt.input),
+			}
+
+			resp := &validator.StringResponse{}
+			v.ValidateString(ctx, req, resp)
+
+			hasError := resp.Diagnostics.HasError()
+			if hasError != tt.expectError {
+				t.Errorf("LabelKeyValidator for %q: hasError = %v, expected %v", tt.input, hasError, tt.expectError)
+			}
+		})
+	}
+}
+
+func TestRequiredNameValidators(t *testing.T) {
+	validators := RequiredNameValidators()
+	if len(validators) != 2 {
+		t.Errorf("RequiredNameValidators() returned %d validators, expected 2", len(validators))
+	}
+}
+
+func TestRequiredNamespaceValidators(t *testing.T) {
+	validators := RequiredNamespaceValidators()
+	if len(validators) != 2 {
+		t.Errorf("RequiredNamespaceValidators() returned %d validators, expected 2", len(validators))
+	}
+}
+
+func TestOptionalDomainValidators(t *testing.T) {
+	validators := OptionalDomainValidators()
+	if len(validators) != 1 {
+		t.Errorf("OptionalDomainValidators() returned %d validators, expected 1", len(validators))
+	}
+}
+
+func TestValidatorDescriptions(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name      string
+		validator interface {
+			Description(context.Context) string
+			MarkdownDescription(context.Context) string
+		}
+	}{
+		{"NameValidator", NameValidator()},
+		{"NamespaceValidator", NamespaceValidator()},
+		{"DomainValidator", DomainValidator()},
+		{"LabelKeyValidator", LabelKeyValidator()},
+		{"NonEmptyStringValidator", NonEmptyStringValidator()},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			desc := tt.validator.Description(ctx)
+			mdDesc := tt.validator.MarkdownDescription(ctx)
+
+			if desc == "" {
+				t.Errorf("%s.Description() returned empty string", tt.name)
+			}
+			if mdDesc == "" {
+				t.Errorf("%s.MarkdownDescription() returned empty string", tt.name)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
Add comprehensive unit tests for 6 internal packages that previously showed `[no test files]` warnings in CI.

## Related Issue
Closes #526

## Changes Made
Added test files for:
- `internal/errors/errors_test.go` - 17 tests covering error types, API error creation, diagnostic helpers
- `internal/planmodifiers/planmodifiers_test.go` - 7 tests covering plan modifiers for unknown values, defaults
- `internal/privatestate/privatestate_test.go` - 11 tests covering private state management, JSON serialization
- `internal/stateupgraders/stateupgraders_test.go` - 11 tests covering state upgrade utilities, field operations
- `internal/timeouts/timeouts_test.go` - 11 tests covering timeout configurations, resource type detection
- `internal/validators/validators_test.go` - 14 tests covering name, namespace, domain, port validators

Total: 71 new tests across 6 packages.

## Testing
- [x] All tests pass locally with `go test ./internal/errors/... ./internal/planmodifiers/... ./internal/privatestate/... ./internal/stateupgraders/... ./internal/timeouts/... ./internal/validators/... -v`
- [x] Uses table-driven test patterns consistent with existing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)