### PR TITLE
fix(ci): add force-publish input for sync-mcp-version job

### DIFF
--- a/.github/workflows/_build-mcp-server.yml
+++ b/.github/workflows/_build-mcp-server.yml
@@ -10,6 +10,11 @@ on:
         required: false
         default: false
         type: boolean
+      force-publish:
+        description: 'Force publish even without detected changes (for version sync)'
+        required: false
+        default: false
+        type: boolean
     outputs:
       changed:
         description: 'Whether the MCP server had changes'
@@ -85,7 +90,7 @@ jobs:
           fi
 
       - name: Publish to npm
-        if: inputs.publish && steps.check.outputs.has_changes == 'true'
+        if: inputs.publish && (inputs.force-publish || steps.check.outputs.has_changes == 'true')
         env:
           NODE_AUTH_TOKEN: ${{ secrets.npm-token }}
         run: |

--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -298,6 +298,7 @@ jobs:
     uses: ./.github/workflows/_build-mcp-server.yml
     with:
       publish: true
+      force-publish: true  # Sync version regardless of file changes in commit
     secrets:
       npm-token: ${{ secrets.NPM_TOKEN }}
 


### PR DESCRIPTION
## Summary

The `sync-mcp-version` job was skipping npm publish because the `has_changes` check looked at the current commit, not whether a version sync was needed. This caused `publish-mcp-registry` to fail with misleading "duplicate version" errors - the version was never actually published to npm.

## Related Issue

Closes #557

## Root Cause

1. `sync-mcp-version` runs after `tag-release` creates a new version tag
2. It calls `_build-mcp-server.yml` with `publish: true`
3. The workflow checks if `mcp-server/` or `docs/` changed in the **current commit**
4. When `sync-mcp-version` runs, the commit doesn't contain MCP changes
5. `has_changes=false` → npm publish was **SKIPPED**
6. `publish-mcp-registry` failed because npm didn't have the new version

## Changes Made

- Add `force-publish` input to `_build-mcp-server.yml`
- Use `force-publish: true` in `sync-mcp-version` job
- npm publish now runs when `force-publish` is true OR `has_changes` is true

## Expected Flow After Fix

```
Human commit → tag-release (v2.14.3) → sync-mcp-version
  → force-publish=true → npm publish 2.14.3 ✅
  → publish-mcp-registry → MCP Registry publish ✅
```

## Testing

- [ ] Workflow syntax validates
- [ ] Manual merge and monitor on-merge workflow
- [ ] Verify npm has new version
- [ ] Verify MCP Registry publish succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)