### PR TITLE
test: verify full pipeline with MCP Registry fix

### DIFF
--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -36,7 +36,8 @@
     "claude",
     "openapi",
     "infrastructure-as-code",
-    "iac"
+    "iac",
+    "api-documentation"
   ],
   "author": "Robin Mordasiewicz",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Final verification that both CI fixes work together for v2.14.5.

## Fixes Being Verified

1. **PR #558**: `force-publish: true` - ensures npm publish is not skipped
2. **PR #564**: `duplicate version` handling - treats already-registered versions as success

## Expected Outcome

After merging, workflow should:
1. ✅ Tag and Release creates v2.14.5
2. ✅ `sync-mcp-version` publishes 2.14.5 to npm (force-publish=true)
3. ✅ `publish-mcp-registry` either:
   - Publishes 2.14.5 to MCP Registry (new version), OR
   - Logs "version already exists" and succeeds (if already registered)

## Test Plan

- [ ] Monitor on-merge workflow after merging
- [ ] Verify all jobs succeed (no failures)
- [ ] Confirm npm has 2.14.5: `npm view @robinmordasiewicz/f5xc-terraform-mcp version`

## Related Issue

Closes #565

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)