### PR TITLE
test: verify MCP Registry jq query fix works in live workflow

### DIFF
--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@
 // improving clarity by grouping related properties with a single explanatory note.
 //
 // Version tagging and releases are automated via CI/CD using semantic versioning.
+// MCP server documentation is available at https://github.com/robinmordasiewicz/terraform-provider-f5xc/tree/main/mcp-server
 
 package main
 


### PR DESCRIPTION
## Summary

Trigger a version bump to verify the MCP Registry jq query fix (#573) works correctly in a live workflow execution.

## Changes

Added MCP server documentation link to main.go header comment.

## Expected Verification After Merge

Watch workflow logs for:
1. `Registry latest version: 2.14.6` (NOT `0.0.0`)
2. `Version 2.14.7 will be published to MCP Registry`
3. Successful publish (no "duplicate version" error)
4. `✅ Version 2.14.7 is correctly registered as latest in MCP Registry`

## Related Issues

Closes #574
Verifies fix from #572 / PR #573

🤖 Generated with [Claude Code](https://claude.com/claude-code)