### PR TITLE
feat(pre-commit): add JSON/YAML schema validation hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,6 +36,60 @@ repos:
 
       - id: check-toml
 
+  # =============================================================================
+  # JSON/YAML Schema Validation - validate against official schemas
+  # Catches structural errors BEFORE they reach CI/CD
+  # =============================================================================
+  - repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: 0.34.0
+    hooks:
+      # GitHub Workflows (built-in hook validates against SchemaStore)
+      - id: check-github-workflows
+        args: ["--verbose"]
+
+      # Docker Compose (built-in hook validates against SchemaStore)
+      - id: check-compose-spec
+        files: docker-compose\.yml$
+
+      # GoReleaser config
+      - id: check-jsonschema
+        name: Validate GoReleaser config
+        files: ^\.goreleaser\.yml$
+        types: [yaml]
+        args: ["--schemafile", "https://goreleaser.com/static/schema.json"]
+
+      # GolangCI-lint config
+      - id: check-jsonschema
+        name: Validate GolangCI-lint config
+        files: ^\.golangci\.yml$
+        types: [yaml]
+        args: ["--schemafile", "https://golangci-lint.run/jsonschema/golangci.jsonschema.json"]
+
+      # Pre-commit config (self-validation)
+      - id: check-jsonschema
+        name: Validate pre-commit config
+        files: ^\.pre-commit-config\.yaml$
+        types: [yaml]
+        args: ["--schemafile", "https://www.schemastore.org/pre-commit-config.json"]
+
+      # TypeScript config
+      - id: check-jsonschema
+        name: Validate TypeScript config
+        files: tsconfig\.json$
+        types: [json]
+        args: ["--schemafile", "https://www.schemastore.org/tsconfig.json"]
+
+      # MCP Server manifest (validates against embedded $schema)
+      - id: check-metaschema
+        name: Validate MCP server.json against its $schema
+        files: ^mcp-server/server\.json$
+
+  # =============================================================================
+  # General file checks - security and safety (continued)
+  # =============================================================================
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
       # Security and safety checks
       - id: check-added-large-files
         args: [--maxkb=1000]


### PR DESCRIPTION
## Summary

Add comprehensive JSON and YAML schema validation using `check-jsonschema` (v0.34.0) pre-commit hooks to catch structural errors before they reach CI/CD.

## Related Issue

Closes #545

## Changes Made

### Schema Validation Hooks (`.pre-commit-config.yaml`)

Added 7 schema validation hooks:

| Hook | Files | Schema Source |
|------|-------|---------------|
| `check-github-workflows` | `.github/workflows/*.yml` | SchemaStore (built-in) |
| `check-compose-spec` | `docker-compose.yml` | SchemaStore (built-in) |
| `check-jsonschema` | `.goreleaser.yml` | `goreleaser.com/static/schema.json` |
| `check-jsonschema` | `.golangci.yml` | `golangci-lint.run/jsonschema/golangci.jsonschema.json` |
| `check-jsonschema` | `.pre-commit-config.yaml` | SchemaStore (self-validation) |
| `check-jsonschema` | `tsconfig.json` | SchemaStore |
| `check-metaschema` | `mcp-server/server.json` | Validates against embedded `$schema` |

### Advisory Hook Fix (`scripts/update-subscription-metadata.sh`)

Fixed the subscription metadata update hook to be truly advisory:
- Added 30-second timeout to prevent blocking on network issues
- Gracefully skips (exit 0) on timeout or network errors instead of failing
- Works on both Linux (`timeout`) and macOS (`gtimeout`)

## Exclusions

- `docs/specifications/api/*` - External OpenAPI specs (not controlled by us)
- `package.json`, `package-lock.json` - npm handles validation
- `tools/*.json` - Custom internal formats without published schemas

## Testing

- [x] All new schema validation hooks pass on all files
- [x] Self-validation of `.pre-commit-config.yaml` passes
- [x] Subscription metadata hook now handles timeouts gracefully
- [x] All existing pre-commit hooks still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)