### PR TITLE
test(mcp): verify JSON schema validation in mcp-unified job

### DIFF
--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -6,6 +6,8 @@
  * - Terraform provider documentation (resources, data sources, functions, guides)
  * - F5 Distributed Cloud OpenAPI specifications (270+ specs)
  * - Search and query capabilities for both documentation and API specs
+ * - Subscription tier information for resources and properties
+ * - Addon service activation workflows
  *
  * Version Synchronization:
  * The npm package version is automatically synced with GitHub releases via CI/CD.


### PR DESCRIPTION
## Summary
Verify the new JSON schema validation step in the mcp-unified workflow job works correctly.

## Related Issue
Closes #588

## Background
PR #587 replaced the fake `mcp-publisher publish --dry-run` (which was actually publishing!) with proper JSON schema validation using jq.

## Changes Made
- Updated MCP server header comment to document subscription tier and addon service features

## Testing
This PR triggers the mcp-unified job to confirm:
- [ ] The validation step runs and shows expected output
- [ ] npm publish works correctly
- [ ] MCP Registry publish works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)