### PR TITLE
chore(mcp): update server.json to v2.14.8

### DIFF
--- a/mcp-server/manifest.json
+++ b/mcp-server/manifest.json
@@ -3,7 +3,7 @@
   "name": "f5xc-terraform-mcp",
   "displayName": "F5 Distributed Cloud Terraform Provider",
   "description": "MCP server providing AI assistants with access to F5 Distributed Cloud Terraform provider documentation, 270+ OpenAPI specifications, subscription tier information, and addon service activation workflows.",
-  "version": "2.14.5",
+  "version": "2.14.8",
   "author": {
     "name": "Robin Mordasiewicz",
     "url": "https://github.com/robinmordasiewicz"

--- a/mcp-server/server.json
+++ b/mcp-server/server.json
@@ -3,12 +3,12 @@
   "name": "io.github.robinmordasiewicz/f5xc-terraform-mcp",
   "title": "F5 Distributed Cloud Terraform Provider",
   "description": "F5 Distributed Cloud Terraform provider docs, 270+ OpenAPI specs, and subscription info for AI.",
-  "version": "2.14.5",
+  "version": "2.14.8",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@robinmordasiewicz/f5xc-terraform-mcp",
-      "version": "2.14.5",
+      "version": "2.14.8",
       "transport": {
         "type": "stdio"
       },
@@ -16,12 +16,12 @@
     },
     {
       "registryType": "mcpb",
-      "identifier": "https://github.com/robinmordasiewicz/terraform-provider-f5xc/releases/download/v2.14.5/f5xc-terraform-mcp-2.14.5.mcpb",
-      "version": "2.14.5",
+      "identifier": "https://github.com/robinmordasiewicz/terraform-provider-f5xc/releases/download/v2.14.8/f5xc-terraform-mcp-2.14.8.mcpb",
+      "version": "2.14.8",
       "transport": {
         "type": "stdio"
       },
-      "fileSha256": "59a559925a27d86d0ccdbb2d2f34077fc3f24094e1ded9ce2862e10554dc7692"
+      "fileSha256": "c51f6d69b3c5332621b791d1c285bcac153b72fa1414f4570aec06d57e96ba82"
     }
   ],
   "repository": {


### PR DESCRIPTION
Automated update of server.json for MCP Registry publication.

**Version**: 2.14.8
**SHA256**: `c51f6d69b3c5332621b791d1c285bcac153b72fa1414f4570aec06d57e96ba82`

This PR updates the server.json with the correct MCPB download URL and hash.