### PR TITLE
test: validate forked release workflow

### DIFF
--- a/.github/workflows/_tag-release.yml
+++ b/.github/workflows/_tag-release.yml
@@ -1,6 +1,9 @@
 # Reusable workflow for version tagging and release
 # Called by: on-merge.yml
 #
+# Uses forked release action with updated dependencies for better cache performance.
+# Fork: robinmordasiewicz/ghaction-terraform-provider-release@v6
+#
 # NOTE: This workflow fetches the LATEST main HEAD to ensure tags include
 # any regeneration commits that were pushed by the on-merge workflow.
 name: Tag and Release


### PR DESCRIPTION
## Summary

Validation test for the forked release workflow (`robinmordasiewicz/ghaction-terraform-provider-release@v6`).

## Related Issue

Closes #622

## Purpose

This PR adds documentation clarifying the fork usage and triggers a release to validate:
- ✅ No cache 400 errors from `actions/setup-go`
- ✅ No Node.js deprecation warnings
- ✅ GoReleaser completes successfully
- ✅ Release artifacts are properly signed

## Changes Made

- Added descriptive comments in `_tag-release.yml` about the forked workflow

## Expected Results

When merged, the On Merge workflow should:
1. Create a version tag
2. Trigger the release workflow using our fork
3. Complete without cache warnings or errors

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)