### PR TITLE
fix(mcp): update server.json to current MCP Registry schema 2025-10-17

### DIFF
--- a/mcp-server/server.json
+++ b/mcp-server/server.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
   "name": "io.github.robinmordasiewicz/f5xc-terraform-mcp",
   "title": "F5 Distributed Cloud Terraform Provider",
   "description": "MCP server providing AI assistants with access to F5 Distributed Cloud Terraform provider documentation, 270+ OpenAPI specifications, subscription tier information, and addon service activation workflows.",


### PR DESCRIPTION
## Summary
Update `mcp-server/server.json` to use the current MCP Registry schema `2025-10-17` instead of the deprecated `2025-09-29` schema.

## Related Issue
Closes #529

## Changes Made
- Updated `$schema` URL from `2025-09-29` to `2025-10-17`

## Root Cause
The MCP Registry has deprecated the `2025-09-29` schema, causing the workflow to fail with:
```
Error: deprecated schema detected: https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json.
```

## Testing
- [x] Pre-commit hooks pass
- [x] File already uses camelCase field names (no migration needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)