### PR TITLE
chore(mcp): update server.json to v2.15.4

### DIFF
--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -1,145 +1,153 @@
-# F5 Distributed Cloud Terraform MCP Server
+# MCP Registry
 
-MCP server providing AI assistants with access to F5 Distributed Cloud (F5XC) Terraform provider documentation, 270+ OpenAPI specifications, subscription tier information, and addon service workflows.
+The MCP registry provides MCP clients with a list of MCP servers, like an app store for MCP servers.
 
-## Installation
+[**📤 Publish my MCP server**](docs/modelcontextprotocol-io/quickstart.mdx) | [**⚡️ Live API docs**](https://registry.modelcontextprotocol.io/docs) | [**👀 Ecosystem vision**](docs/design/ecosystem-vision.md) | 📖 **[Full documentation](./docs)**
 
-### Option 1: npm (Requires Node.js 18+)
+## Development Status
 
-```bash
-# Run directly with npx
-npx @robinmordasiewicz/f5xc-terraform-mcp
+**2025-10-24 update**: The Registry API has entered an **API freeze (v0.1)** 🎉. For the next month or more, the API will remain stable with no breaking changes, allowing integrators to confidently implement support. This freeze applies to v0.1 while development continues on v0. We'll use this period to validate the API in real-world integrations and gather feedback to shape v1 for general availability. Thank you to everyone for your contributions and patience—your involvement has been key to getting us here!
 
-# Or install globally
-npm install -g @robinmordasiewicz/f5xc-terraform-mcp
-f5xc-terraform-mcp
-```
+**2025-09-08 update**: The registry has launched in preview 🎉 ([announcement blog post](https://blog.modelcontextprotocol.io/posts/2025-09-08-mcp-registry-preview/)). While the system is now more stable, this is still a preview release and breaking changes or data resets may occur. A general availability (GA) release will follow later. We'd love your feedback in [GitHub discussions](https://github.com/modelcontextprotocol/registry/discussions/new?category=ideas) or in the [#registry-dev Discord](https://discord.com/channels/1358869848138059966/1369487942862504016) ([joining details here](https://modelcontextprotocol.io/community/communication)).
 
-### Option 2: Binary Bundle (No Dependencies)
+Current key maintainers:
+- **Adam Jones** (Anthropic) [@domdomegg](https://github.com/domdomegg)  
+- **Tadas Antanavicius** (PulseMCP) [@tadasant](https://github.com/tadasant)
+- **Toby Padilla** (GitHub) [@toby](https://github.com/toby)
+- **Radoslav (Rado) Dimitrov** (Stacklok) [@rdimitrov](https://github.com/rdimitrov)
 
-Download the standalone `.mcpb` binary - no Node.js or Docker required:
+## Contributing
 
-1. Download from [GitHub Releases](https://github.com/robinmordasiewicz/terraform-provider-f5xc/releases/latest) - look for `f5xc-terraform-mcp-X.X.X.mcpb`
+We use multiple channels for collaboration - see [modelcontextprotocol.io/community/communication](https://modelcontextprotocol.io/community/communication).
 
-2. Make executable and run:
-```bash
-chmod +x f5xc-terraform-mcp-*.mcpb
-./f5xc-terraform-mcp-*.mcpb
-```
+Often (but not always) ideas flow through this pipeline:
 
-### Option 3: Portable Node.js (No Admin Rights)
+- **[Discord](https://modelcontextprotocol.io/community/communication)** - Real-time community discussions
+- **[Discussions](https://github.com/modelcontextprotocol/registry/discussions)** - Propose and discuss product/technical requirements
+- **[Issues](https://github.com/modelcontextprotocol/registry/issues)** - Track well-scoped technical work  
+- **[Pull Requests](https://github.com/modelcontextprotocol/registry/pulls)** - Contribute work towards issues
 
-For users without admin privileges who cannot install Node.js system-wide:
+### Quick start:
 
-1. Download Node.js portable binaries from [nodejs.org/download/prebuilt-binaries](https://nodejs.org/en/download/prebuilt-binaries)
-2. Extract to user directory (e.g., `~/node/`)
-3. Add to PATH: `export PATH="$HOME/node/bin:$PATH"`
-4. Use npx as normal
+#### Pre-requisites
 
-## Configuration
+- **Docker**
+- **Go 1.24.x**
+- **ko** - Container image builder for Go ([installation instructions](https://ko.build/install/))
+- **golangci-lint v2.4.0**
 
-### Claude Desktop
-
-Add to your Claude Desktop configuration (`~/Library/Application Support/Claude/claude_desktop_config.json` on macOS):
-
-```json
-{
-  "mcpServers": {
-    "f5xc-terraform": {
-      "command": "npx",
-      "args": ["-y", "@robinmordasiewicz/f5xc-terraform-mcp"]
-    }
-  }
-}
-```
-
-Or with the binary bundle:
-
-```json
-{
-  "mcpServers": {
-    "f5xc-terraform": {
-      "command": "/path/to/f5xc-terraform-mcp.mcpb"
-    }
-  }
-}
-```
-
-### Claude Code CLI
+#### Running the server
 
 ```bash
-claude mcp add f5xc-terraform -- npx -y @robinmordasiewicz/f5xc-terraform-mcp
+# Start full development environment
+make dev-compose
 ```
 
-### VSCode with Cline/Continue
+This starts the registry at [`localhost:8080`](http://localhost:8080) with PostgreSQL. The database uses ephemeral storage and is reset each time you restart the containers, ensuring a clean state for development and testing.
 
-Add to your MCP settings:
+**Note:** The registry uses [ko](https://ko.build) to build container images. The `make dev-compose` command automatically builds the registry image with ko and loads it into your local Docker daemon before starting the services.
 
-```json
-{
-  "mcpServers": {
-    "f5xc-terraform": {
-      "command": "npx",
-      "args": ["-y", "@robinmordasiewicz/f5xc-terraform-mcp"]
-    }
-  }
-}
+By default, the registry seeds from the production API with a filtered subset of servers (to keep startup fast). This ensures your local environment mirrors production behavior and all seed data passes validation. For offline development you can seed from a file without validation with `MCP_REGISTRY_SEED_FROM=data/seed.json MCP_REGISTRY_ENABLE_REGISTRY_VALIDATION=false make dev-compose`.
+
+The setup can be configured with environment variables in [docker-compose.yml](./docker-compose.yml) - see [.env.example](./.env.example) for a reference.
+
+<details>
+<summary>Alternative: Running a pre-built Docker image</summary>
+
+Pre-built Docker images are automatically published to GitHub Container Registry:
+
+```bash
+# Run latest stable release
+docker run -p 8080:8080 ghcr.io/modelcontextprotocol/registry:latest
+
+# Run latest from main branch (continuous deployment)
+docker run -p 8080:8080 ghcr.io/modelcontextprotocol/registry:main
+
+# Run specific release version
+docker run -p 8080:8080 ghcr.io/modelcontextprotocol/registry:v1.0.0
+
+# Run development build from main branch
+docker run -p 8080:8080 ghcr.io/modelcontextprotocol/registry:main-20250906-abc123d
 ```
 
-## Available Tools
+**Available tags:** 
+- **Releases**: `latest`, `v1.0.0`, `v1.1.0`, etc.
+- **Continuous**: `main` (latest main branch build)
+- **Development**: `main-<date>-<sha>` (specific commit builds)
 
-The server provides 6 consolidated tools optimized for token efficiency:
+</details>
 
-| Tool | Description |
-|------|-------------|
-| `f5xc_terraform_discover` | Discovery meta-tool - lists available tools and their schemas |
-| `f5xc_terraform_docs` | Search, get, or list provider documentation (resources, data sources, functions, guides) |
-| `f5xc_terraform_api` | Search OpenAPI specs, get spec details, find endpoints, get schema definitions |
-| `f5xc_terraform_subscription` | Get subscription tier requirements for resources |
-| `f5xc_terraform_addon` | Get addon service activation information |
-| `f5xc_terraform_get_summary` | Get provider overview with statistics |
+#### Publishing a server
 
-### Example Usage
+To publish a server, we've built a simple CLI. You can use it with:
 
-**Search documentation:**
-```
-f5xc_terraform_docs(operation: "search", query: "http_loadbalancer")
-```
+```bash
+# Build the latest CLI
+make publisher
 
-**Get full resource documentation:**
-```
-f5xc_terraform_docs(operation: "get", name: "http_loadbalancer", type: "resource")
+# Use it!
+./bin/mcp-publisher --help
 ```
 
-**Find API endpoints:**
+See [the publisher guide](./docs/modelcontextprotocol-io/quickstart.mdx) for more details.
+
+#### Other commands
+
+```bash
+# Run lint, unit tests and integration tests
+make check
 ```
-f5xc_terraform_api(operation: "find_endpoints", pattern: "/namespaces", method: "POST")
+
+There are also a few more helpful commands for development. Run `make help` to learn more, or look in [Makefile](./Makefile).
+
+<!--
+For Claude and other AI tools: Always prefer make targets over custom commands where possible.
+-->
+
+## Architecture
+
+### Project Structure
+
+```
+├── cmd/                     # Application entry points
+│   └── publisher/           # Server publishing tool
+├── data/                    # Seed data
+├── deploy/                  # Deployment configuration (Pulumi)
+├── docs/                    # Documentation
+├── internal/                # Private application code
+│   ├── api/                 # HTTP handlers and routing
+│   ├── auth/                # Authentication (GitHub OAuth, JWT, namespace blocking)
+│   ├── config/              # Configuration management
+│   ├── database/            # Data persistence (PostgreSQL)
+│   ├── service/             # Business logic
+│   ├── telemetry/           # Metrics and monitoring
+│   └── validators/          # Input validation
+├── pkg/                     # Public packages
+│   ├── api/                 # API types and structures
+│   │   └── v0/              # Version 0 API types
+│   └── model/               # Data models for server.json
+├── scripts/                 # Development and testing scripts
+├── tests/                   # Integration tests
+└── tools/                   # CLI tools and utilities
+    └── validate-*.sh        # Schema validation tools
 ```
 
-**Check subscription requirements:**
-```
-f5xc_terraform_subscription(operation: "get", resource: "bot_defense_advanced_policy")
-```
+### Authentication
 
-## What's Included
+Publishing supports multiple authentication methods:
+- **GitHub OAuth** - For publishing by logging into GitHub
+- **GitHub OIDC** - For publishing from GitHub Actions
+- **DNS verification** - For proving ownership of a domain and its subdomains
+- **HTTP verification** - For proving ownership of a domain
 
-- **144+ Terraform Resources** - Full documentation for all F5XC resources
-- **270+ OpenAPI Specifications** - Complete API reference for F5XC services
-- **Subscription Tier Info** - Which features require which subscription level
-- **Addon Service Workflows** - Activation status and requirements
-- **Example Configurations** - Working Terraform examples for each resource
+The registry validates namespace ownership when publishing. E.g. to publish...:
+- `io.github.domdomegg/my-cool-mcp` you must login to GitHub as `domdomegg`, or be in a GitHub Action on domdomegg's repos
+- `me.adamjones/my-cool-mcp` you must prove ownership of `adamjones.me` via DNS or HTTP challenge
 
-## Version Synchronization
+## Community Projects
 
-The MCP server version is automatically synchronized with the Terraform provider releases. Both always share the same version number (e.g., v2.15.2).
+Check out [community projects](docs/community-projects.md) to explore notable registry-related work created by the community.
 
-## Links
+## More documentation
 
-- [Terraform Provider](https://registry.terraform.io/providers/robinmordasiewicz/f5xc/latest)
-- [GitHub Repository](https://github.com/robinmordasiewicz/terraform-provider-f5xc)
-- [npm Package](https://www.npmjs.com/package/@robinmordasiewicz/f5xc-terraform-mcp)
-- [F5 Distributed Cloud Documentation](https://docs.cloud.f5.com/)
-
-## License
-
-MIT
+See the [documentation](./docs) for more details if your question has not been answered here!

--- a/mcp-server/manifest.json
+++ b/mcp-server/manifest.json
@@ -3,7 +3,7 @@
   "name": "f5xc-terraform-mcp",
   "displayName": "F5 Distributed Cloud Terraform Provider",
   "description": "MCP server providing AI assistants with access to F5 Distributed Cloud Terraform provider documentation, 270+ OpenAPI specifications, subscription tier information, and addon service activation workflows.",
-  "version": "2.14.10",
+  "version": "2.15.4",
   "author": {
     "name": "Robin Mordasiewicz",
     "url": "https://github.com/robinmordasiewicz"

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@robinmordasiewicz/f5xc-terraform-mcp",
-  "version": "2.14.10",
+  "version": "2.15.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@robinmordasiewicz/f5xc-terraform-mcp",
-      "version": "2.14.10",
+      "version": "2.15.4",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.6.1",

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robinmordasiewicz/f5xc-terraform-mcp",
-  "version": "2.14.10",
+  "version": "2.15.4",
   "description": "MCP server for F5 Distributed Cloud Terraform provider - documentation, 270+ OpenAPI specs, subscription info, and addon activation workflows for AI assistants",
   "type": "module",
   "main": "dist/index.js",

--- a/mcp-server/server.json
+++ b/mcp-server/server.json
@@ -3,12 +3,12 @@
   "name": "io.github.robinmordasiewicz/f5xc-terraform-mcp",
   "title": "F5 Distributed Cloud Terraform Provider",
   "description": "F5 Distributed Cloud Terraform provider docs, 270+ OpenAPI specs, and subscription info for AI.",
-  "version": "2.15.0",
+  "version": "2.15.4",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@robinmordasiewicz/f5xc-terraform-mcp",
-      "version": "2.15.0",
+      "version": "2.15.4",
       "transport": {
         "type": "stdio"
       },
@@ -16,12 +16,12 @@
     },
     {
       "registryType": "mcpb",
-      "identifier": "https://github.com/robinmordasiewicz/terraform-provider-f5xc/releases/download/v2.15.0/f5xc-terraform-mcp-2.15.0.mcpb",
-      "version": "2.15.0",
+      "identifier": "https://github.com/robinmordasiewicz/terraform-provider-f5xc/releases/download/v2.15.4/f5xc-terraform-mcp-2.15.4.mcpb",
+      "version": "2.15.4",
       "transport": {
         "type": "stdio"
       },
-      "fileSha256": "02315ab84516ecd4090e3e8471fc481e0943fd120b925e650d2fbae3d68a4de6"
+      "fileSha256": "c33f2315a0b39e0469d0431c5cb20fadf48166a56b7f804a5b888dcd79ac44ff"
     }
   ],
   "repository": {


### PR DESCRIPTION
## Summary
Automated update of server.json for MCP Registry publication.

## Version
**Version**: 2.15.4
**SHA256**: `c33f2315a0b39e0469d0431c5cb20fadf48166a56b7f804a5b888dcd79ac44ff`

## Publication Status
- npm: Published
- MCP Registry: Published

🤖 Generated with [Claude Code](https://claude.com/claude-code)