### PR TITLE
test(mcp): add infrastructure-as-code keyword to package.json

### DIFF
--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -34,7 +34,8 @@
     "terraform-provider",
     "ai",
     "claude",
-    "openapi"
+    "openapi",
+    "infrastructure-as-code"
   ],
   "author": "Robin Mordasiewicz",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Small metadata change to verify MCP Registry publishing pipeline after fix #558.

## Related Issue

Closes #559

## Purpose

This PR verifies that the `force-publish` fix works correctly:
1. `tag-release` creates a new version tag
2. `sync-mcp-version` publishes to npm (should NOT skip due to force-publish)
3. `publish-mcp-registry` publishes to MCP Registry successfully

## Change

Added `infrastructure-as-code` keyword to package.json - legitimate metadata improvement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)