### PR TITLE
fix(mcp): restore schema to 2025-09-29 (actual current version)

### DIFF
--- a/mcp-server/server.json
+++ b/mcp-server/server.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-07-09/server.schema.json",
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "io.github.robinmordasiewicz/f5xc-terraform-mcp",
   "title": "F5 Distributed Cloud Terraform Provider",
   "description": "MCP server providing AI assistants with access to F5 Distributed Cloud Terraform provider documentation, 270+ OpenAPI specifications, subscription tier information, and addon service activation workflows.",


### PR DESCRIPTION
## Summary

Restores the MCP Registry schema URL to `2025-09-29`, which is the actual current version according to the [official CHANGELOG](https://github.com/modelcontextprotocol/registry/blob/main/docs/reference/server-json/CHANGELOG.md).

## Related Issue

Closes #534

## Root Cause

The Perplexity search in PR #533 returned outdated information, incorrectly identifying `2025-07-09` as the current schema version. The MCP Registry CHANGELOG clearly shows `2025-09-29` is the current version with camelCase field names.

## Schema History

| PR | Schema Version | Status |
|---|---|---|
| Original | 2025-09-29 | ✅ Correct |
| #530 | 2025-10-17 | ❌ Deprecated |
| #533 | 2025-07-09 | ❌ Deprecated |
| This PR | 2025-09-29 | ✅ Correct |

## Changes Made

- Updated `mcp-server/server.json` `$schema` URL from `2025-07-09` to `2025-09-29`

## Verification

- Schema URL confirmed via direct fetch of https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json
- CHANGELOG confirms 2025-09-29 is current version with camelCase field names
- Our server.json already uses correct camelCase fields (`registryType`, `fileSha256`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)