### PR TITLE
fix(ci): move PR creation after publish in MCP Registry workflow

### DIFF
--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -699,6 +699,20 @@ jobs:
             echo "changed=true" >> $GITHUB_OUTPUT
           fi
 
+      # IMPORTANT: Publish BEFORE creating PR to ensure no spurious PRs on failure
+      # If publish fails, the job stops and no PR is created
+      - name: Publish to MCP Registry
+        working-directory: mcp-server
+        run: mcp-publisher publish --file server.json
+
+      - name: Verify publication
+        run: |
+          SERVER_NAME=$(jq -r '.name' mcp-server/server.json)
+          echo "Verifying publication of: $SERVER_NAME"
+          sleep 3
+          curl -s "https://registry.modelcontextprotocol.io/v0/servers?search=${SERVER_NAME}" | jq '.'
+
+      # Create PR only AFTER successful publish to prevent spurious PRs
       - name: Create Pull Request for server.json update
         if: steps.check.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@v6
@@ -716,17 +730,6 @@ jobs:
             This PR updates the server.json with the correct MCPB download URL and hash.
           labels: automated,mcp
           delete-branch: true
-
-      - name: Publish to MCP Registry
-        working-directory: mcp-server
-        run: mcp-publisher publish --file server.json
-
-      - name: Verify publication
-        run: |
-          SERVER_NAME=$(jq -r '.name' mcp-server/server.json)
-          echo "Verifying publication of: $SERVER_NAME"
-          sleep 3
-          curl -s "https://registry.modelcontextprotocol.io/v0/servers?search=${SERVER_NAME}" | jq '.'
 
   # ===========================================================================
   # Summary


### PR DESCRIPTION
## Summary

Fixes the logic error where spurious chore PRs were created even when the MCP Registry publish workflow failed.

## Related Issue

Closes #541

## Problem

The `publish-mcp-registry` job was creating PRs for server.json updates **before** the actual MCP Registry publish step. This caused PRs like #540 to be created even when the workflow failed.

**Previous order:**
1. Validate server.json (dry run)
2. Check for changes
3. **Create Pull Request** ← PR created here
4. **Publish to MCP Registry** ← but this step might fail AFTER PR is created

## Solution

Reorder steps so PR is only created after successful publish:

**New order:**
1. Validate server.json (dry run)
2. Check for changes
3. **Publish to MCP Registry** ← now before PR creation
4. Verify publication
5. **Create Pull Request** ← only after successful publish

This ensures:
- ❌ Validation failure → job stops, no PR
- ❌ Publish failure → job stops, no PR
- ✅ Publish success → Create PR with version updates

## Testing

This is a workflow logic change that will be validated when the next merge to main triggers the `publish-mcp-registry` job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)