### PR TITLE
fix(ci): properly investigate MCP Registry duplicate version errors

### DIFF
--- a/.github/workflows/_build-mcp-server.yml
+++ b/.github/workflows/_build-mcp-server.yml
@@ -10,11 +10,6 @@ on:
         required: false
         default: false
         type: boolean
-      force-publish:
-        description: 'Force publish even without detected changes (for version sync)'
-        required: false
-        default: false
-        type: boolean
     outputs:
       changed:
         description: 'Whether the MCP server had changes'
@@ -89,8 +84,23 @@ jobs:
             echo "has_changes=false" >> $GITHUB_OUTPUT
           fi
 
+      - name: NPM Publish Diagnostics
+        if: inputs.publish
+        run: |
+          echo "=== NPM PUBLISH DIAGNOSTICS (build-mcp-server) ==="
+          echo "Workflow run ID: ${{ github.run_id }}"
+          echo "Publish input: ${{ inputs.publish }}"
+          echo "Has changes: ${{ steps.check.outputs.has_changes }}"
+          echo "Will attempt publish: ${{ steps.check.outputs.has_changes == 'true' && 'YES' || 'NO - no changes detected' }}"
+          echo "package.json version: $(node -p "require('./package.json').version")"
+          cd ..
+          echo "Git tag version: $(git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//' || echo 'NO TAGS')"
+          cd mcp-server
+          echo "npm registry version: $(npm view @robinmordasiewicz/f5xc-terraform-mcp version 2>/dev/null || echo 'NOT FOUND')"
+          echo "=================================================="
+
       - name: Publish to npm
-        if: inputs.publish && (inputs.force-publish || steps.check.outputs.has_changes == 'true')
+        if: inputs.publish && steps.check.outputs.has_changes == 'true'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.npm-token }}
         run: |

--- a/.github/workflows/_tag-release.yml
+++ b/.github/workflows/_tag-release.yml
@@ -94,6 +94,18 @@ jobs:
           echo "new_tag=$NEW_TAG" >> $GITHUB_OUTPUT
           echo "Next version: $NEW_TAG"
 
+      - name: Version Diagnostics
+        run: |
+          echo "=== VERSION DIAGNOSTICS (tag-release) ==="
+          echo "Workflow run ID: ${{ github.run_id }}"
+          echo "Triggered by SHA: ${{ github.sha }}"
+          echo "Current HEAD SHA: $(git rev-parse HEAD)"
+          echo "Latest git tag: ${{ steps.get_tag.outputs.latest_tag }}"
+          echo "Calculated next version: ${{ steps.version.outputs.new_tag }}"
+          echo "Version bump type: ${{ steps.version.outputs.bump }}"
+          echo "Tag exists check: $(git rev-parse ${{ steps.version.outputs.new_tag }} 2>/dev/null && echo 'YES - ALREADY EXISTS' || echo 'NO - WILL CREATE')"
+          echo "============================================"
+
       - name: Check if tag exists
         id: check
         run: |

--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -298,7 +298,6 @@ jobs:
     uses: ./.github/workflows/_build-mcp-server.yml
     with:
       publish: true
-      force-publish: true  # Sync version regardless of file changes in commit
     secrets:
       npm-token: ${{ secrets.NPM_TOKEN }}
 
@@ -703,31 +702,78 @@ jobs:
             echo "changed=true" >> $GITHUB_OUTPUT
           fi
 
+      - name: MCP Registry Diagnostics
+        run: |
+          echo "=== MCP REGISTRY DIAGNOSTICS (on-merge) ==="
+          echo "Workflow run ID: ${{ github.run_id }}"
+          echo "Tag-release output new-tag: ${{ needs.tag-release.outputs.new-tag }}"
+          echo "Version from step: ${{ steps.version.outputs.version }}"
+          echo "server.json version: $(jq -r '.version' mcp-server/server.json)"
+          echo "npm package version: $(npm view @robinmordasiewicz/f5xc-terraform-mcp version 2>/dev/null || echo 'NOT FOUND')"
+          echo ""
+          echo "Querying MCP Registry for current state..."
+          SERVER_NAME=$(jq -r '.name' mcp-server/server.json)
+          echo "Server name: $SERVER_NAME"
+          REGISTRY_RESPONSE=$(curl -s "https://registry.modelcontextprotocol.io/v0/servers?search=${SERVER_NAME}")
+          echo "Registry response:"
+          echo "$REGISTRY_RESPONSE" | jq '.'
+          REGISTRY_VERSION=$(echo "$REGISTRY_RESPONSE" | jq -r '.servers[0].version // "NOT FOUND"')
+          echo "Registry version: $REGISTRY_VERSION"
+          echo "=============================================="
+
+      - name: Validate MCP Registry publish is needed
+        id: mcp-check
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          SERVER_NAME=$(jq -r '.name' mcp-server/server.json)
+
+          # Query MCP Registry API for existing versions
+          REGISTRY_RESPONSE=$(curl -s "https://registry.modelcontextprotocol.io/v0/servers?search=${SERVER_NAME}")
+          REGISTRY_VERSION=$(echo "$REGISTRY_RESPONSE" | jq -r '.servers[0].version // "0.0.0"')
+
+          echo "Target version: $VERSION"
+          echo "Registry version: $REGISTRY_VERSION"
+
+          if [ "$VERSION" = "$REGISTRY_VERSION" ]; then
+            echo "::notice::Version $VERSION already exists in MCP Registry - SKIPPING publish"
+            echo "should-publish=false" >> $GITHUB_OUTPUT
+            echo "reason=already-registered" >> $GITHUB_OUTPUT
+          else
+            echo "Version $VERSION will be published to MCP Registry"
+            echo "should-publish=true" >> $GITHUB_OUTPUT
+          fi
+
       # IMPORTANT: Publish BEFORE creating PR to ensure no spurious PRs on failure
       # If publish fails, the job stops and no PR is created
       - name: Publish to MCP Registry
+        if: steps.mcp-check.outputs.should-publish == 'true'
         working-directory: mcp-server
-        run: |
-          OUTPUT=$(mcp-publisher publish --file server.json 2>&1) || {
-            if echo "$OUTPUT" | grep -q "cannot publish duplicate version"; then
-              echo "⚠️ Version already exists in MCP Registry - treating as success"
-              echo "$OUTPUT"
-              exit 0
-            else
-              echo "❌ MCP Registry publish failed:"
-              echo "$OUTPUT"
-              exit 1
-            fi
-          }
-          echo "✅ Published to MCP Registry"
-          echo "$OUTPUT"
+        run: mcp-publisher publish --file server.json
 
       - name: Verify publication
         run: |
           SERVER_NAME=$(jq -r '.name' mcp-server/server.json)
-          echo "Verifying publication of: $SERVER_NAME"
-          sleep 3
-          curl -s "https://registry.modelcontextprotocol.io/v0/servers?search=${SERVER_NAME}" | jq '.'
+          VERSION="${{ steps.version.outputs.version }}"
+          SKIPPED="${{ steps.mcp-check.outputs.should-publish == 'false' }}"
+
+          if [ "$SKIPPED" = "true" ]; then
+            echo "::notice::Publish was SKIPPED (version $VERSION already exists)"
+            echo "Verifying existing registration..."
+          else
+            echo "Verifying publication of: $SERVER_NAME@$VERSION"
+            sleep 3
+          fi
+
+          REGISTRY_RESPONSE=$(curl -s "https://registry.modelcontextprotocol.io/v0/servers?search=${SERVER_NAME}")
+          echo "Registry state:"
+          echo "$REGISTRY_RESPONSE" | jq '.'
+
+          REGISTRY_VERSION=$(echo "$REGISTRY_RESPONSE" | jq -r '.servers[0].version // "NOT FOUND"')
+          if [ "$REGISTRY_VERSION" = "$VERSION" ]; then
+            echo "✅ Version $VERSION is correctly registered in MCP Registry"
+          else
+            echo "::warning::Version mismatch - expected $VERSION, found $REGISTRY_VERSION"
+          fi
 
       # Create PR only AFTER successful publish to prevent spurious PRs
       - name: Create Pull Request for server.json update


### PR DESCRIPTION
## Summary

Reverts band-aid fixes that masked symptoms and adds proper diagnostics and pre-publish validation to properly understand and fix MCP Registry duplicate version errors.

## Related Issue

Closes #568

## Changes

### Reverted Band-Aid Fixes
- Removed `force-publish` input from `_build-mcp-server.yml`
- Removed `force-publish: true` from `sync-mcp-version` job in `on-merge.yml`
- Removed duplicate error suppression from `publish-mcp-registry` job

### Added Diagnostics
- **Version diagnostics** in `_tag-release.yml` before tag creation - logs workflow run ID, SHAs, calculated version, tag existence
- **NPM publish diagnostics** in `_build-mcp-server.yml` - logs package.json version, git tag version, npm registry version
- **MCP Registry diagnostics** in `on-merge.yml` - logs all version sources and queries registry for current state

### Added Pre-Publish Validation
- MCP Registry pre-check that queries registry BEFORE attempting publish
- **Skips gracefully** if version already exists (idempotent - no error)
- Enhanced verify step to confirm registration state matches expected version

## Expected Behavior

The workflow will now:
1. **Log version state** at each step for traceability
2. **Check registry state BEFORE publish** - not after failure
3. **Skip gracefully** if version already exists (no error masking)
4. **Fail properly** if something actually goes wrong

## Test Plan

- [ ] Verify workflow runs and diagnostic logs appear
- [ ] Verify pre-publish validation correctly detects existing versions
- [ ] Verify workflow completes successfully (skip or publish as appropriate)
- [ ] Analyze logs to identify root cause if duplicates still occur

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)