### PR TITLE
docs: clarify mcpb files are executables not VSCode extensions

### DIFF
--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -19,6 +19,8 @@ f5xc-terraform-mcp
 
 Download the standalone `.mcpb` binary - no Node.js or Docker required:
 
+> **Note:** The `.mcpb` file is a standalone executable, NOT a VSCode extension. Do not try to install it through VSCode's extension manager. Configure it via `mcp.json` as shown in the Configuration section below.
+
 1. Download from [GitHub Releases](https://github.com/robinmordasiewicz/terraform-provider-f5xc/releases/latest) - look for `f5xc-terraform-mcp-X.X.X.mcpb`
 
 2. Make executable and run:

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -217,11 +217,14 @@ Create a `.vscode/mcp.json` file in your workspace:
 
 #### Option 2: Corporate Environments (No Node.js Required)
 
-For environments where npm/Node.js cannot be installed:
+For environments where npm/Node.js cannot be installed, use the standalone binary bundle:
+
+-> **Note:** The `.mcpb` file is a standalone executable, NOT a VSCode extension. Do not try to install it through VSCode's extension manager. Configure it via `mcp.json` as shown below.
 
 1. Download the latest `.mcpb` bundle from [GitHub Releases](https://github.com/robinmordasiewicz/terraform-provider-f5xc/releases)
-2. Place the file in a known location (e.g., `~/.mcp/f5xc-terraform-mcp.mcpb`)
-3. Create a `.vscode/mcp.json` file:
+2. Make it executable: `chmod +x f5xc-terraform-mcp-*.mcpb`
+3. Place the file in a known location (e.g., `~/.mcp/f5xc-terraform-mcp.mcpb`)
+4. Create a `.vscode/mcp.json` file:
 
 ```json
 {


### PR DESCRIPTION
## Summary

Adds clear documentation explaining that `.mcpb` files are standalone executables, NOT installable extensions.

## Related Issue

Closes #608

## Problem

Users were attempting to install `.mcpb` files through:
- VSCode's extension manager → "No manifest.json found" error
- Claude Desktop drag-and-drop → similar installation failure

## Changes Made

- Added warning note to `mcp-server/README.md` explaining mcpb files are executables
- Added warning note to `templates/index.md.tmpl` for Terraform Registry docs
- Added `chmod +x` step to Registry docs

## Correct Installation Method

For `.mcpb` files, users must:
1. Download the `.mcpb` file
2. Make it executable (`chmod +x`)
3. Configure the path in their MCP config JSON file

**NOT**: Drag-and-drop or install through extension/server managers

🤖 Generated with [Claude Code](https://claude.com/claude-code)