### PR TITLE
fix(ci): ensure npm publish runs on every tag release

### DIFF
--- a/.github/workflows/_build-mcp-server.yml
+++ b/.github/workflows/_build-mcp-server.yml
@@ -90,8 +90,8 @@ jobs:
           echo "=== NPM PUBLISH DIAGNOSTICS (build-mcp-server) ==="
           echo "Workflow run ID: ${{ github.run_id }}"
           echo "Publish input: ${{ inputs.publish }}"
-          echo "Has changes: ${{ steps.check.outputs.has_changes }}"
-          echo "Will attempt publish: ${{ steps.check.outputs.has_changes == 'true' && 'YES' || 'NO - no changes detected' }}"
+          echo "Has changes (for info only): ${{ steps.check.outputs.has_changes }}"
+          echo "Will attempt publish: ${{ inputs.publish == true && 'YES' || 'NO - publish not requested' }}"
           echo "package.json version: $(node -p "require('./package.json').version")"
           cd ..
           echo "Git tag version: $(git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//' || echo 'NO TAGS')"
@@ -100,7 +100,10 @@ jobs:
           echo "=================================================="
 
       - name: Publish to npm
-        if: inputs.publish && steps.check.outputs.has_changes == 'true'
+        # Publish whenever requested - version existence check handles idempotency
+        # Previously required mcp-server/ or docs/ changes, but this broke MCP Registry
+        # which needs npm package to exist for ANY version bump
+        if: inputs.publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.npm-token }}
         run: |


### PR DESCRIPTION
## Summary
Remove change detection condition from npm publish step to ensure all publishing steps run together on every version bump.

## Related Issue
Closes #576

## Problem
The workflow chain was broken because npm publish was conditional on changes to `mcp-server/` or `docs/` directories:

1. Tag release creates version vX.Y.Z ✅
2. npm publish is **skipped** (no mcp-server/ changes) ❌
3. MCP Registry fails with "NPM package not found" ❌

## Solution
Remove the change detection condition. The npm publish step already has idempotency via version existence check (lines 111-116), so running it every time is safe.

**Before:**
```yaml
if: inputs.publish && steps.check.outputs.has_changes == 'true'
```

**After:**
```yaml
if: inputs.publish
```

## Testing
This PR will verify:
1. npm publish runs even when only workflow files change
2. MCP Registry publish succeeds (npm package exists)
3. PR #573's jq query fix correctly detects registry versions

## Expected Workflow After Fix
```
Commit merges to main
  → tag-release: Creates v2.14.8
  → sync-mcp-version: Publishes to npm (always runs now)
  → publish-mcp-registry: Publishes to MCP Registry (npm exists)
SUCCESS
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)