### PR TITLE
fix(ci): resolve MCP Registry publish race condition

### DIFF
--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -567,18 +567,19 @@ jobs:
       gpg-passphrase: ${{ secrets.PASSPHRASE }}
 
   # ===========================================================================
-  # STEP 7: Publish to MCP Registry (after release is created)
+  # STEP 7: Publish to MCP Registry (after npm package is published)
   # ===========================================================================
   # This job publishes the MCP server to the official MCP Registry.
-  # It runs directly after tag-release instead of relying on release triggers,
-  # because releases created by GITHUB_TOKEN don't trigger other workflows.
+  # It must run AFTER sync-mcp-version because the MCP Registry validates
+  # that the referenced npm package exists before accepting publication.
   publish-mcp-registry:
     name: Publish MCP Registry
-    needs: [tag-release]
+    needs: [tag-release, sync-mcp-version]
     if: |
       always() &&
       needs.tag-release.result == 'success' &&
-      needs.tag-release.outputs.tag-created == 'true'
+      needs.tag-release.outputs.tag-created == 'true' &&
+      needs.sync-mcp-version.result == 'success'
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Summary

Fixes the race condition where `publish-mcp-registry` was failing because it ran in parallel with `sync-mcp-version`, attempting to validate the npm package before it was published.

## Related Issue

Closes #549

## Root Cause

The `publish-mcp-registry` job only depended on `tag-release`, allowing it to run simultaneously with `sync-mcp-version`. When MCP Registry validation checked if the npm package existed, it returned a 404 because `sync-mcp-version` hadn't finished publishing yet.

```
Current Flow (BROKEN):
                    ┌─────────────────────┐
                    │   tag-release       │
                    └──────────┬──────────┘
                               │
              ┌────────────────┼────────────────┐
              ▼                                 ▼
┌─────────────────────┐           ┌─────────────────────┐
│ sync-mcp-version    │           │ publish-mcp-registry│
│ (publishes to npm)  │           │ (validates npm pkg) │  ← FAILS: npm pkg not found!
└─────────────────────┘           └─────────────────────┘
```

## Changes Made

- Added `sync-mcp-version` to `publish-mcp-registry` job's `needs:` array
- Added `needs.sync-mcp-version.result == 'success'` to the job's `if` condition

```
Fixed Flow:
┌─────────────────────┐
│   tag-release       │
└──────────┬──────────┘
           │
           ▼
┌─────────────────────┐
│ sync-mcp-version    │  ← Publishes to npm FIRST
└──────────┬──────────┘
           │
           ▼
┌─────────────────────┐
│ publish-mcp-registry│  ← Now npm package exists!
└─────────────────────┘
```

## Testing

- [x] Pre-commit hooks pass (including GitHub Workflows schema validation)
- [x] YAML syntax validated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>