### PR TITLE
fix(mcp): shorten description to meet 100 char limit

### DIFF
--- a/mcp-server/server.json
+++ b/mcp-server/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.robinmordasiewicz/f5xc-terraform-mcp",
   "title": "F5 Distributed Cloud Terraform Provider",
-  "description": "MCP server providing AI assistants with access to F5 Distributed Cloud Terraform provider documentation, 270+ OpenAPI specifications, subscription tier information, and addon service activation workflows.",
+  "description": "F5 Distributed Cloud Terraform provider docs, 270+ OpenAPI specs, and subscription info for AI.",
   "version": "2.12.1",
   "packages": [
     {


### PR DESCRIPTION
## Summary

Shortens the MCP server description to meet the 100 character limit introduced in schema version 2025-12-11.

## Related Issue

Closes #538

## Root Cause

The 2025-12-11 schema introduced a 100 character limit on the description field. Our description was 196 characters.

## Changes Made

**Before (196 chars):**
```
MCP server providing AI assistants with access to F5 Distributed Cloud Terraform provider documentation, 270+ OpenAPI specifications, subscription tier information, and addon service activation workflows.
```

**After (95 chars):**
```
F5 Distributed Cloud Terraform provider docs, 270+ OpenAPI specs, and subscription info for AI.
```

## Testing

- Length verified: `echo "..." | wc -c` = 96 (including newline) = 95 chars

🤖 Generated with [Claude Code](https://claude.com/claude-code)