### PR TITLE
fix(mcp): update schema to 2025-12-11 (actual current version)

### DIFF
--- a/mcp-server/server.json
+++ b/mcp-server/server.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.robinmordasiewicz/f5xc-terraform-mcp",
   "title": "F5 Distributed Cloud Terraform Provider",
   "description": "MCP server providing AI assistants with access to F5 Distributed Cloud Terraform provider documentation, 270+ OpenAPI specifications, subscription tier information, and addon service activation workflows.",


### PR DESCRIPTION
## Summary

Updates the MCP Registry schema URL to `2025-12-11`, which is the actual current version according to the [official CHANGELOG](https://github.com/modelcontextprotocol/registry/blob/main/docs/reference/server-json/CHANGELOG.md).

## Related Issue

Closes #536

## Root Cause

The MCP Registry is rapidly deprecating older schema versions. The CHANGELOG shows a clear progression:
- `2025-07-09` ← deprecated
- `2025-09-29` ← deprecated  
- `2025-10-17` ← deprecated
- **`2025-12-11` ← CURRENT**

## Schema History

| PR | Schema Version | Status |
|---|---|---|
| Original | 2025-09-29 | ❌ Deprecated |
| #530 | 2025-10-17 | ❌ Deprecated |
| #533 | 2025-07-09 | ❌ Deprecated |
| #535 | 2025-09-29 | ❌ Deprecated |
| This PR | 2025-12-11 | ✅ Current |

## Changes Made

- Updated `mcp-server/server.json` `$schema` URL from `2025-09-29` to `2025-12-11`

## Verification

- Schema URL confirmed via direct fetch of https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)