### PR TITLE
fix(ci): handle MCP Registry duplicate version gracefully

### DIFF
--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -707,7 +707,20 @@ jobs:
       # If publish fails, the job stops and no PR is created
       - name: Publish to MCP Registry
         working-directory: mcp-server
-        run: mcp-publisher publish --file server.json
+        run: |
+          OUTPUT=$(mcp-publisher publish --file server.json 2>&1) || {
+            if echo "$OUTPUT" | grep -q "cannot publish duplicate version"; then
+              echo "⚠️ Version already exists in MCP Registry - treating as success"
+              echo "$OUTPUT"
+              exit 0
+            else
+              echo "❌ MCP Registry publish failed:"
+              echo "$OUTPUT"
+              exit 1
+            fi
+          }
+          echo "✅ Published to MCP Registry"
+          echo "$OUTPUT"
 
       - name: Verify publication
         run: |


### PR DESCRIPTION
## Summary

Handle MCP Registry "duplicate version" errors gracefully to prevent workflow failures when a version is already registered.

## Problem

The `publish-mcp-registry` job fails when attempting to publish a version that already exists in the MCP Registry:
```
Error: publish failed: server returned status 400: {"errors":[{"message":"invalid version: cannot publish duplicate version"}]}
```

This occurred because:
1. Earlier broken CI runs had npm publish skipped (bug fixed in PR #558)
2. But MCP Registry publish succeeded (it doesn't depend on npm)
3. Creating orphaned versions in MCP Registry

## Solution

Updated the "Publish to MCP Registry" step to:
- Attempt to publish
- If "duplicate version" error occurs, log warning and treat as success
- Only fail on other errors

## Test Plan

After merging, the next release should:
1. ✅ Tag and Release creates new version
2. ✅ `sync-mcp-version` publishes to npm
3. ✅ `publish-mcp-registry` either publishes OR logs "version already exists" and succeeds

## Related Issue

Closes #563

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)