### PR TITLE
chore: add MCP Registry token files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ tmp/
 terraform.tfvars
 *-secret.txt
 *-credentials.json
+
+# MCP Registry authentication tokens (created by mcp-publisher CLI)
+.mcpregistry_*

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -127,6 +127,534 @@
     }
   ],
   "results": {
+    "docs/index.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/index.md",
+        "hashed_secret": "ce96fff993090da7bf7842fdecba16e112c336f9",
+        "is_verified": false,
+        "line_number": 60
+      }
+    ],
+    "docs/resources/cloud_credentials.md": [
+      {
+        "type": "AWS Access Key",
+        "filename": "docs/resources/cloud_credentials.md",
+        "hashed_secret": "25910f981e85ca04baf359199dd0bd4a3ae738b6",
+        "is_verified": false,
+        "line_number": 37
+      }
+    ],
+    "docs/resources/virtual_host.md": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/resources/virtual_host.md",
+        "hashed_secret": "b63a1e8efe59d9dfa139cdcee1c397b176d181de",
+        "is_verified": false,
+        "line_number": 97
+      }
+    ],
+    "examples/provider/provider.tf": [
+      {
+        "type": "Secret Keyword",
+        "filename": "examples/provider/provider.tf",
+        "hashed_secret": "ce96fff993090da7bf7842fdecba16e112c336f9",
+        "is_verified": false,
+        "line_number": 27
+      }
+    ],
+    "examples/resources/f5xc_cloud_credentials/resource.tf": [
+      {
+        "type": "AWS Access Key",
+        "filename": "examples/resources/f5xc_cloud_credentials/resource.tf",
+        "hashed_secret": "25910f981e85ca04baf359199dd0bd4a3ae738b6",
+        "is_verified": false,
+        "line_number": 21
+      }
+    ],
+    "internal/client/client_test.go": [
+      {
+        "type": "Private Key",
+        "filename": "internal/client/client_test.go",
+        "hashed_secret": "be4fc4886bd949b369d5e092eb87494f12e57e5b",
+        "is_verified": false,
+        "line_number": 538
+      }
+    ],
+    "internal/mocks/fixtures.go": [
+      {
+        "type": "AWS Access Key",
+        "filename": "internal/mocks/fixtures.go",
+        "hashed_secret": "25910f981e85ca04baf359199dd0bd4a3ae738b6",
+        "is_verified": false,
+        "line_number": 261
+      }
+    ],
+    "internal/provider/alert_receiver_resource.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/alert_receiver_resource.go",
+        "hashed_secret": "44e17306b837162269a410204daaa5ecee4ec22c",
+        "is_verified": false,
+        "line_number": 1149
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/alert_receiver_resource.go",
+        "hashed_secret": "810dde83fa912ef604289c8c8295cbb34a91146e",
+        "is_verified": false,
+        "line_number": 1151
+      }
+    ],
+    "internal/provider/api_crawler_resource.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/api_crawler_resource.go",
+        "hashed_secret": "44e17306b837162269a410204daaa5ecee4ec22c",
+        "is_verified": false,
+        "line_number": 410
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/api_crawler_resource.go",
+        "hashed_secret": "f42cc677325ae1dc04d0769b926dd555c068202e",
+        "is_verified": false,
+        "line_number": 412
+      }
+    ],
+    "internal/provider/authentication_resource.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/authentication_resource.go",
+        "hashed_secret": "44e17306b837162269a410204daaa5ecee4ec22c",
+        "is_verified": false,
+        "line_number": 659
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/authentication_resource.go",
+        "hashed_secret": "f5a1ce4a170ef6b8fa88e87844068fb390975e58",
+        "is_verified": false,
+        "line_number": 661
+      }
+    ],
+    "internal/provider/aws_tgw_site_resource.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/aws_tgw_site_resource.go",
+        "hashed_secret": "44e17306b837162269a410204daaa5ecee4ec22c",
+        "is_verified": false,
+        "line_number": 2558
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/aws_tgw_site_resource.go",
+        "hashed_secret": "c6b6b2f434bbaf26904ac693b214d9ac7431275b",
+        "is_verified": false,
+        "line_number": 2560
+      }
+    ],
+    "internal/provider/aws_vpc_site_resource.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/aws_vpc_site_resource.go",
+        "hashed_secret": "44e17306b837162269a410204daaa5ecee4ec22c",
+        "is_verified": false,
+        "line_number": 3504
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/aws_vpc_site_resource.go",
+        "hashed_secret": "73a593129139937dfc5f0aa05ff34e7485392e68",
+        "is_verified": false,
+        "line_number": 3517
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/aws_vpc_site_resource.go",
+        "hashed_secret": "78ad2b7dc424aa4c8c55ff71314194dddc4bfdd5",
+        "is_verified": false,
+        "line_number": 3527
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/aws_vpc_site_resource.go",
+        "hashed_secret": "9a12fa7df86d3f41ee92120df1d038004f0408e4",
+        "is_verified": false,
+        "line_number": 3529
+      }
+    ],
+    "internal/provider/azure_vnet_site_resource.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/azure_vnet_site_resource.go",
+        "hashed_secret": "44e17306b837162269a410204daaa5ecee4ec22c",
+        "is_verified": false,
+        "line_number": 6526
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/azure_vnet_site_resource.go",
+        "hashed_secret": "73a593129139937dfc5f0aa05ff34e7485392e68",
+        "is_verified": false,
+        "line_number": 6539
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/azure_vnet_site_resource.go",
+        "hashed_secret": "78ad2b7dc424aa4c8c55ff71314194dddc4bfdd5",
+        "is_verified": false,
+        "line_number": 6549
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/azure_vnet_site_resource.go",
+        "hashed_secret": "9a12fa7df86d3f41ee92120df1d038004f0408e4",
+        "is_verified": false,
+        "line_number": 6551
+      }
+    ],
+    "internal/provider/cdn_loadbalancer_resource.go": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "internal/provider/cdn_loadbalancer_resource.go",
+        "hashed_secret": "0c5aa2932d2cec0a3f054674b7124b6b6af51cf5",
+        "is_verified": false,
+        "line_number": 7564
+      }
+    ],
+    "internal/provider/certificate_resource.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/certificate_resource.go",
+        "hashed_secret": "44e17306b837162269a410204daaa5ecee4ec22c",
+        "is_verified": false,
+        "line_number": 451
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/certificate_resource.go",
+        "hashed_secret": "73a593129139937dfc5f0aa05ff34e7485392e68",
+        "is_verified": false,
+        "line_number": 464
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/certificate_resource.go",
+        "hashed_secret": "78ad2b7dc424aa4c8c55ff71314194dddc4bfdd5",
+        "is_verified": false,
+        "line_number": 474
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/certificate_resource.go",
+        "hashed_secret": "349cb608cf7819b58f593d76831138248a53e692",
+        "is_verified": false,
+        "line_number": 476
+      }
+    ],
+    "internal/provider/cloud_credentials_resource.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/cloud_credentials_resource.go",
+        "hashed_secret": "44e17306b837162269a410204daaa5ecee4ec22c",
+        "is_verified": false,
+        "line_number": 769
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/cloud_credentials_resource.go",
+        "hashed_secret": "c7d97602c6d816d8b4d1a46cb8f15f8db37c6113",
+        "is_verified": false,
+        "line_number": 776
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/cloud_credentials_resource.go",
+        "hashed_secret": "89af4295942e05c18cb9c53626672fcae9f2d25c",
+        "is_verified": false,
+        "line_number": 778
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/cloud_credentials_resource.go",
+        "hashed_secret": "f5a1ce4a170ef6b8fa88e87844068fb390975e58",
+        "is_verified": false,
+        "line_number": 787
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/cloud_credentials_resource.go",
+        "hashed_secret": "a12e3075ad2723519dc300eb5ac034245422c886",
+        "is_verified": false,
+        "line_number": 795
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/cloud_credentials_resource.go",
+        "hashed_secret": "e9421639eb11c95931528f95c7d51f5272c740a3",
+        "is_verified": false,
+        "line_number": 807
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/cloud_credentials_resource.go",
+        "hashed_secret": "893c5bdd17654597e159a83132ad0a9361cc8f1b",
+        "is_verified": false,
+        "line_number": 911
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/cloud_credentials_resource.go",
+        "hashed_secret": "43259ee56c70a675a49ad20df106e0429ba3e79f",
+        "is_verified": false,
+        "line_number": 932
+      }
+    ],
+    "internal/provider/cminstance_resource.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/cminstance_resource.go",
+        "hashed_secret": "44e17306b837162269a410204daaa5ecee4ec22c",
+        "is_verified": false,
+        "line_number": 465
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/cminstance_resource.go",
+        "hashed_secret": "73a593129139937dfc5f0aa05ff34e7485392e68",
+        "is_verified": false,
+        "line_number": 476
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/cminstance_resource.go",
+        "hashed_secret": "78ad2b7dc424aa4c8c55ff71314194dddc4bfdd5",
+        "is_verified": false,
+        "line_number": 486
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/cminstance_resource.go",
+        "hashed_secret": "40667c963954878f32e63b0d9f28d5c92fe25edf",
+        "is_verified": false,
+        "line_number": 522
+      }
+    ],
+    "internal/provider/container_registry_resource.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/container_registry_resource.go",
+        "hashed_secret": "44e17306b837162269a410204daaa5ecee4ec22c",
+        "is_verified": false,
+        "line_number": 376
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/container_registry_resource.go",
+        "hashed_secret": "73a593129139937dfc5f0aa05ff34e7485392e68",
+        "is_verified": false,
+        "line_number": 389
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/container_registry_resource.go",
+        "hashed_secret": "78ad2b7dc424aa4c8c55ff71314194dddc4bfdd5",
+        "is_verified": false,
+        "line_number": 399
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/container_registry_resource.go",
+        "hashed_secret": "40667c963954878f32e63b0d9f28d5c92fe25edf",
+        "is_verified": false,
+        "line_number": 401
+      }
+    ],
+    "internal/provider/gcp_vpc_site_resource.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/gcp_vpc_site_resource.go",
+        "hashed_secret": "44e17306b837162269a410204daaa5ecee4ec22c",
+        "is_verified": false,
+        "line_number": 3245
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/gcp_vpc_site_resource.go",
+        "hashed_secret": "73a593129139937dfc5f0aa05ff34e7485392e68",
+        "is_verified": false,
+        "line_number": 3258
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/gcp_vpc_site_resource.go",
+        "hashed_secret": "78ad2b7dc424aa4c8c55ff71314194dddc4bfdd5",
+        "is_verified": false,
+        "line_number": 3268
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/gcp_vpc_site_resource.go",
+        "hashed_secret": "9a12fa7df86d3f41ee92120df1d038004f0408e4",
+        "is_verified": false,
+        "line_number": 3270
+      }
+    ],
+    "internal/provider/global_log_receiver_resource.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/global_log_receiver_resource.go",
+        "hashed_secret": "44e17306b837162269a410204daaa5ecee4ec22c",
+        "is_verified": false,
+        "line_number": 3107
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/global_log_receiver_resource.go",
+        "hashed_secret": "f9ff1133ff9fd4f62bc6572e01e0acb75a6be1bc",
+        "is_verified": false,
+        "line_number": 3109
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/global_log_receiver_resource.go",
+        "hashed_secret": "810dde83fa912ef604289c8c8295cbb34a91146e",
+        "is_verified": false,
+        "line_number": 3270
+      }
+    ],
+    "internal/provider/http_loadbalancer_resource.go": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "internal/provider/http_loadbalancer_resource.go",
+        "hashed_secret": "0c5aa2932d2cec0a3f054674b7124b6b6af51cf5",
+        "is_verified": false,
+        "line_number": 13191
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/http_loadbalancer_resource.go",
+        "hashed_secret": "44e17306b837162269a410204daaa5ecee4ec22c",
+        "is_verified": false,
+        "line_number": 21617
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/http_loadbalancer_resource.go",
+        "hashed_secret": "064b2503403a6a36ab3f02c9d12471a90531ec58",
+        "is_verified": false,
+        "line_number": 21619
+      }
+    ],
+    "internal/provider/infraprotect_tunnel_resource.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/infraprotect_tunnel_resource.go",
+        "hashed_secret": "44e17306b837162269a410204daaa5ecee4ec22c",
+        "is_verified": false,
+        "line_number": 656
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/infraprotect_tunnel_resource.go",
+        "hashed_secret": "d55ebadb21cb0a7523e3e52585262e0ecd0038e6",
+        "is_verified": false,
+        "line_number": 661
+      }
+    ],
+    "internal/provider/nfv_service_resource.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/nfv_service_resource.go",
+        "hashed_secret": "44e17306b837162269a410204daaa5ecee4ec22c",
+        "is_verified": false,
+        "line_number": 2806
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/nfv_service_resource.go",
+        "hashed_secret": "c6b6b2f434bbaf26904ac693b214d9ac7431275b",
+        "is_verified": false,
+        "line_number": 2808
+      }
+    ],
+    "internal/provider/securemesh_site_v2_resource.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/securemesh_site_v2_resource.go",
+        "hashed_secret": "44e17306b837162269a410204daaa5ecee4ec22c",
+        "is_verified": false,
+        "line_number": 8232
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/securemesh_site_v2_resource.go",
+        "hashed_secret": "c6b6b2f434bbaf26904ac693b214d9ac7431275b",
+        "is_verified": false,
+        "line_number": 8234
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/securemesh_site_v2_resource.go",
+        "hashed_secret": "e9421639eb11c95931528f95c7d51f5272c740a3",
+        "is_verified": false,
+        "line_number": 8303
+      }
+    ],
+    "internal/provider/tenant_configuration_resource.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/tenant_configuration_resource.go",
+        "hashed_secret": "44e17306b837162269a410204daaa5ecee4ec22c",
+        "is_verified": false,
+        "line_number": 390
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/tenant_configuration_resource.go",
+        "hashed_secret": "bd8ef007b37592ab4aa99488242cb787ac27402a",
+        "is_verified": false,
+        "line_number": 416
+      }
+    ],
+    "internal/provider/virtual_host_resource.go": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "internal/provider/virtual_host_resource.go",
+        "hashed_secret": "b63a1e8efe59d9dfa139cdcee1c397b176d181de",
+        "is_verified": false,
+        "line_number": 1598
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/virtual_host_resource.go",
+        "hashed_secret": "44e17306b837162269a410204daaa5ecee4ec22c",
+        "is_verified": false,
+        "line_number": 3079
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/virtual_host_resource.go",
+        "hashed_secret": "0b53e5f72acb76f13bd31cad7118195e9a238c9c",
+        "is_verified": false,
+        "line_number": 3092
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/virtual_host_resource.go",
+        "hashed_secret": "0879e308bea9b00ca8b94423cac4385d22887479",
+        "is_verified": false,
+        "line_number": 3102
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/provider/virtual_host_resource.go",
+        "hashed_secret": "1c433ad60d60a9d70e6d59fc15830fd0495b4afd",
+        "is_verified": false,
+        "line_number": 3104
+      }
+    ],
     "mcp-server/server.json": [
       {
         "type": "Hex High Entropy String",
@@ -135,7 +663,25 @@
         "is_verified": false,
         "line_number": 24
       }
+    ],
+    "templates/index.md.tmpl": [
+      {
+        "type": "Secret Keyword",
+        "filename": "templates/index.md.tmpl",
+        "hashed_secret": "ce96fff993090da7bf7842fdecba16e112c336f9",
+        "is_verified": false,
+        "line_number": 94
+      }
+    ],
+    "tools/generate-examples.go": [
+      {
+        "type": "AWS Access Key",
+        "filename": "tools/generate-examples.go",
+        "hashed_secret": "25910f981e85ca04baf359199dd0bd4a3ae738b6",
+        "is_verified": false,
+        "line_number": 682
+      }
     ]
   },
-  "generated_at": "2025-12-18T14:47:28Z"
+  "generated_at": "2025-12-18T15:50:01Z"
 }


### PR DESCRIPTION
## Summary
Adds `.mcpregistry_*` pattern to .gitignore to prevent accidental commits of sensitive authentication tokens created by the `mcp-publisher` CLI.

## Related Issue
Closes #599

## Changes Made
- Added `.mcpregistry_*` pattern to `.gitignore`
- Updated `.secrets.baseline` to include existing false positives in auto-generated code

## Security Impact
Prevents credential leakage from local development token files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)