### PR TITLE
fix: document release workflow improvements in main.go

### DIFF
--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@
 // improving clarity by grouping related properties with a single explanatory note.
 //
 // Version tagging and releases are automated via CI/CD using semantic versioning.
+// Release workflow uses forked action with updated dependencies for improved cache performance.
 // MCP server documentation is available at https://github.com/robinmordasiewicz/terraform-provider-f5xc/tree/main/mcp-server
 
 package main


### PR DESCRIPTION
## Summary

Added documentation comment to main.go noting the release workflow improvements.

## Related Issue

Closes #626

## Purpose

This PR makes a substantive code change (not just workflow file change) to trigger the full release flow, validating the forked release workflow.

## Changes Made

- Added comment in main.go documenting that the release workflow uses forked action with improved cache performance

## Expected Results

When merged, the On Merge workflow will:
1. Detect substantive code change (main.go)
2. Trigger Tag and Release job
3. Create v2.15.8 using `robinmordasiewicz/ghaction-terraform-provider-release@v6`
4. Complete **without** `##[warning]Failed to restore: Cache service responded with 400`

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)