### PR TITLE
feat(pre-commit): auto-add subscription metadata on every commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -228,21 +228,21 @@ repos:
         pass_filenames: false
 
   # =============================================================================
-  # Subscription Tier Metadata Update (Optional)
+  # Subscription Tier Metadata Update
   # =============================================================================
-  # Updates subscription tier metadata from F5 XC Catalog API when generator changes
-  # Skips gracefully if F5XC credentials are not available
+  # Fetches latest subscription tier metadata from F5 XC Catalog API on every commit.
+  # Requires VPN access and F5XC credentials (F5XC_API_URL + F5XC_API_TOKEN or P12).
+  # If data changes, the file is automatically added to the commit.
+  # Skips gracefully if credentials are not configured - does not block commits.
   - repo: local
     hooks:
       - id: update-subscription-metadata
         name: Update subscription tier metadata
         entry: scripts/update-subscription-metadata.sh
         language: system
-        files: ^tools/generate-subscription-metadata\.go$
+        always_run: true
         pass_filenames: false
         stages: [pre-commit]
-        # This hook is advisory - it won't fail if credentials are unavailable
-        # When credentials are set, it updates tools/subscription-tiers.json
 
 # =============================================================================
 # CI Configuration

--- a/scripts/update-subscription-metadata.sh
+++ b/scripts/update-subscription-metadata.sh
@@ -6,8 +6,12 @@
 # tools/subscription-tiers.json with the latest tier information from the
 # F5 XC Catalog API.
 #
-# The generated file is committed to the repository and changes trigger
-# documentation regeneration in CI/CD.
+# When run as a pre-commit hook:
+# - Fetches latest subscription tier data from F5 XC API (requires VPN)
+# - If data has changed, automatically adds the file to the current commit
+# - Skips gracefully if credentials are unavailable
+#
+# The generated file triggers documentation regeneration in CI/CD when changed.
 #
 # Required Environment Variables:
 #   F5XC_API_URL      - F5 XC API URL (e.g., https://console.ves.volterra.io)
@@ -130,7 +134,6 @@ main() {
             exit 1
         else
             echo -e "${GREEN}Updated subscription tier metadata${NC}"
-            echo "Changes detected - please commit tools/subscription-tiers.json"
 
             # Show summary of changes
             if command -v jq &> /dev/null; then
@@ -142,6 +145,12 @@ main() {
                 echo "  Services: ${services}"
                 echo "  Resources: ${resources}"
                 echo "  Advanced tier resources: ${advanced}"
+            fi
+
+            # Auto-add to current commit (for pre-commit hook integration)
+            if git rev-parse --git-dir > /dev/null 2>&1; then
+                git add "${METADATA_FILE}"
+                echo -e "${GREEN}Added ${METADATA_FILE} to commit${NC}"
             fi
             exit 0
         fi


### PR DESCRIPTION
## Summary

Modifies the subscription metadata pre-commit hook to:
- Run on **every commit** (not just when the generator changes)
- **Auto-add** `tools/subscription-tiers.json` to the commit when it changes
- Continue to skip gracefully for developers without credentials

## Changes Made

### `scripts/update-subscription-metadata.sh`
- Added `git add` command to auto-stage metadata file when it changes
- Updated script header comments to document VPN/credentials requirements

### `.pre-commit-config.yaml`
- Changed from `files: ^tools/generate-subscription-metadata\.go$` to `always_run: true`
- Updated comments to reflect new behavior

## Testing

- ✅ Script runs successfully with VPN credentials
- ✅ Script skips gracefully without credentials (exit 0)
- ✅ `--check` mode still works for CI validation
- ✅ All pre-commit hooks pass

## Related Issue

Closes #547

🤖 Generated with [Claude Code](https://claude.com/claude-code)