### PR TITLE
fix(mcp): read version from package.json instead of hardcoded value

### DIFF
--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -15,8 +15,14 @@
  * @see https://www.npmjs.com/package/@robinmordasiewicz/f5xc-terraform-mcp
  */
 
+import { createRequire } from 'module';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+
+// Read version from package.json at runtime
+const require = createRequire(import.meta.url);
+const packageJson = require('../package.json');
+const VERSION = packageJson.version;
 
 import { ResponseFormat } from './types.js';
 import {
@@ -81,7 +87,7 @@ const CHARACTER_LIMIT = 50000; // Maximum response size
 // Create MCP server instance
 const server = new McpServer({
   name: 'f5xc-terraform-mcp',
-  version: '1.0.0',
+  version: VERSION,
 });
 
 // =============================================================================


### PR DESCRIPTION
## Summary

The MCP server was reporting version `'1.0.0'` while the actual npm package version is `2.4.3`. This fix reads the version from `package.json` at runtime.

## Related Issue

Closes #551

## Changes Made

- Added `createRequire` import from Node.js `module` package
- Read `package.json` at runtime to get the version
- Use the dynamic `VERSION` constant in server configuration

## Testing

- [x] Pre-commit hooks pass
- [x] TypeScript compilation should work (uses standard Node.js APIs)

## Additional Context

This change triggers the full CI/CD pipeline including:
- Build and test
- MCP server build
- Tag and release
- npm publish
- MCP Registry publish

This will verify the race condition fix from #550.

🤖 Generated with Claude Code

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>