### PR TITLE
chore: update Go and check-jsonschema versions

### DIFF
--- a/.github/workflows/discover-defaults.yml
+++ b/.github/workflows/discover-defaults.yml
@@ -54,7 +54,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  GO_VERSION: '1.23'
+  GO_VERSION: '1.24'
 
 jobs:
   # ═══════════════════════════════════════════════════════════════════════════

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,7 +41,7 @@ repos:
   # Catches structural errors BEFORE they reach CI/CD
   # =============================================================================
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.34.0
+    rev: 0.36.0
     hooks:
       # GitHub Workflows (built-in hook validates against SchemaStore)
       - id: check-github-workflows


### PR DESCRIPTION
## Summary

Updates software versions identified during comprehensive dependency audit:

- **Go version**: 1.23 → 1.24 in `discover-defaults.yml` (aligns with `go.mod` and `acc-tests.yml`)
- **check-jsonschema**: 0.34.0 → 0.36.0 in `.pre-commit-config.yaml`

## Related Issue

Closes #617

## Changes Made

| File | Change |
|------|--------|
| `.github/workflows/discover-defaults.yml` | `GO_VERSION: '1.23'` → `'1.24'` |
| `.pre-commit-config.yaml` | `rev: 0.34.0` → `rev: 0.36.0` |

## Why These Updates

1. **Go 1.23 → 1.24**: The `discover-defaults.yml` workflow was using Go 1.23 while `go.mod` and `acc-tests.yml` use Go 1.24. This creates inconsistency and potential compatibility issues.

2. **check-jsonschema 0.34.0 → 0.36.0**: Latest version includes bug fixes and improved schema validation.

## Not Updated (Still Current)

All other pre-commit hooks were audited and confirmed at latest versions:
- ✅ pre-commit-hooks v6.0.0
- ✅ golangci-lint v2.7.2
- ✅ pre-commit-terraform v1.104.0
- ✅ shellcheck-py v0.11.0.1
- ✅ markdownlint-cli2 v0.20.0
- ✅ detect-secrets v1.5.0

Node.js 20 remains at current version (Maintenance LTS until April 2026).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)