### PR TITLE
chore(mcp): update server.json to v2.14.10

### DIFF
--- a/mcp-server/LICENSE
+++ b/mcp-server/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 MCP Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -1,346 +1,153 @@
-# F5 Distributed Cloud Terraform Provider MCP Server
+# MCP Registry
 
-A Model Context Protocol (MCP) server that provides AI assistants with comprehensive access to the F5 Distributed Cloud (F5XC) Terraform provider documentation and OpenAPI specifications.
+The MCP registry provides MCP clients with a list of MCP servers, like an app store for MCP servers.
 
-## Features
+[**📤 Publish my MCP server**](docs/modelcontextprotocol-io/quickstart.mdx) | [**⚡️ Live API docs**](https://registry.modelcontextprotocol.io/docs) | [**👀 Ecosystem vision**](docs/design/ecosystem-vision.md) | 📖 **[Full documentation](./docs)**
 
-- **144+ Resource Documentation**: Complete Terraform resource docs with arguments, attributes, and examples
-- **270+ OpenAPI Specifications**: Full F5XC API specifications for all services
-- **Intelligent Search**: Search across documentation and API specs with relevance scoring
-- **Schema Exploration**: Browse and query API schema definitions
-- **Endpoint Discovery**: Find API endpoints by pattern across all specifications
+## Development Status
 
-## Installation
+**2025-10-24 update**: The Registry API has entered an **API freeze (v0.1)** 🎉. For the next month or more, the API will remain stable with no breaking changes, allowing integrators to confidently implement support. This freeze applies to v0.1 while development continues on v0. We'll use this period to validate the API in real-world integrations and gather feedback to shape v1 for general availability. Thank you to everyone for your contributions and patience—your involvement has been key to getting us here!
 
-Choose the installation method that best fits your environment:
+**2025-09-08 update**: The registry has launched in preview 🎉 ([announcement blog post](https://blog.modelcontextprotocol.io/posts/2025-09-08-mcp-registry-preview/)). While the system is now more stable, this is still a preview release and breaking changes or data resets may occur. A general availability (GA) release will follow later. We'd love your feedback in [GitHub discussions](https://github.com/modelcontextprotocol/registry/discussions/new?category=ideas) or in the [#registry-dev Discord](https://discord.com/channels/1358869848138059966/1369487942862504016) ([joining details here](https://modelcontextprotocol.io/community/communication)).
 
-| Method | Best For | Requirements |
-|--------|----------|--------------|
-| [VSCode MCP Gallery](#vscode-mcp-gallery) | VSCode users (easiest) | VSCode 1.99+ |
-| [npx (Recommended)](#from-npm) | Developers with Node.js | Node.js 18+ |
-| [MCPB Bundle](#mcpb-bundle-no-nodejs-required) | Corporate laptops (no Node.js) | None |
-| [From Source](#from-source) | Contributors | Node.js 18+, npm |
-
-### VSCode MCP Gallery
-
-The easiest way to install for VSCode users. Choose from multiple options:
-
-**Option A: MCP Gallery Search (Recommended for VSCode 1.105+)**
-
-1. Open VSCode
-2. Open the Extensions view (`Ctrl+Shift+X` / `Cmd+Shift+X`)
-3. Type `@MCP` in the search box to filter MCP servers
-4. Search for `f5xc` or `F5 Distributed Cloud`
-5. Click **Install**
-
-**Option B: Command Palette**
-
-1. Open VSCode
-2. Press `Ctrl+Shift+P` / `Cmd+Shift+P` to open Command Palette
-3. Run `MCP: Add Server`
-4. Select `npm package`
-5. Enter: `@robinmordasiewicz/f5xc-terraform-mcp`
-6. Choose scope: **Global** (all workspaces) or **Workspace** (this project only)
-
-### From npm
-
-```bash
-npm install -g @robinmordasiewicz/f5xc-terraform-mcp
-```
-
-Or run directly with npx (no installation required):
-
-```bash
-npx @robinmordasiewicz/f5xc-terraform-mcp
-```
-
-### MCPB Bundle (No Node.js Required)
-
-For corporate environments where Node.js cannot be installed. The MCPB bundle is fully self-contained with all dependencies included.
-
-**For VSCode:**
-
-1. Download the latest `.mcpb` file from [GitHub Releases](https://github.com/robinmordasiewicz/terraform-provider-f5xc/releases)
-2. In VSCode, press `Ctrl+Shift+P` / `Cmd+Shift+P`
-3. Run `MCP: Add Server`
-4. Drag and drop the `.mcpb` file, or select it when prompted
-5. Run `MCP: List Servers` to verify installation
-
-**For Claude Desktop:**
-
-1. Download the latest `.mcpb` file from [GitHub Releases](https://github.com/robinmordasiewicz/terraform-provider-f5xc/releases)
-2. Double-click the file to install, or drag it into Claude Desktop
-3. Restart Claude Desktop to activate
-
-**File**: `f5xc-terraform-mcp-X.Y.Z.mcpb`
-
-> **Note:** MCPB bundles are automatically built and attached to each GitHub Release. No npm or Node.js installation is required. The bundle includes a self-contained Node.js runtime.
-
-### From Source
-
-```bash
-cd mcp-server
-npm install
-npm run build
-```
-
-## Configuration
-
-### Claude Desktop
-
-Add to your Claude Desktop configuration (`~/Library/Application Support/Claude/claude_desktop_config.json` on macOS):
-
-```json
-{
-  "mcpServers": {
-    "f5xc-terraform": {
-      "command": "npx",
-      "args": ["-y", "@robinmordasiewicz/f5xc-terraform-mcp"]
-    }
-  }
-}
-```
-
-Or if running from source:
-
-```json
-{
-  "mcpServers": {
-    "f5xc": {
-      "command": "node",
-      "args": ["/path/to/terraform-provider-f5xc/mcp-server/dist/index.js"]
-    }
-  }
-}
-```
-
-### Claude Code (CLI)
-
-Install the MCP server with a single command:
-
-```bash
-claude mcp add f5xc-terraform -- npx -y @robinmordasiewicz/f5xc-terraform-mcp
-```
-
-**Scope Options:**
-
-- `--scope local` (default): Available only in the current directory
-- `--scope project`: Shared with anyone who clones the repository (saved in `.mcp.json`)
-- `--scope user`: Available in all your Claude Code sessions
-
-Examples with different scopes:
-
-```bash
-# User-wide installation (recommended for personal use)
-claude mcp add --scope user f5xc-terraform -- npx -y @robinmordasiewicz/f5xc-terraform-mcp
-
-# Project-specific installation (for team collaboration)
-claude mcp add --scope project f5xc-terraform -- npx -y @robinmordasiewicz/f5xc-terraform-mcp
-```
-
-**Verify Installation:**
-
-```bash
-claude mcp list
-```
-
-You should see `f5xc-terraform` listed with a `✓ Connected` status.
-
-**Remove Server:**
-
-```bash
-claude mcp remove f5xc-terraform
-```
-
-### Visual Studio Code (with GitHub Copilot)
-
-VS Code 1.99+ supports MCP servers through GitHub Copilot. Configure by creating a `.vscode/mcp.json` file in your workspace:
-
-```json
-{
-  "servers": {
-    "f5xc-terraform": {
-      "command": "npx",
-      "args": ["-y", "@robinmordasiewicz/f5xc-terraform-mcp"]
-    }
-  }
-}
-```
-
-**Alternative: Command Palette**
-
-1. Open Command Palette (`Ctrl+Shift+P` / `Cmd+Shift+P`)
-2. Run `MCP: Add Server`
-3. Select `npm package`
-4. Enter: `@robinmordasiewicz/f5xc-terraform-mcp`
-
-**Alternative: Command Line**
-
-```bash
-code --add-mcp "{\"name\":\"f5xc-terraform\",\"command\":\"npx\",\"args\":[\"-y\",\"@robinmordasiewicz/f5xc-terraform-mcp\"]}"
-```
-
-**Global Configuration (User Settings)**
-
-To make the MCP server available across all workspaces, add to your VS Code user settings (`settings.json`):
-
-```json
-{
-  "mcp": {
-    "servers": {
-      "f5xc-terraform": {
-        "command": "npx",
-        "args": ["-y", "@robinmordasiewicz/f5xc-terraform-mcp"]
-      }
-    }
-  }
-}
-```
-
-**Verify VSCode Installation:**
-
-1. Press `Ctrl+Shift+P` / `Cmd+Shift+P`
-2. Run `MCP: List Servers`
-3. Look for `f5xc-terraform` with a green status indicator
-
-**Troubleshooting VSCode:**
-
-- **Server not appearing**: Restart VSCode after adding the server configuration
-- **Connection issues**: Check the Output panel (`View > Output`) and select "MCP" from the dropdown
-- **Node.js not found**: Use the [MCPB Bundle](#mcpb-bundle-no-nodejs-required) method instead
-
-## Available Tools
-
-### Documentation Tools
-
-| Tool | Description |
-|------|-------------|
-| `f5xc_terraform_search_docs` | Search provider documentation by keyword |
-| `f5xc_terraform_get_doc` | Get complete documentation for a resource |
-| `f5xc_terraform_list_docs` | List all available documentation |
-
-### API Specification Tools
-
-| Tool | Description |
-|------|-------------|
-| `f5xc_terraform_search_api_specs` | Search OpenAPI specifications |
-| `f5xc_terraform_get_api_spec` | Get a specific API specification |
-| `f5xc_terraform_find_endpoints` | Find API endpoints by URL pattern |
-| `f5xc_terraform_get_schema_definition` | Get a schema definition from a spec |
-| `f5xc_terraform_list_definitions` | List all definitions in a spec |
-
-### Subscription Tier Tools
-
-| Tool | Description |
-|------|-------------|
-| `f5xc_terraform_get_subscription_info` | Get subscription tier requirements for resources |
-| `f5xc_terraform_get_property_subscription_info` | Get property-level subscription tier indicators |
-
-### Addon Service Tools
-
-| Tool | Description |
-|------|-------------|
-| `f5xc_terraform_addon_list_services` | List available addon services with activation requirements |
-| `f5xc_terraform_addon_check_activation` | Check if an addon service is activated for the tenant |
-| `f5xc_terraform_addon_activation_workflow` | Get activation workflow and Terraform code for addons |
-
-### Utility Tools
-
-| Tool | Description |
-|------|-------------|
-| `f5xc_terraform_get_summary` | Get overview of all available docs and specs |
-
-## Usage Examples
-
-### Find HTTP Load Balancer Documentation
-
-```
-User: How do I configure an HTTP load balancer in F5XC with Terraform?
-
-Claude: [Uses f5xc_terraform_search_docs with query "http_loadbalancer"]
-        [Uses f5xc_terraform_get_doc with name "http_loadbalancer"]
-```
-
-### Discover API Endpoints
-
-```
-User: What API endpoints are available for managing namespaces?
-
-Claude: [Uses f5xc_terraform_find_endpoints with pattern "/namespaces"]
-```
-
-### Explore Schema Definitions
-
-```
-User: What fields are available in the app_firewall configuration?
-
-Claude: [Uses f5xc_terraform_get_api_spec with name "app_firewall"]
-        [Uses f5xc_terraform_list_definitions with spec_name "app_firewall"]
-        [Uses f5xc_terraform_get_schema_definition for specific type]
-```
-
-## Development
-
-### Build
-
-```bash
-npm run build
-```
-
-### Development Mode (with auto-reload)
-
-```bash
-npm run dev
-```
-
-### Type Check
-
-```bash
-npm run typecheck
-```
-
-## Architecture
-
-```
-mcp-server/
-├── src/
-│   ├── index.ts          # MCP server entry point
-│   ├── types.ts          # TypeScript type definitions
-│   ├── schemas/          # Zod validation schemas
-│   │   └── index.ts
-│   └── services/         # Core services
-│       ├── documentation.ts   # Doc loading and search
-│       └── api-specs.ts       # OpenAPI spec handling
-├── package.json
-├── tsconfig.json
-└── README.md
-```
-
-## Resources Served
-
-### Documentation Types
-
-- **Resources**: Terraform resources (http_loadbalancer, origin_pool, namespace, etc.)
-- **Data Sources**: Terraform data sources for reading existing resources
-- **Functions**: Provider-defined functions (blindfold, blindfold_file)
-- **Guides**: Step-by-step tutorials and how-to guides
-
-### API Specifications
-
-All F5 Distributed Cloud public APIs including:
-- HTTP/TCP Load Balancers
-- Origin Pools
-- Application Firewalls (WAF)
-- Namespaces
-- DNS Management
-- Network Policies
-- Cloud Sites (AWS, Azure, GCP)
-- And 260+ more...
-
-## License
-
-MIT
+Current key maintainers:
+- **Adam Jones** (Anthropic) [@domdomegg](https://github.com/domdomegg)  
+- **Tadas Antanavicius** (PulseMCP) [@tadasant](https://github.com/tadasant)
+- **Toby Padilla** (GitHub) [@toby](https://github.com/toby)
+- **Radoslav (Rado) Dimitrov** (Stacklok) [@rdimitrov](https://github.com/rdimitrov)
 
 ## Contributing
 
-Contributions welcome! Please see the main [terraform-provider-f5xc](https://github.com/robinmordasiewicz/terraform-provider-f5xc) repository for contribution guidelines.
+We use multiple channels for collaboration - see [modelcontextprotocol.io/community/communication](https://modelcontextprotocol.io/community/communication).
+
+Often (but not always) ideas flow through this pipeline:
+
+- **[Discord](https://modelcontextprotocol.io/community/communication)** - Real-time community discussions
+- **[Discussions](https://github.com/modelcontextprotocol/registry/discussions)** - Propose and discuss product/technical requirements
+- **[Issues](https://github.com/modelcontextprotocol/registry/issues)** - Track well-scoped technical work  
+- **[Pull Requests](https://github.com/modelcontextprotocol/registry/pulls)** - Contribute work towards issues
+
+### Quick start:
+
+#### Pre-requisites
+
+- **Docker**
+- **Go 1.24.x**
+- **ko** - Container image builder for Go ([installation instructions](https://ko.build/install/))
+- **golangci-lint v2.4.0**
+
+#### Running the server
+
+```bash
+# Start full development environment
+make dev-compose
+```
+
+This starts the registry at [`localhost:8080`](http://localhost:8080) with PostgreSQL. The database uses ephemeral storage and is reset each time you restart the containers, ensuring a clean state for development and testing.
+
+**Note:** The registry uses [ko](https://ko.build) to build container images. The `make dev-compose` command automatically builds the registry image with ko and loads it into your local Docker daemon before starting the services.
+
+By default, the registry seeds from the production API with a filtered subset of servers (to keep startup fast). This ensures your local environment mirrors production behavior and all seed data passes validation. For offline development you can seed from a file without validation with `MCP_REGISTRY_SEED_FROM=data/seed.json MCP_REGISTRY_ENABLE_REGISTRY_VALIDATION=false make dev-compose`.
+
+The setup can be configured with environment variables in [docker-compose.yml](./docker-compose.yml) - see [.env.example](./.env.example) for a reference.
+
+<details>
+<summary>Alternative: Running a pre-built Docker image</summary>
+
+Pre-built Docker images are automatically published to GitHub Container Registry:
+
+```bash
+# Run latest stable release
+docker run -p 8080:8080 ghcr.io/modelcontextprotocol/registry:latest
+
+# Run latest from main branch (continuous deployment)
+docker run -p 8080:8080 ghcr.io/modelcontextprotocol/registry:main
+
+# Run specific release version
+docker run -p 8080:8080 ghcr.io/modelcontextprotocol/registry:v1.0.0
+
+# Run development build from main branch
+docker run -p 8080:8080 ghcr.io/modelcontextprotocol/registry:main-20250906-abc123d
+```
+
+**Available tags:** 
+- **Releases**: `latest`, `v1.0.0`, `v1.1.0`, etc.
+- **Continuous**: `main` (latest main branch build)
+- **Development**: `main-<date>-<sha>` (specific commit builds)
+
+</details>
+
+#### Publishing a server
+
+To publish a server, we've built a simple CLI. You can use it with:
+
+```bash
+# Build the latest CLI
+make publisher
+
+# Use it!
+./bin/mcp-publisher --help
+```
+
+See [the publisher guide](./docs/modelcontextprotocol-io/quickstart.mdx) for more details.
+
+#### Other commands
+
+```bash
+# Run lint, unit tests and integration tests
+make check
+```
+
+There are also a few more helpful commands for development. Run `make help` to learn more, or look in [Makefile](./Makefile).
+
+<!--
+For Claude and other AI tools: Always prefer make targets over custom commands where possible.
+-->
+
+## Architecture
+
+### Project Structure
+
+```
+├── cmd/                     # Application entry points
+│   └── publisher/           # Server publishing tool
+├── data/                    # Seed data
+├── deploy/                  # Deployment configuration (Pulumi)
+├── docs/                    # Documentation
+├── internal/                # Private application code
+│   ├── api/                 # HTTP handlers and routing
+│   ├── auth/                # Authentication (GitHub OAuth, JWT, namespace blocking)
+│   ├── config/              # Configuration management
+│   ├── database/            # Data persistence (PostgreSQL)
+│   ├── service/             # Business logic
+│   ├── telemetry/           # Metrics and monitoring
+│   └── validators/          # Input validation
+├── pkg/                     # Public packages
+│   ├── api/                 # API types and structures
+│   │   └── v0/              # Version 0 API types
+│   └── model/               # Data models for server.json
+├── scripts/                 # Development and testing scripts
+├── tests/                   # Integration tests
+└── tools/                   # CLI tools and utilities
+    └── validate-*.sh        # Schema validation tools
+```
+
+### Authentication
+
+Publishing supports multiple authentication methods:
+- **GitHub OAuth** - For publishing by logging into GitHub
+- **GitHub OIDC** - For publishing from GitHub Actions
+- **DNS verification** - For proving ownership of a domain and its subdomains
+- **HTTP verification** - For proving ownership of a domain
+
+The registry validates namespace ownership when publishing. E.g. to publish...:
+- `io.github.domdomegg/my-cool-mcp` you must login to GitHub as `domdomegg`, or be in a GitHub Action on domdomegg's repos
+- `me.adamjones/my-cool-mcp` you must prove ownership of `adamjones.me` via DNS or HTTP challenge
+
+## Community Projects
+
+Check out [community projects](docs/community-projects.md) to explore notable registry-related work created by the community.
+
+## More documentation
+
+See the [documentation](./docs) for more details if your question has not been answered here!

--- a/mcp-server/manifest.json
+++ b/mcp-server/manifest.json
@@ -3,7 +3,7 @@
   "name": "f5xc-terraform-mcp",
   "displayName": "F5 Distributed Cloud Terraform Provider",
   "description": "MCP server providing AI assistants with access to F5 Distributed Cloud Terraform provider documentation, 270+ OpenAPI specifications, subscription tier information, and addon service activation workflows.",
-  "version": "2.14.5",
+  "version": "2.14.10",
   "author": {
     "name": "Robin Mordasiewicz",
     "url": "https://github.com/robinmordasiewicz"

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@robinmordasiewicz/f5xc-terraform-mcp",
-  "version": "2.4.3",
+  "version": "2.14.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@robinmordasiewicz/f5xc-terraform-mcp",
-      "version": "2.4.3",
+      "version": "2.14.10",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.6.1",

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robinmordasiewicz/f5xc-terraform-mcp",
-  "version": "2.4.3",
+  "version": "2.14.10",
   "description": "MCP server for F5 Distributed Cloud Terraform provider - documentation, 270+ OpenAPI specs, subscription info, and addon activation workflows for AI assistants",
   "type": "module",
   "main": "dist/index.js",

--- a/mcp-server/server.json
+++ b/mcp-server/server.json
@@ -3,12 +3,12 @@
   "name": "io.github.robinmordasiewicz/f5xc-terraform-mcp",
   "title": "F5 Distributed Cloud Terraform Provider",
   "description": "F5 Distributed Cloud Terraform provider docs, 270+ OpenAPI specs, and subscription info for AI.",
-  "version": "2.14.5",
+  "version": "2.14.10",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@robinmordasiewicz/f5xc-terraform-mcp",
-      "version": "2.14.5",
+      "version": "2.14.10",
       "transport": {
         "type": "stdio"
       },
@@ -16,12 +16,12 @@
     },
     {
       "registryType": "mcpb",
-      "identifier": "https://github.com/robinmordasiewicz/terraform-provider-f5xc/releases/download/v2.14.5/f5xc-terraform-mcp-2.14.5.mcpb",
-      "version": "2.14.5",
+      "identifier": "https://github.com/robinmordasiewicz/terraform-provider-f5xc/releases/download/v2.14.10/f5xc-terraform-mcp-2.14.10.mcpb",
+      "version": "2.14.10",
       "transport": {
         "type": "stdio"
       },
-      "fileSha256": "59a559925a27d86d0ccdbb2d2f34077fc3f24094e1ded9ce2862e10554dc7692"
+      "fileSha256": "925920239fe293337ade135cad9c3760da0bca9ec8d7a85f83c32bad36f66c31"
     }
   ],
   "repository": {


### PR DESCRIPTION
## Summary
Automated update of server.json for MCP Registry publication.

## Version
**Version**: 2.14.10
**SHA256**: `925920239fe293337ade135cad9c3760da0bca9ec8d7a85f83c32bad36f66c31`

## Publication Status
- npm: Published
- MCP Registry: Published

🤖 Generated with [Claude Code](https://claude.com/claude-code)