### PR TITLE
fix(ci): document complete list of updated action versions in forked workflow

### DIFF
--- a/.github/workflows/_tag-release.yml
+++ b/.github/workflows/_tag-release.yml
@@ -150,7 +150,8 @@ jobs:
     if: needs.tag.outputs.created == 'true' && inputs.create-release
     # Using our fork with updated action versions to fix cache 400 errors
     # Original: hashicorp/ghaction-terraform-provider-release/.github/workflows/community.yml@v5
-    # Fork updates: checkout@v6.0.1, setup-go@v6.1.0, goreleaser@v6.4.0
+    # Fork updates: checkout@v6.0.1, setup-go@v6.1.0, ghaction-import-gpg@v6.3.0
+    # goreleaser@v6.4.0, download-artifact@v7.0.0
     uses: robinmordasiewicz/ghaction-terraform-provider-release/.github/workflows/community.yml@v6
     secrets:
       gpg-private-key: ${{ secrets.gpg-private-key }}


### PR DESCRIPTION
## Summary

Updated comments in `_tag-release.yml` to accurately document all action versions updated in the forked release workflow.

## Related Issue

Closes #624

## Purpose

This PR serves two purposes:
1. **Documentation**: Accurately reflect all action versions in the fork
2. **Validation**: The `fix:` commit type triggers a patch version bump, which will run the release workflow using our forked action

## Action Versions Updated in Fork

| Action | HashiCorp v5 | Our Fork v6 |
|--------|--------------|-------------|
| actions/checkout | v4.1.6 | v6.0.1 |
| actions/setup-go | v5.0.1 | v6.1.0 |
| crazy-max/ghaction-import-gpg | v6.1.0 | v6.3.0 |
| goreleaser/goreleaser-action | v6.0.0 | v6.4.0 |
| actions/download-artifact | v4.1.7 | v7.0.0 |

## Expected Results

When this PR merges, the On Merge workflow will:
1. Detect the `fix:` commit type → patch version bump
2. Create version tag (v2.15.8)
3. Run the release using our forked workflow
4. Complete **without** `##[warning]Failed to restore: Cache service responded with 400`

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)