### PR TITLE
fix: use forked release workflow with updated dependencies

### DIFF
--- a/.github/workflows/_tag-release.yml
+++ b/.github/workflows/_tag-release.yml
@@ -145,7 +145,10 @@ jobs:
     name: Create Release
     needs: tag
     if: needs.tag.outputs.created == 'true' && inputs.create-release
-    uses: hashicorp/ghaction-terraform-provider-release/.github/workflows/community.yml@v5
+    # Using our fork with updated action versions to fix cache 400 errors
+    # Original: hashicorp/ghaction-terraform-provider-release/.github/workflows/community.yml@v5
+    # Fork updates: checkout@v6.0.1, setup-go@v6.1.0, goreleaser@v6.4.0
+    uses: robinmordasiewicz/ghaction-terraform-provider-release/.github/workflows/community.yml@v6
     secrets:
       gpg-private-key: ${{ secrets.gpg-private-key }}
       gpg-private-key-passphrase: ${{ secrets.gpg-passphrase }}


### PR DESCRIPTION
## Summary

Replace HashiCorp's release workflow with our fork that has updated action versions to fix cache 400 errors during releases.

## Related Issue

Closes #620

## Changes

| Component | Change |
|-----------|--------|
| Release workflow | `hashicorp/...@v5` → `robinmordasiewicz/...@v6` |

## Fork Details

Created fork at: https://github.com/robinmordasiewicz/ghaction-terraform-provider-release

**Updated action versions in fork:**

| Action | Old (HashiCorp v5) | New (Fork v6) |
|--------|-------------------|---------------|
| `actions/checkout` | v4.1.6 | v6.0.1 |
| `actions/setup-go` | v5.0.1 | v6.1.0 |
| `ghaction-import-gpg` | v6.1.0 | v6.3.0 |
| `goreleaser-action` | v6.0.0 | v6.4.0 |
| `download-artifact` | v4.1.7 | v7.0.0 |

## Problem Fixed

The outdated `setup-go@v5.0.1` in HashiCorp's workflow caused cache failures:
```
##[warning]Failed to restore: Cache service responded with 400
```

This warning appeared on every release, slowing builds due to missing dependency cache.

## Benefits

1. ✅ Fixes cache 400 errors
2. ✅ Faster releases with working dependency cache
3. ✅ Control over action version updates
4. ✅ Can sync with upstream HashiCorp changes as needed

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)