### PR TITLE
fix(mcp): update schema to 2025-07-09 and validate before PR creation

### DIFF
--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -677,6 +677,19 @@ jobs:
           fs.writeFileSync('manifest.json', JSON.stringify(manifest, null, 2) + '\n');
           "
 
+      - name: Install mcp-publisher CLI
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_linux_amd64.tar.gz" | tar xz
+          sudo mv mcp-publisher /usr/local/bin/
+          mcp-publisher --version
+
+      - name: Authenticate via GitHub OIDC
+        run: mcp-publisher login github-oidc
+
+      - name: Validate server.json (dry run)
+        working-directory: mcp-server
+        run: mcp-publisher publish --dry-run --file server.json
+
       - name: Check for changes
         id: check
         run: |
@@ -703,19 +716,6 @@ jobs:
             This PR updates the server.json with the correct MCPB download URL and hash.
           labels: automated,mcp
           delete-branch: true
-
-      - name: Install mcp-publisher CLI
-        run: |
-          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_linux_amd64.tar.gz" | tar xz
-          sudo mv mcp-publisher /usr/local/bin/
-          mcp-publisher --version
-
-      - name: Authenticate via GitHub OIDC
-        run: mcp-publisher login github-oidc
-
-      - name: Validate server.json (dry run)
-        working-directory: mcp-server
-        run: mcp-publisher publish --dry-run --file server.json
 
       - name: Publish to MCP Registry
         working-directory: mcp-server

--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -141,6 +141,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      id-token: write
 
     steps:
       - name: Checkout
@@ -185,6 +186,19 @@ jobs:
           manifest.version = '$VERSION';
           fs.writeFileSync('manifest.json', JSON.stringify(manifest, null, 2) + '\n');
           "
+
+      - name: Install mcp-publisher CLI
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_linux_amd64.tar.gz" | tar xz
+          sudo mv mcp-publisher /usr/local/bin/
+          mcp-publisher --version
+
+      - name: Authenticate via GitHub OIDC
+        run: mcp-publisher login github-oidc
+
+      - name: Validate server.json (dry run)
+        working-directory: mcp-server
+        run: mcp-publisher publish --dry-run --file server.json
 
       - name: Check for changes
         id: check

--- a/mcp-server/server.json
+++ b/mcp-server/server.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-07-09/server.schema.json",
   "name": "io.github.robinmordasiewicz/f5xc-terraform-mcp",
   "title": "F5 Distributed Cloud Terraform Provider",
   "description": "MCP server providing AI assistants with access to F5 Distributed Cloud Terraform provider documentation, 270+ OpenAPI specifications, subscription tier information, and addon service activation workflows.",


### PR DESCRIPTION
## Summary
Two fixes for MCP Registry publication workflow:

1. **Schema update**: Update `server.json` schema from deprecated `2025-10-17` to current `2025-07-09`
2. **Logic fix**: Reorder workflow steps to validate BEFORE creating PR

## Related Issue
Closes #532

## Changes Made

### 1. Schema Update
Updated `mcp-server/server.json`:
```diff
- "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json"
+ "$schema": "https://static.modelcontextprotocol.io/schemas/2025-07-09/server.schema.json"
```

### 2. Workflow Logic Fix
Reordered steps in both `on-merge.yml` and `publish-mcp-registry.yml`:

**Before (wrong order):**
1. Update server.json
2. Check for changes
3. Create PR ← PR created even if validation fails!
4. Install mcp-publisher
5. Validate (dry run)
6. Publish

**After (correct order):**
1. Update server.json
2. Install mcp-publisher
3. Authenticate via OIDC
4. Validate (dry run) ← Fails here if schema invalid
5. Check for changes
6. Create PR ← Only runs if validation passed
7. Publish

This prevents chore PRs like `chore(mcp): update server.json to v2.12.6` from being created when mcp-publisher validation fails.

## Testing
- [x] Pre-commit hooks pass
- [x] Schema version verified via Perplexity search (2025-07-09 is current)

🤖 Generated with [Claude Code](https://claude.com/claude-code)