### PR TITLE
test: verify force-publish fix with new version

### DIFF
--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -35,7 +35,8 @@
     "ai",
     "claude",
     "openapi",
-    "infrastructure-as-code"
+    "infrastructure-as-code",
+    "iac"
   ],
   "author": "Robin Mordasiewicz",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Trigger v2.14.4 release to verify the `force-publish` fix works end-to-end for NEW versions.

## Background

The previous test (PR #560) confirmed:
- ✅ `force-publish: true` correctly bypassed the `has_changes` check
- ✅ `sync-mcp-version` successfully published 2.14.3 to npm

However, MCP Registry failed because v2.14.3 was already registered from a previous (broken) run. This is expected behavior - you cannot republish the same version.

## Expected Outcome

This PR will trigger v2.14.4, which should:
1. ✅ Tag and Release creates v2.14.4
2. ✅ `sync-mcp-version` publishes 2.14.4 to npm (force-publish=true)
3. ✅ `publish-mcp-registry` publishes 2.14.4 to MCP Registry (NEW version)

## Test Plan

- [ ] Monitor on-merge workflow after merging
- [ ] Verify `sync-mcp-version` succeeds
- [ ] Verify `publish-mcp-registry` succeeds (this is the KEY test)
- [ ] Confirm npm has 2.14.4: `npm view @robinmordasiewicz/f5xc-terraform-mcp version`

## Related Issue

Closes #561

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)