### PR TITLE
fix(mcp): enable drag-and-drop mcpb installation in Claude Desktop

### DIFF
--- a/mcp-server/manifest.json
+++ b/mcp-server/manifest.json
@@ -1,26 +1,31 @@
 {
-  "$schema": "https://static.modelcontextprotocol.io/schemas/mcpb/manifest.schema.json",
+  "manifest_version": "0.3",
   "name": "f5xc-terraform-mcp",
-  "displayName": "F5 Distributed Cloud Terraform Provider",
-  "description": "MCP server providing AI assistants with access to F5 Distributed Cloud Terraform provider documentation, 270+ OpenAPI specifications, subscription tier information, and addon service activation workflows.",
+  "display_name": "F5 Distributed Cloud Terraform Provider",
   "version": "2.14.10",
+  "description": "MCP server providing AI assistants with access to F5 Distributed Cloud Terraform provider documentation, 270+ OpenAPI specifications, subscription tier information, and addon service activation workflows.",
   "author": {
     "name": "Robin Mordasiewicz",
     "url": "https://github.com/robinmordasiewicz"
   },
   "license": "MPL-2.0",
-  "repository": "https://github.com/robinmordasiewicz/terraform-provider-f5xc",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/robinmordasiewicz/terraform-provider-f5xc"
+  },
+  "homepage": "https://registry.terraform.io/providers/robinmordasiewicz/f5xc/latest",
   "server": {
     "type": "node",
-    "entry": "dist/index.js",
-    "runtime": {
-      "minVersion": "18.0.0"
+    "entry_point": "dist/index.js",
+    "mcp_config": {
+      "command": "node",
+      "args": ["${__dirname}/dist/index.js"]
     }
   },
-  "capabilities": {
-    "tools": true,
-    "resources": false,
-    "prompts": false
+  "compatibility": {
+    "runtime": {
+      "node": ">=18.0.0"
+    }
   },
   "tools": [
     {
@@ -47,14 +52,6 @@
       "name": "f5xc_terraform_get_summary",
       "description": "Get a summary of all available F5XC documentation and API specifications"
     }
-  ],
-  "categories": [
-    "infrastructure",
-    "terraform",
-    "f5",
-    "cloud",
-    "security",
-    "networking"
   ],
   "keywords": [
     "f5xc",

--- a/mcp-server/scripts/build-mcpb.sh
+++ b/mcp-server/scripts/build-mcpb.sh
@@ -105,9 +105,10 @@ fs.writeFileSync('manifest.json', JSON.stringify(manifest, null, 2));
 "
 
 # Create the .mcpb bundle (ZIP file)
+# IMPORTANT: manifest.json must be at the root of the archive for Claude Desktop drag-and-drop
 echo -e "${YELLOW}Creating MCPB bundle...${NC}"
-cd "$BUILD_DIR"
-zip -r "f5xc-terraform-mcp-${VERSION}.mcpb" "f5xc-terraform-mcp" -x "*.DS_Store" -x "*__MACOSX*"
+cd "$BUNDLE_DIR"
+zip -r "$OUTPUT_FILE" . -x "*.DS_Store" -x "*__MACOSX*"
 
 # Calculate SHA-256 hash
 echo -e "${YELLOW}Calculating SHA-256 hash...${NC}"


### PR DESCRIPTION
## Summary

Fixes MCPB bundle format to enable drag-and-drop installation in Claude Desktop and VSCode.

## Related Issue
Closes #611

## Changes Made

### 1. Fixed ZIP Structure (`build-mcpb.sh`)
- **Problem**: ZIP was created with files nested in `f5xc-terraform-mcp/` subdirectory
- **Solution**: Changed to create ZIP with contents at root level
- Claude Desktop requires `manifest.json` at the root of the archive

### 2. Updated Manifest to v0.3 Spec (`manifest.json`)
- Added `manifest_version: "0.3"` (required field)
- Changed `entry` → `entry_point`
- Added `mcp_config` object with `command` and `args`
- Updated `compatibility.runtime` format
- Removed deprecated `capabilities` and `categories` fields

## Testing

Built bundle locally and verified structure:
```bash
./mcp-server/scripts/build-mcpb.sh
unzip -l build/f5xc-terraform-mcp-*.mcpb | head -20
# Confirmed manifest.json is at root, not in subdirectory
```

## Verification Steps

After merge:
1. Download the `.mcpb` from the next release
2. Drag-and-drop into Claude Desktop
3. Should install successfully without "No manifest.json found" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)