### PR TITLE
chore(mcp): update server.json to v2.15.0 for registry publication

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -131,11 +131,11 @@
       {
         "type": "Hex High Entropy String",
         "filename": "mcp-server/server.json",
-        "hashed_secret": "fe3cbd008f01eab00e3eb49afeb976ae872aed4c",
+        "hashed_secret": "480f190e6f35637ee1c84281c7e1df636a083db1",
         "is_verified": false,
         "line_number": 24
       }
     ]
   },
-  "generated_at": "2025-12-18T03:45:44Z"
+  "generated_at": "2025-12-18T14:47:28Z"
 }

--- a/mcp-server/server.json
+++ b/mcp-server/server.json
@@ -3,12 +3,12 @@
   "name": "io.github.robinmordasiewicz/f5xc-terraform-mcp",
   "title": "F5 Distributed Cloud Terraform Provider",
   "description": "F5 Distributed Cloud Terraform provider docs, 270+ OpenAPI specs, and subscription info for AI.",
-  "version": "2.14.10",
+  "version": "2.15.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@robinmordasiewicz/f5xc-terraform-mcp",
-      "version": "2.14.10",
+      "version": "2.15.0",
       "transport": {
         "type": "stdio"
       },
@@ -16,12 +16,12 @@
     },
     {
       "registryType": "mcpb",
-      "identifier": "https://github.com/robinmordasiewicz/terraform-provider-f5xc/releases/download/v2.14.10/f5xc-terraform-mcp-2.14.10.mcpb",
-      "version": "2.14.10",
+      "identifier": "https://github.com/robinmordasiewicz/terraform-provider-f5xc/releases/download/v2.15.0/f5xc-terraform-mcp-2.15.0.mcpb",
+      "version": "2.15.0",
       "transport": {
         "type": "stdio"
       },
-      "fileSha256": "925920239fe293337ade135cad9c3760da0bca9ec8d7a85f83c32bad36f66c31"
+      "fileSha256": "02315ab84516ecd4090e3e8471fc481e0943fd120b925e650d2fbae3d68a4de6"
     }
   ],
   "repository": {


### PR DESCRIPTION
## Summary

Update MCP server.json to match published v2.15.0 for GitHub MCP Registry publication.

## Related Issue

Closes #596

## Changes Made

- Bump version from 2.14.10 to 2.15.0
- Update npm package version reference  
- Update mcpb URL to v2.15.0 release
- Update fileSha256 for v2.15.0 mcpb file
- Update secrets baseline for new hash

## Purpose

Prepares the MCP server for publication to the GitHub MCP Registry so it appears in VSCode's `@MCP` marketplace search.

## After Merge

Run the following to publish to the registry:
```bash
mcp-publisher login github
mcp-publisher publish --file=mcp-server/server.json
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)