### PR TITLE
feat: implement F5XC API v2 migration infrastructure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -407,3 +407,138 @@ jobs:
             exit 1
           fi
           echo "MCP server build validated successfully"
+
+  # ═══════════════════════════════════════════════════════════════════════════
+  # V2 Migration Validation - Compares v1 vs v2 schema generation
+  # Only runs on PRs with 'v2-migration' label
+  # ═══════════════════════════════════════════════════════════════════════════
+  migration-validation:
+    name: V2 Migration Validation
+    runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'pull_request' &&
+      contains(github.event.pull_request.labels.*.name, 'v2-migration')
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+
+      - name: Capture baseline schemas
+        id: baseline
+        run: |
+          echo "::group::Capturing baseline schema state"
+
+          # Create baseline directory
+          mkdir -p /tmp/baseline-schemas
+
+          # Copy current generated resources as baseline
+          cp internal/provider/*_resource.go /tmp/baseline-schemas/ || {
+            echo "No resource files found in internal/provider/"
+            exit 1
+          }
+
+          BASELINE_COUNT=$(ls -1 /tmp/baseline-schemas/*_resource.go 2>/dev/null | wc -l)
+          echo "Captured $BASELINE_COUNT baseline resources"
+          echo "baseline_count=$BASELINE_COUNT" >> $GITHUB_OUTPUT
+
+          echo "::endgroup::"
+
+      - name: Generate with v2 specs
+        id: generate
+        run: |
+          echo "::group::Regenerating with current specs"
+
+          # Create candidate directory
+          mkdir -p /tmp/candidate-schemas
+
+          # Check if v2 specs exist
+          if [ -f "docs/specifications/api/index.json" ]; then
+            echo "V2 specs detected (index.json present)"
+            SPEC_VERSION="v2"
+          else
+            echo "V1 specs detected (no index.json)"
+            SPEC_VERSION="v1"
+          fi
+          echo "spec_version=$SPEC_VERSION" >> $GITHUB_OUTPUT
+
+          # Run generator (this will use whichever spec version is available)
+          if ! go run tools/generate-all-schemas.go; then
+            echo "::error::Schema generation failed"
+            exit 1
+          fi
+
+          # Copy generated resources as candidate
+          cp internal/provider/*_resource.go /tmp/candidate-schemas/ || {
+            echo "::warning::No resource files generated"
+          }
+
+          CANDIDATE_COUNT=$(ls -1 /tmp/candidate-schemas/*_resource.go 2>/dev/null | wc -l)
+          echo "Generated $CANDIDATE_COUNT candidate resources"
+          echo "candidate_count=$CANDIDATE_COUNT" >> $GITHUB_OUTPUT
+
+          echo "::endgroup::"
+
+      - name: Compare schemas
+        id: compare
+        run: |
+          echo "::group::Comparing baseline vs candidate schemas"
+
+          # Run comparison tool
+          go run tools/compare-schemas/main.go \
+            --baseline /tmp/baseline-schemas \
+            --candidate /tmp/candidate-schemas \
+            --output /tmp
+
+          COMPARE_EXIT=$?
+
+          # Check for breaking changes (exit code 2)
+          if [ $COMPARE_EXIT -eq 2 ]; then
+            echo "has_breaking=true" >> $GITHUB_OUTPUT
+          else
+            echo "has_breaking=false" >> $GITHUB_OUTPUT
+          fi
+
+          echo "::endgroup::"
+
+      - name: Upload comparison report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: schema-comparison-report
+          path: |
+            /tmp/comparison-report.md
+            /tmp/comparison-report.json
+          retention-days: 30
+
+      - name: Report results
+        run: |
+          echo "=== V2 Migration Validation Results ==="
+          echo ""
+
+          if [ -f "/tmp/comparison-report.md" ]; then
+            cat /tmp/comparison-report.md
+          fi
+
+          echo ""
+          echo "=== Summary ==="
+          echo "Baseline: ${{ steps.baseline.outputs.baseline_count }} resources"
+          echo "Candidate: ${{ steps.generate.outputs.candidate_count }} resources"
+          echo "Spec Version: ${{ steps.generate.outputs.spec_version }}"
+
+          if [ "${{ steps.compare.outputs.has_breaking }}" = "true" ]; then
+            echo ""
+            echo "::error::BREAKING CHANGES DETECTED"
+            echo "Review the comparison report above and address breaking changes"
+            echo "before merging this v2-migration PR."
+            exit 1
+          fi
+
+          echo ""
+          echo "No breaking changes detected - migration validation passed"

--- a/.github/workflows/sync-openapi.yml
+++ b/.github/workflows/sync-openapi.yml
@@ -1,6 +1,10 @@
 # Scheduled workflow to sync F5 Distributed Cloud OpenAPI specifications
 # Downloads the latest specs and creates a PR if changes are detected
 # The on-merge.yml workflow handles regeneration when this PR merges
+#
+# Supports two spec sources:
+# - V2: Enriched API specs from f5xc-api-enriched repository (38 domain files + index.json)
+# - V1 (legacy): Original specs from docs.cloud.f5.com (269 individual files)
 name: Sync OpenAPI Specs
 
 on:
@@ -10,6 +14,20 @@ on:
     # 7pm Mountain Time (01:00 UTC next day during MST, 02:00 UTC during MDT)
     - cron: '0 1 * * *'
   workflow_dispatch:
+    inputs:
+      spec_source:
+        description: 'Spec source to use'
+        required: false
+        default: 'v2'
+        type: choice
+        options:
+          - v2
+          - v1
+      spec_version:
+        description: 'V2 spec version (e.g., v2.0.11, or "latest")'
+        required: false
+        default: 'latest'
+        type: string
 
 concurrency:
   group: openapi-sync
@@ -23,6 +41,11 @@ permissions:
 env:
   SPEC_DIR: docs/specifications/api
   PR_TITLE: "feat: update F5 Distributed Cloud OpenAPI specifications"
+  # V2 spec source configuration
+  ENRICHED_REPO: robinmordasiewicz/f5xc-api-enriched
+  # Default to v2 specs unless overridden
+  SPEC_SOURCE: ${{ inputs.spec_source || 'v2' }}
+  SPEC_VERSION: ${{ inputs.spec_version || 'latest' }}
 
 jobs:
   sync:
@@ -47,18 +70,66 @@ jobs:
             echo "exists=false" >> $GITHUB_OUTPUT
           fi
 
+      - name: Determine spec source and version
+        if: steps.existing_pr.outputs.exists == 'false'
+        id: spec_config
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          SPEC_SOURCE="${{ env.SPEC_SOURCE }}"
+          SPEC_VERSION="${{ env.SPEC_VERSION }}"
+
+          echo "Spec source: $SPEC_SOURCE"
+          echo "spec_source=$SPEC_SOURCE" >> $GITHUB_OUTPUT
+
+          if [ "$SPEC_SOURCE" = "v2" ]; then
+            # Determine v2 version
+            if [ "$SPEC_VERSION" = "latest" ] || [ -z "$SPEC_VERSION" ]; then
+              # Get latest release from enriched repo
+              LATEST=$(gh release list --repo "${{ env.ENRICHED_REPO }}" --limit 1 --json tagName --jq '.[0].tagName' 2>/dev/null || echo "")
+              if [ -z "$LATEST" ]; then
+                echo "::warning::Could not determine latest v2 release, falling back to v1"
+                SPEC_SOURCE="v1"
+                echo "spec_source=v1" >> $GITHUB_OUTPUT
+              else
+                SPEC_VERSION="$LATEST"
+                echo "Using latest v2 release: $SPEC_VERSION"
+              fi
+            fi
+            echo "spec_version=$SPEC_VERSION" >> $GITHUB_OUTPUT
+
+            # Build v2 download URL
+            if [ "$SPEC_SOURCE" = "v2" ]; then
+              DOWNLOAD_URL="https://github.com/${{ env.ENRICHED_REPO }}/releases/download/${SPEC_VERSION}/f5xc-api-specs-${SPEC_VERSION}.zip"
+              echo "V2 download URL: $DOWNLOAD_URL"
+              echo "download_url=$DOWNLOAD_URL" >> $GITHUB_OUTPUT
+            fi
+          fi
+
+          if [ "$SPEC_SOURCE" = "v1" ]; then
+            # V1 legacy URL
+            DOWNLOAD_URL="https://docs.cloud.f5.com/docs-v2/downloads/f5-distributed-cloud-open-api.zip"
+            echo "V1 download URL: $DOWNLOAD_URL"
+            echo "download_url=$DOWNLOAD_URL" >> $GITHUB_OUTPUT
+            echo "spec_version=v1" >> $GITHUB_OUTPUT
+          fi
+
       - name: Download OpenAPI specs
         if: steps.existing_pr.outputs.exists == 'false'
         run: |
           mkdir -p ${{ env.SPEC_DIR }}
+
+          DOWNLOAD_URL="${{ steps.spec_config.outputs.download_url }}"
+          SPEC_SOURCE="${{ steps.spec_config.outputs.spec_source }}"
+
+          echo "Downloading specs from: $DOWNLOAD_URL"
 
           # Retry logic with exponential backoff
           max_attempts=3
           attempt=1
           while [ $attempt -le $max_attempts ]; do
             echo "::group::Download attempt $attempt of $max_attempts"
-            if curl -sL --fail --retry 2 --retry-delay 5 -o openapi.zip \
-                "https://docs.cloud.f5.com/docs-v2/downloads/f5-distributed-cloud-open-api.zip"; then
+            if curl -sL --fail --retry 2 --retry-delay 5 -o openapi.zip "$DOWNLOAD_URL"; then
               echo "Download successful"
               echo "::endgroup::"
               break
@@ -75,8 +146,34 @@ jobs:
             fi
           done
 
+          # Clear existing specs before extracting
+          rm -rf ${{ env.SPEC_DIR }}/*
+
           unzip -o openapi.zip -d ${{ env.SPEC_DIR }}
           rm openapi.zip
+
+          # Verify spec structure based on source type
+          if [ "$SPEC_SOURCE" = "v2" ]; then
+            echo "Verifying v2 spec structure..."
+            if [ ! -f "${{ env.SPEC_DIR }}/index.json" ]; then
+              echo "::error::V2 spec structure invalid: index.json not found"
+              exit 1
+            fi
+            if [ ! -d "${{ env.SPEC_DIR }}/domains" ]; then
+              echo "::error::V2 spec structure invalid: domains/ directory not found"
+              exit 1
+            fi
+            DOMAIN_COUNT=$(ls -1 ${{ env.SPEC_DIR }}/domains/*.json 2>/dev/null | wc -l)
+            echo "V2 structure verified: index.json + $DOMAIN_COUNT domain files"
+          else
+            echo "Verifying v1 spec structure..."
+            SPEC_COUNT=$(ls -1 ${{ env.SPEC_DIR }}/docs-cloud-f5-com.*.ves-swagger.json 2>/dev/null | wc -l)
+            if [ "$SPEC_COUNT" -eq "0" ]; then
+              echo "::error::V1 spec structure invalid: no *.ves-swagger.json files found"
+              exit 1
+            fi
+            echo "V1 structure verified: $SPEC_COUNT spec files"
+          fi
 
       - name: Check for changes
         if: steps.existing_pr.outputs.exists == 'false'
@@ -129,15 +226,28 @@ jobs:
       - name: Create branch and commit
         if: steps.changes.outputs.changed == 'true'
         run: |
+          SPEC_SOURCE="${{ steps.spec_config.outputs.spec_source }}"
+          SPEC_VERSION="${{ steps.spec_config.outputs.spec_version }}"
+
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git checkout -b openapi-update-${{ steps.date.outputs.date }}
           git add -A
+
+          if [ "$SPEC_SOURCE" = "v2" ]; then
+            SOURCE_URL="https://github.com/${{ env.ENRICHED_REPO }}/releases/tag/${SPEC_VERSION}"
+            SPEC_INFO="V2 Enriched Specs (${SPEC_VERSION})"
+          else
+            SOURCE_URL="https://docs.cloud.f5.com/docs-v2/downloads/f5-distributed-cloud-open-api.zip"
+            SPEC_INFO="V1 Legacy Specs"
+          fi
+
           git commit -m "${{ env.PR_TITLE }}
 
           Automated sync from F5 Distributed Cloud OpenAPI specifications.
 
-          Source: https://docs.cloud.f5.com/docs-v2/downloads/f5-distributed-cloud-open-api.zip
+          Spec Format: ${SPEC_INFO}
+          Source: ${SOURCE_URL}
           Date: ${{ steps.date.outputs.date }}
 
           When this PR merges, the on-merge workflow will:
@@ -210,15 +320,44 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.AUTO_MERGE_TOKEN }}
         run: |
+          SPEC_SOURCE="${{ steps.spec_config.outputs.spec_source }}"
+          SPEC_VERSION="${{ steps.spec_config.outputs.spec_version }}"
+
+          if [ "$SPEC_SOURCE" = "v2" ]; then
+            SOURCE_URL="https://github.com/${{ env.ENRICHED_REPO }}/releases/tag/${SPEC_VERSION}"
+            SPEC_INFO="V2 Enriched Specs"
+            V2_NOTE="
+          ## V2 Enriched Specs
+
+          This update uses enriched API specifications with:
+          - \`x-f5xc-category\`: Official resource categorization
+          - \`x-f5xc-requires-tier\`: Subscription tier requirements
+          - \`x-f5xc-example\`: Enhanced example values
+          - \`x-f5xc-description-*\`: Improved descriptions"
+          else
+            SOURCE_URL="https://docs.cloud.f5.com/docs-v2/downloads/f5-distributed-cloud-open-api.zip"
+            SPEC_INFO="V1 Legacy Specs"
+            V2_NOTE=""
+          fi
+
+          # Add v2-migration label if using v2 specs
+          LABELS="automated,openapi-update"
+          if [ "$SPEC_SOURCE" = "v2" ]; then
+            LABELS="$LABELS,v2-migration"
+          fi
+
           PR_URL=$(gh pr create \
             --title "${{ env.PR_TITLE }}" \
             --body "## Summary
 
           This PR updates the F5 Distributed Cloud OpenAPI specifications.
 
-          **Source:** https://docs.cloud.f5.com/docs-v2/downloads/f5-distributed-cloud-open-api.zip
+          **Spec Format:** ${SPEC_INFO}
+          **Version:** ${SPEC_VERSION}
+          **Source:** ${SOURCE_URL}
           **Date:** ${{ steps.date.outputs.date }}
           **Tracking Issue:** #${{ steps.issue.outputs.result }}
+          ${V2_NOTE}
 
           ## What happens when this merges?
 
@@ -238,7 +377,7 @@ jobs:
           🤖 Generated with [Claude Code](https://claude.com/claude-code)
 
           Closes #${{ steps.issue.outputs.result }}" \
-            --label "automated,openapi-update")
+            --label "$LABELS")
 
           PR_NUM=$(echo "$PR_URL" | grep -oE '[0-9]+$')
           echo "number=$PR_NUM" >> $GITHUB_OUTPUT

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -679,9 +679,9 @@
         "filename": "tools/generate-examples.go",
         "hashed_secret": "25910f981e85ca04baf359199dd0bd4a3ae738b6",
         "is_verified": false,
-        "line_number": 682
+        "line_number": 693
       }
     ]
   },
-  "generated_at": "2025-12-18T15:50:01Z"
+  "generated_at": "2026-01-05T17:59:47Z"
 }

--- a/templates/guides/v3-migration.md
+++ b/templates/guides/v3-migration.md
@@ -1,0 +1,149 @@
+---
+page_title: "Guide: Migrating to Provider v3.0.0"
+subcategory: "Guides"
+description: |-
+  Migration guide for upgrading from F5XC Terraform provider v2.x to v3.0.0,
+  which introduces enriched API specifications and improved documentation.
+---
+
+# Migrating to Provider v3.0.0
+
+This guide covers the migration from F5XC Terraform provider v2.x to v3.0.0. Version 3.0.0 introduces significant improvements to the provider's API specification foundation, bringing enhanced documentation, better categorization, and improved example generation.
+
+## Overview
+
+Provider v3.0.0 represents a major upgrade to the underlying API specification infrastructure:
+
+| Aspect | v2.x | v3.0.0 |
+| ------ | ---- | ------ |
+| **API Specs** | 269 individual files | 38 domain-organized files |
+| **Categories** | Pattern-based | API-defined (`x-f5xc-category`) |
+| **Subscription Info** | Static metadata | API-defined (`x-f5xc-requires-tier`) |
+| **Examples** | Hardcoded | API-enriched (`x-f5xc-example`) |
+| **Descriptions** | Schema-only | Multi-level descriptions |
+
+## What's New
+
+### Improved Resource Categorization
+
+Resources are now categorized based on official F5 API metadata rather than pattern matching. This provides more accurate Terraform Registry navigation:
+
+- **Security**: WAF, DDoS protection, certificates, blindfold encryption
+- **Networking**: DNS, CDN, network policies, rate limiting
+- **Infrastructure**: Sites, service mesh, cloud infrastructure
+- **Platform**: Tenants, identity, authentication, billing
+- **Operations**: Observability, statistics, support
+- **AI Services**: AI-powered features (preview)
+
+### Enhanced Documentation
+
+Documentation now includes:
+
+- **Subscription badges**: Clear indication when Advanced subscription is required
+- **Preview notices**: Warning when features are in preview/beta status
+- **Improved descriptions**: Enriched descriptions from API metadata
+- **Better examples**: API-sourced example values for attributes
+
+### Specification Foundation
+
+The provider now uses enriched API specifications that include:
+
+- `x-f5xc-category`: Official resource categorization
+- `x-f5xc-requires-tier`: Subscription tier requirements
+- `x-f5xc-complexity`: Resource complexity indicators
+- `x-f5xc-is-preview`: Preview/beta feature flags
+- `x-f5xc-example`: Enriched example values
+
+## Migration Steps
+
+### Step 1: Update Provider Version
+
+Update your Terraform configuration to use v3.0.0:
+
+```hcl
+terraform {
+  required_providers {
+    f5xc = {
+      source  = "robinmordasiewicz/f5xc"
+      version = "~> 3.0"
+    }
+  }
+}
+```
+
+### Step 2: Run Terraform Plan
+
+After updating, run `terraform plan` to verify your configuration:
+
+```bash
+terraform init -upgrade
+terraform plan
+```
+
+### Step 3: Review Any Warnings
+
+Version 3.0.0 may display new warnings about:
+
+- **Subscription requirements**: Resources now clearly indicate when Advanced subscription is needed
+- **Preview features**: Some features may be marked as preview with potential for change
+- **Deprecations**: Any deprecated attributes will be clearly documented
+
+## Breaking Changes
+
+Version 3.0.0 maintains backward compatibility with v2.x configurations. However, be aware of:
+
+### Documentation Changes
+
+- Resource subcategories in the Terraform Registry may change due to improved categorization
+- Example configurations may be updated to reflect API-enriched values
+
+### Potential State Changes
+
+No state migration is required. Your existing Terraform state files will continue to work without modification.
+
+## Compatibility Matrix
+
+| Terraform Version | Provider v3.0.0 |
+| ----------------- | --------------- |
+| 1.8.0+            | Supported       |
+| 1.7.x             | Supported       |
+| 1.6.x             | Supported       |
+| 1.5.x             | Supported       |
+| < 1.5.0           | Not supported   |
+
+## Troubleshooting
+
+### Issue: "Subscription Required" Warning
+
+If you see a subscription warning for a resource you're using:
+
+1. Verify your F5 Distributed Cloud subscription tier
+2. Contact F5 support if you believe the warning is incorrect
+3. Check the resource documentation for subscription requirements
+
+### Issue: Changes Detected After Upgrade
+
+If `terraform plan` shows changes after upgrading:
+
+1. Review the changes carefully - they may be improvements to default values
+2. The changes are typically cosmetic (descriptions, examples)
+3. Run `terraform apply` to update the state if changes are acceptable
+
+### Issue: Resource Category Changed
+
+If you have automation relying on resource subcategories:
+
+1. Update your automation to use the new category names
+2. The new categories align with official F5 API organization
+
+## Getting Help
+
+- **Documentation**: [Provider Documentation](https://registry.terraform.io/providers/robinmordasiewicz/f5xc/latest/docs)
+- **Issues**: [GitHub Issues](https://github.com/robinmordasiewicz/terraform-provider-f5xc/issues)
+- **F5 Support**: [F5 Distributed Cloud Console](https://console.ves.volterra.io)
+
+## Related Guides
+
+- [Authentication Guide](authentication)
+- [HTTP Load Balancer Guide](http-loadbalancer)
+- [Blindfold Encryption Guide](blindfold)

--- a/tools/compare-schemas/main.go
+++ b/tools/compare-schemas/main.go
@@ -1,0 +1,580 @@
+//go:build ignore
+// +build ignore
+
+// This tool compares Terraform provider schemas between two generations
+// (e.g., v1 vs v2 OpenAPI spec-based generation) to detect regressions.
+//
+// Usage:
+//
+//	go run tools/compare-schemas/main.go --baseline <dir> --candidate <dir>
+//
+// The tool detects:
+//   - Missing resources (present in baseline but not candidate)
+//   - New resources (present in candidate but not baseline)
+//   - Missing attributes (attributes in baseline but not candidate)
+//   - New attributes (attributes in candidate but not baseline)
+//   - Type changes (attribute type differs between versions)
+//
+// Output:
+//   - comparison-report.md: Human-readable report
+//   - comparison-report.json: Machine-readable report
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// SchemaInfo holds extracted schema information for a resource
+type SchemaInfo struct {
+	Name       string                 `json:"name"`
+	Attributes map[string]AttrInfo    `json:"attributes"`
+	FilePath   string                 `json:"file_path,omitempty"`
+}
+
+// AttrInfo holds information about a single attribute
+type AttrInfo struct {
+	Name        string `json:"name"`
+	Type        string `json:"type"`
+	Required    bool   `json:"required"`
+	Optional    bool   `json:"optional"`
+	Computed    bool   `json:"computed"`
+	Description string `json:"description,omitempty"`
+}
+
+// ComparisonReport holds the full comparison results
+type ComparisonReport struct {
+	Summary     ReportSummary        `json:"summary"`
+	Missing     []ResourceDiff       `json:"missing_resources"`
+	New         []ResourceDiff       `json:"new_resources"`
+	Changed     []ResourceChange     `json:"changed_resources"`
+	Unchanged   []string             `json:"unchanged_resources"`
+}
+
+// ReportSummary provides overview statistics
+type ReportSummary struct {
+	BaselineResources  int  `json:"baseline_resources"`
+	CandidateResources int  `json:"candidate_resources"`
+	MissingCount       int  `json:"missing_count"`
+	NewCount           int  `json:"new_count"`
+	ChangedCount       int  `json:"changed_count"`
+	UnchangedCount     int  `json:"unchanged_count"`
+	HasBreaking        bool `json:"has_breaking_changes"`
+}
+
+// ResourceDiff represents a resource that exists in one version but not the other
+type ResourceDiff struct {
+	Name           string `json:"name"`
+	AttributeCount int    `json:"attribute_count"`
+}
+
+// ResourceChange represents changes to a resource between versions
+type ResourceChange struct {
+	Name               string       `json:"name"`
+	MissingAttributes  []AttrDiff   `json:"missing_attributes,omitempty"`
+	NewAttributes      []AttrDiff   `json:"new_attributes,omitempty"`
+	TypeChanges        []TypeChange `json:"type_changes,omitempty"`
+	IsBreaking         bool         `json:"is_breaking"`
+}
+
+// AttrDiff represents an attribute difference
+type AttrDiff struct {
+	Name     string `json:"name"`
+	Type     string `json:"type"`
+	Required bool   `json:"required"`
+}
+
+// TypeChange represents an attribute type change
+type TypeChange struct {
+	Name        string `json:"name"`
+	OldType     string `json:"old_type"`
+	NewType     string `json:"new_type"`
+	IsBreaking  bool   `json:"is_breaking"`
+}
+
+func main() {
+	baselineDir := flag.String("baseline", "", "Directory containing baseline provider resources")
+	candidateDir := flag.String("candidate", "", "Directory containing candidate provider resources")
+	outputDir := flag.String("output", ".", "Output directory for reports")
+	flag.Parse()
+
+	if *baselineDir == "" || *candidateDir == "" {
+		fmt.Fprintf(os.Stderr, "Usage: go run main.go --baseline <dir> --candidate <dir> [--output <dir>]\n")
+		fmt.Fprintf(os.Stderr, "\nCompare Terraform provider schemas between two generation runs.\n\n")
+		fmt.Fprintf(os.Stderr, "Arguments:\n")
+		fmt.Fprintf(os.Stderr, "  --baseline   Directory with baseline *_resource.go files\n")
+		fmt.Fprintf(os.Stderr, "  --candidate  Directory with candidate *_resource.go files\n")
+		fmt.Fprintf(os.Stderr, "  --output     Output directory for reports (default: current)\n")
+		os.Exit(1)
+	}
+
+	fmt.Printf("Comparing schemas:\n")
+	fmt.Printf("  Baseline:  %s\n", *baselineDir)
+	fmt.Printf("  Candidate: %s\n", *candidateDir)
+
+	// Extract schemas from both directories
+	baseline, err := extractSchemas(*baselineDir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error extracting baseline schemas: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Printf("  Baseline resources: %d\n", len(baseline))
+
+	candidate, err := extractSchemas(*candidateDir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error extracting candidate schemas: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Printf("  Candidate resources: %d\n", len(candidate))
+
+	// Compare schemas
+	report := compareSchemas(baseline, candidate)
+
+	// Generate reports
+	mdPath := filepath.Join(*outputDir, "comparison-report.md")
+	if err := writeMarkdownReport(report, mdPath); err != nil {
+		fmt.Fprintf(os.Stderr, "Error writing markdown report: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Printf("  Generated: %s\n", mdPath)
+
+	jsonPath := filepath.Join(*outputDir, "comparison-report.json")
+	if err := writeJSONReport(report, jsonPath); err != nil {
+		fmt.Fprintf(os.Stderr, "Error writing JSON report: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Printf("  Generated: %s\n", jsonPath)
+
+	// Print summary
+	fmt.Printf("\nSummary:\n")
+	fmt.Printf("  Missing resources:  %d\n", report.Summary.MissingCount)
+	fmt.Printf("  New resources:      %d\n", report.Summary.NewCount)
+	fmt.Printf("  Changed resources:  %d\n", report.Summary.ChangedCount)
+	fmt.Printf("  Unchanged resources: %d\n", report.Summary.UnchangedCount)
+
+	if report.Summary.HasBreaking {
+		fmt.Printf("\n  BREAKING CHANGES DETECTED\n")
+		os.Exit(2)
+	}
+}
+
+// extractSchemas parses Go files and extracts schema information
+func extractSchemas(dir string) (map[string]SchemaInfo, error) {
+	schemas := make(map[string]SchemaInfo)
+
+	files, err := filepath.Glob(filepath.Join(dir, "*_resource.go"))
+	if err != nil {
+		return nil, err
+	}
+
+	for _, file := range files {
+		schema, err := extractSchemaFromFile(file)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Could not extract schema from %s: %v\n", file, err)
+			continue
+		}
+		if schema.Name != "" {
+			schemas[schema.Name] = schema
+		}
+	}
+
+	return schemas, nil
+}
+
+// extractSchemaFromFile parses a single Go file and extracts schema info
+func extractSchemaFromFile(filePath string) (SchemaInfo, error) {
+	schema := SchemaInfo{
+		Attributes: make(map[string]AttrInfo),
+		FilePath:   filePath,
+	}
+
+	// Extract resource name from filename
+	base := filepath.Base(filePath)
+	schema.Name = strings.TrimSuffix(base, "_resource.go")
+
+	// Parse the Go file
+	fset := token.NewFileSet()
+	node, err := parser.ParseFile(fset, filePath, nil, parser.ParseComments)
+	if err != nil {
+		return schema, err
+	}
+
+	// Find the model struct (usually named *Model)
+	ast.Inspect(node, func(n ast.Node) bool {
+		typeSpec, ok := n.(*ast.TypeSpec)
+		if !ok {
+			return true
+		}
+
+		// Look for structs ending with "Model"
+		if !strings.HasSuffix(typeSpec.Name.Name, "Model") {
+			return true
+		}
+
+		structType, ok := typeSpec.Type.(*ast.StructType)
+		if !ok {
+			return true
+		}
+
+		// Extract fields
+		for _, field := range structType.Fields.List {
+			if field.Tag == nil {
+				continue
+			}
+
+			attr := extractAttrFromField(field)
+			if attr.Name != "" {
+				schema.Attributes[attr.Name] = attr
+			}
+		}
+
+		return true
+	})
+
+	return schema, nil
+}
+
+// extractAttrFromField extracts attribute info from a struct field
+func extractAttrFromField(field *ast.Field) AttrInfo {
+	attr := AttrInfo{}
+
+	// Get field name
+	if len(field.Names) > 0 {
+		attr.Name = field.Names[0].Name
+	}
+
+	// Get field type
+	attr.Type = extractTypeString(field.Type)
+
+	// Parse tfsdk tag for the attribute name used in Terraform
+	if field.Tag != nil {
+		tag := field.Tag.Value
+		tfsdkRegex := regexp.MustCompile(`tfsdk:"([^"]+)"`)
+		if match := tfsdkRegex.FindStringSubmatch(tag); len(match) > 1 {
+			attr.Name = match[1]
+		}
+	}
+
+	return attr
+}
+
+// extractTypeString converts an AST type to a string representation
+func extractTypeString(expr ast.Expr) string {
+	switch t := expr.(type) {
+	case *ast.Ident:
+		return t.Name
+	case *ast.SelectorExpr:
+		if x, ok := t.X.(*ast.Ident); ok {
+			return x.Name + "." + t.Sel.Name
+		}
+		return t.Sel.Name
+	case *ast.ArrayType:
+		return "[]" + extractTypeString(t.Elt)
+	case *ast.StarExpr:
+		return "*" + extractTypeString(t.X)
+	case *ast.MapType:
+		return "map[" + extractTypeString(t.Key) + "]" + extractTypeString(t.Value)
+	case *ast.IndexExpr:
+		return extractTypeString(t.X) + "[" + extractTypeString(t.Index) + "]"
+	default:
+		return "unknown"
+	}
+}
+
+// compareSchemas compares baseline and candidate schemas
+func compareSchemas(baseline, candidate map[string]SchemaInfo) ComparisonReport {
+	report := ComparisonReport{
+		Missing:   []ResourceDiff{},
+		New:       []ResourceDiff{},
+		Changed:   []ResourceChange{},
+		Unchanged: []string{},
+	}
+
+	// Find missing resources (in baseline but not candidate)
+	for name, schema := range baseline {
+		if _, ok := candidate[name]; !ok {
+			report.Missing = append(report.Missing, ResourceDiff{
+				Name:           name,
+				AttributeCount: len(schema.Attributes),
+			})
+		}
+	}
+
+	// Find new resources (in candidate but not baseline)
+	for name, schema := range candidate {
+		if _, ok := baseline[name]; !ok {
+			report.New = append(report.New, ResourceDiff{
+				Name:           name,
+				AttributeCount: len(schema.Attributes),
+			})
+		}
+	}
+
+	// Compare resources that exist in both
+	for name, baseSchema := range baseline {
+		candSchema, ok := candidate[name]
+		if !ok {
+			continue
+		}
+
+		change := compareResourceSchemas(name, baseSchema, candSchema)
+		if len(change.MissingAttributes) > 0 || len(change.NewAttributes) > 0 || len(change.TypeChanges) > 0 {
+			report.Changed = append(report.Changed, change)
+		} else {
+			report.Unchanged = append(report.Unchanged, name)
+		}
+	}
+
+	// Sort results
+	sort.Slice(report.Missing, func(i, j int) bool { return report.Missing[i].Name < report.Missing[j].Name })
+	sort.Slice(report.New, func(i, j int) bool { return report.New[i].Name < report.New[j].Name })
+	sort.Slice(report.Changed, func(i, j int) bool { return report.Changed[i].Name < report.Changed[j].Name })
+	sort.Strings(report.Unchanged)
+
+	// Calculate summary
+	report.Summary = ReportSummary{
+		BaselineResources:  len(baseline),
+		CandidateResources: len(candidate),
+		MissingCount:       len(report.Missing),
+		NewCount:           len(report.New),
+		ChangedCount:       len(report.Changed),
+		UnchangedCount:     len(report.Unchanged),
+		HasBreaking:        len(report.Missing) > 0,
+	}
+
+	// Check for breaking changes in changed resources
+	for _, change := range report.Changed {
+		if change.IsBreaking {
+			report.Summary.HasBreaking = true
+			break
+		}
+	}
+
+	return report
+}
+
+// compareResourceSchemas compares two versions of a resource schema
+func compareResourceSchemas(name string, baseline, candidate SchemaInfo) ResourceChange {
+	change := ResourceChange{
+		Name:              name,
+		MissingAttributes: []AttrDiff{},
+		NewAttributes:     []AttrDiff{},
+		TypeChanges:       []TypeChange{},
+	}
+
+	// Find missing attributes
+	for attrName, baseAttr := range baseline.Attributes {
+		if _, ok := candidate.Attributes[attrName]; !ok {
+			change.MissingAttributes = append(change.MissingAttributes, AttrDiff{
+				Name:     attrName,
+				Type:     baseAttr.Type,
+				Required: baseAttr.Required,
+			})
+			if baseAttr.Required {
+				change.IsBreaking = true
+			}
+		}
+	}
+
+	// Find new attributes
+	for attrName, candAttr := range candidate.Attributes {
+		if _, ok := baseline.Attributes[attrName]; !ok {
+			change.NewAttributes = append(change.NewAttributes, AttrDiff{
+				Name:     attrName,
+				Type:     candAttr.Type,
+				Required: candAttr.Required,
+			})
+			// New required attributes are breaking changes
+			if candAttr.Required {
+				change.IsBreaking = true
+			}
+		}
+	}
+
+	// Find type changes
+	for attrName, baseAttr := range baseline.Attributes {
+		candAttr, ok := candidate.Attributes[attrName]
+		if !ok {
+			continue
+		}
+
+		if baseAttr.Type != candAttr.Type {
+			isBreaking := isBreakingTypeChange(baseAttr.Type, candAttr.Type)
+			change.TypeChanges = append(change.TypeChanges, TypeChange{
+				Name:       attrName,
+				OldType:    baseAttr.Type,
+				NewType:    candAttr.Type,
+				IsBreaking: isBreaking,
+			})
+			if isBreaking {
+				change.IsBreaking = true
+			}
+		}
+	}
+
+	// Sort results
+	sort.Slice(change.MissingAttributes, func(i, j int) bool { return change.MissingAttributes[i].Name < change.MissingAttributes[j].Name })
+	sort.Slice(change.NewAttributes, func(i, j int) bool { return change.NewAttributes[i].Name < change.NewAttributes[j].Name })
+	sort.Slice(change.TypeChanges, func(i, j int) bool { return change.TypeChanges[i].Name < change.TypeChanges[j].Name })
+
+	return change
+}
+
+// isBreakingTypeChange determines if a type change is breaking
+func isBreakingTypeChange(oldType, newType string) bool {
+	// Type changes are generally breaking, with some exceptions
+
+	// Optional/nullable changes might not be breaking
+	oldNormalized := strings.TrimPrefix(oldType, "*")
+	newNormalized := strings.TrimPrefix(newType, "*")
+
+	if oldNormalized == newNormalized {
+		return false // Adding/removing pointer is usually not breaking
+	}
+
+	// Widening changes (string -> types.String) are usually not breaking
+	terraformTypes := map[string]string{
+		"string":    "types.String",
+		"int64":     "types.Int64",
+		"bool":      "types.Bool",
+		"float64":   "types.Float64",
+	}
+
+	if tfType, ok := terraformTypes[oldType]; ok && newType == tfType {
+		return false
+	}
+
+	return true
+}
+
+// writeMarkdownReport generates a human-readable report
+func writeMarkdownReport(report ComparisonReport, path string) error {
+	var sb strings.Builder
+
+	sb.WriteString("# Schema Comparison Report\n\n")
+
+	// Summary
+	sb.WriteString("## Summary\n\n")
+	sb.WriteString(fmt.Sprintf("| Metric | Count |\n"))
+	sb.WriteString("| ------ | ----- |\n")
+	sb.WriteString(fmt.Sprintf("| Baseline Resources | %d |\n", report.Summary.BaselineResources))
+	sb.WriteString(fmt.Sprintf("| Candidate Resources | %d |\n", report.Summary.CandidateResources))
+	sb.WriteString(fmt.Sprintf("| Missing Resources | %d |\n", report.Summary.MissingCount))
+	sb.WriteString(fmt.Sprintf("| New Resources | %d |\n", report.Summary.NewCount))
+	sb.WriteString(fmt.Sprintf("| Changed Resources | %d |\n", report.Summary.ChangedCount))
+	sb.WriteString(fmt.Sprintf("| Unchanged Resources | %d |\n", report.Summary.UnchangedCount))
+	sb.WriteString("\n")
+
+	if report.Summary.HasBreaking {
+		sb.WriteString("**BREAKING CHANGES DETECTED**\n\n")
+	}
+
+	// Missing resources
+	if len(report.Missing) > 0 {
+		sb.WriteString("## Missing Resources\n\n")
+		sb.WriteString("Resources present in baseline but missing from candidate:\n\n")
+		sb.WriteString("| Resource | Attributes |\n")
+		sb.WriteString("| -------- | ---------- |\n")
+		for _, r := range report.Missing {
+			sb.WriteString(fmt.Sprintf("| `%s` | %d |\n", r.Name, r.AttributeCount))
+		}
+		sb.WriteString("\n")
+	}
+
+	// New resources
+	if len(report.New) > 0 {
+		sb.WriteString("## New Resources\n\n")
+		sb.WriteString("Resources present in candidate but not in baseline:\n\n")
+		sb.WriteString("| Resource | Attributes |\n")
+		sb.WriteString("| -------- | ---------- |\n")
+		for _, r := range report.New {
+			sb.WriteString(fmt.Sprintf("| `%s` | %d |\n", r.Name, r.AttributeCount))
+		}
+		sb.WriteString("\n")
+	}
+
+	// Changed resources
+	if len(report.Changed) > 0 {
+		sb.WriteString("## Changed Resources\n\n")
+		for _, change := range report.Changed {
+			breakingMark := ""
+			if change.IsBreaking {
+				breakingMark = " **BREAKING**"
+			}
+			sb.WriteString(fmt.Sprintf("### `%s`%s\n\n", change.Name, breakingMark))
+
+			if len(change.MissingAttributes) > 0 {
+				sb.WriteString("**Missing Attributes:**\n\n")
+				sb.WriteString("| Attribute | Type | Required |\n")
+				sb.WriteString("| --------- | ---- | -------- |\n")
+				for _, attr := range change.MissingAttributes {
+					req := ""
+					if attr.Required {
+						req = "Yes"
+					}
+					sb.WriteString(fmt.Sprintf("| `%s` | `%s` | %s |\n", attr.Name, attr.Type, req))
+				}
+				sb.WriteString("\n")
+			}
+
+			if len(change.NewAttributes) > 0 {
+				sb.WriteString("**New Attributes:**\n\n")
+				sb.WriteString("| Attribute | Type | Required |\n")
+				sb.WriteString("| --------- | ---- | -------- |\n")
+				for _, attr := range change.NewAttributes {
+					req := ""
+					if attr.Required {
+						req = "Yes"
+					}
+					sb.WriteString(fmt.Sprintf("| `%s` | `%s` | %s |\n", attr.Name, attr.Type, req))
+				}
+				sb.WriteString("\n")
+			}
+
+			if len(change.TypeChanges) > 0 {
+				sb.WriteString("**Type Changes:**\n\n")
+				sb.WriteString("| Attribute | Old Type | New Type | Breaking |\n")
+				sb.WriteString("| --------- | -------- | -------- | -------- |\n")
+				for _, tc := range change.TypeChanges {
+					breaking := ""
+					if tc.IsBreaking {
+						breaking = "Yes"
+					}
+					sb.WriteString(fmt.Sprintf("| `%s` | `%s` | `%s` | %s |\n", tc.Name, tc.OldType, tc.NewType, breaking))
+				}
+				sb.WriteString("\n")
+			}
+		}
+	}
+
+	// Unchanged resources (collapsed)
+	if len(report.Unchanged) > 0 {
+		sb.WriteString("## Unchanged Resources\n\n")
+		sb.WriteString("<details>\n")
+		sb.WriteString("<summary>Click to expand list of unchanged resources</summary>\n\n")
+		for _, name := range report.Unchanged {
+			sb.WriteString(fmt.Sprintf("- `%s`\n", name))
+		}
+		sb.WriteString("\n</details>\n")
+	}
+
+	return os.WriteFile(path, []byte(sb.String()), 0644)
+}
+
+// writeJSONReport generates a machine-readable report
+func writeJSONReport(report ComparisonReport, path string) error {
+	data, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0644)
+}

--- a/tools/pkg/openapi/parser.go
+++ b/tools/pkg/openapi/parser.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"sync"
 )
 
 // ParseFile reads and parses an OpenAPI specification file.
@@ -120,4 +121,443 @@ func GetAPIDocURL(resourceName string, pathMap map[string]string) string {
 		return fmt.Sprintf("https://docs.cloud.f5.com/docs-v2/api/%s", urlPath)
 	}
 	return ""
+}
+
+// =============================================================================
+// V2 Spec Parser Functions - For parsing enriched API specifications
+// =============================================================================
+
+// GetSpecVersion detects whether a spec directory contains v1 or v2 format.
+// v2 has index.json and domains/ subdirectory.
+// v1 has individual docs-cloud-f5-com.*.ves-swagger.json files.
+func GetSpecVersion(specDir string) SpecVersion {
+	// Check for v2 indicators
+	indexPath := filepath.Join(specDir, "index.json")
+	domainsDir := filepath.Join(specDir, "domains")
+
+	indexExists := fileExists(indexPath)
+	domainsExists := dirExists(domainsDir)
+
+	if indexExists && domainsExists {
+		return SpecVersionV2
+	}
+
+	// Check for v1 pattern
+	v1Pattern := filepath.Join(specDir, "docs-cloud-f5-com.*.ves-swagger.json")
+	v1Files, _ := filepath.Glob(v1Pattern)
+	if len(v1Files) > 0 {
+		return SpecVersionV1
+	}
+
+	return SpecVersionUnknown
+}
+
+// IsV2SpecDirectory returns true if the directory contains v2 spec structure.
+func IsV2SpecDirectory(specDir string) bool {
+	return GetSpecVersion(specDir) == SpecVersionV2
+}
+
+// ParseIndex reads and parses the index.json manifest file.
+func ParseIndex(path string) (*Index, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading index file: %w", err)
+	}
+
+	var index Index
+	if err := json.Unmarshal(data, &index); err != nil {
+		return nil, fmt.Errorf("parsing index JSON: %w", err)
+	}
+
+	return &index, nil
+}
+
+// ParseIndexFromDir reads the index.json from a spec directory.
+func ParseIndexFromDir(specDir string) (*Index, error) {
+	indexPath := filepath.Join(specDir, "index.json")
+	return ParseIndex(indexPath)
+}
+
+// FindDomainSpecFiles finds all domain specification files in a v2 spec directory.
+// Returns paths to all .json files in the domains/ subdirectory.
+func FindDomainSpecFiles(specDir string) ([]string, error) {
+	domainsDir := filepath.Join(specDir, "domains")
+	if !dirExists(domainsDir) {
+		return nil, fmt.Errorf("domains directory not found: %s", domainsDir)
+	}
+
+	pattern := filepath.Join(domainsDir, "*.json")
+	files, err := filepath.Glob(pattern)
+	if err != nil {
+		return nil, fmt.Errorf("globbing domain files: %w", err)
+	}
+
+	return files, nil
+}
+
+// ParseDomainSpec reads and parses a domain specification file.
+func ParseDomainSpec(path string) (*DomainSpec, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading domain spec: %w", err)
+	}
+
+	var spec DomainSpec
+	if err := json.Unmarshal(data, &spec); err != nil {
+		return nil, fmt.Errorf("parsing domain spec JSON: %w", err)
+	}
+
+	return &spec, nil
+}
+
+// DomainSpecInfo contains parsed information about a domain and its resources.
+type DomainSpecInfo struct {
+	DomainName    string
+	Category      string
+	RequiresTier  string
+	Complexity    string
+	IsPreview     bool
+	Resources     []ExtractedResource
+	SourceFile    string
+	Spec          *DomainSpec
+}
+
+// ExtractedResource contains information about a single resource extracted from a domain.
+type ExtractedResource struct {
+	Name             string
+	SchemaName       string  // Full schema name in components/schemas
+	Description      string
+	APIPath          string
+	RequiresTier     string
+	Complexity       string
+	Category         string  // Inherited from domain if not specified
+	IsPreview        bool    // Inherited from domain if not specified
+	DomainName       string  // Parent domain
+}
+
+// ExtractResourcesFromDomain parses a domain spec and extracts resource information.
+// It identifies CRUD resources by looking for Create/Get/Update/Delete operations.
+func ExtractResourcesFromDomain(specPath string) (*DomainSpecInfo, error) {
+	spec, err := ParseDomainSpec(specPath)
+	if err != nil {
+		return nil, err
+	}
+
+	domainName := filepath.Base(specPath)
+	domainName = strings.TrimSuffix(domainName, ".json")
+
+	info := &DomainSpecInfo{
+		DomainName:   domainName,
+		Category:     spec.XF5XCCategory,
+		RequiresTier: spec.XF5XCRequiresTier,
+		Complexity:   spec.XF5XCComplexity,
+		IsPreview:    spec.XF5XCIsPreview,
+		SourceFile:   specPath,
+		Spec:         spec,
+		Resources:    []ExtractedResource{},
+	}
+
+	// Extract resources from paths by looking for CRUD operations
+	// Pattern: /api/config/namespaces/{namespace}/{resource_type} with POST (Create)
+	resourcePaths := extractResourcePathsFromPaths(spec.Paths)
+
+	for _, rp := range resourcePaths {
+		resource := ExtractedResource{
+			Name:         rp.ResourceName,
+			SchemaName:   rp.SchemaName,
+			APIPath:      rp.APIPath,
+			DomainName:   domainName,
+			Category:     info.Category,    // Inherit from domain
+			IsPreview:    info.IsPreview,   // Inherit from domain
+			RequiresTier: info.RequiresTier, // Inherit from domain
+			Complexity:   info.Complexity,  // Inherit from domain
+		}
+
+		// Try to get description from schema if available
+		if schema, ok := spec.Components.Schemas[rp.SchemaName]; ok {
+			resource.Description = schema.Description
+			// Override with resource-level x-f5xc-* if specified
+			if schema.XF5XCRequiresTier != "" {
+				resource.RequiresTier = schema.XF5XCRequiresTier
+			}
+			if schema.XF5XCComplexity != "" {
+				resource.Complexity = schema.XF5XCComplexity
+			}
+			if schema.XF5XCCategory != "" {
+				resource.Category = schema.XF5XCCategory
+			}
+		}
+
+		info.Resources = append(info.Resources, resource)
+	}
+
+	return info, nil
+}
+
+// resourcePath holds information about a resource path extracted from OpenAPI paths.
+type resourcePath struct {
+	ResourceName string
+	SchemaName   string
+	APIPath      string
+}
+
+// extractResourcePathsFromPaths analyzes OpenAPI paths to find CRUD resource patterns.
+func extractResourcePathsFromPaths(paths map[string]interface{}) []resourcePath {
+	var results []resourcePath
+	seen := make(map[string]bool)
+
+	// Pattern: /api/config/namespaces/{namespace}/{resource_plural}
+	configPathRegex := regexp.MustCompile(`^/api/config/namespaces/\{namespace\}/([a-z_]+s)$`)
+
+	for path := range paths {
+		matches := configPathRegex.FindStringSubmatch(path)
+		if matches == nil || len(matches) < 2 {
+			continue
+		}
+
+		resourcePlural := matches[1]
+		// Convert plural to singular (simple heuristic)
+		resourceName := strings.TrimSuffix(resourcePlural, "s")
+		if strings.HasSuffix(resourceName, "ie") {
+			resourceName = strings.TrimSuffix(resourceName, "ie") + "y"
+		}
+
+		if seen[resourceName] {
+			continue
+		}
+		seen[resourceName] = true
+
+		// Schema name is typically the request/response type
+		// Convention: ves.io.schema.{resource}.Object or similar
+		schemaName := fmt.Sprintf("ves.io.schema.%s.Object", resourceName)
+
+		results = append(results, resourcePath{
+			ResourceName: resourceName,
+			SchemaName:   schemaName,
+			APIPath:      path,
+		})
+	}
+
+	return results
+}
+
+// GetExampleValue returns the best available example for a schema field.
+// Priority: x-f5xc-example > x-ves-example > empty string.
+func (s *Schema) GetExampleValue() string {
+	if s.XF5XCExample != "" {
+		return s.XF5XCExample
+	}
+	if s.XVesExample != "" {
+		return s.XVesExample
+	}
+	return ""
+}
+
+// GetBestDescription returns the best available description for a schema.
+// Priority: x-f5xc-description-medium > x-f5xc-description-short > description.
+func (s *Schema) GetBestDescription() string {
+	if s.XF5XCDescriptionMed != "" {
+		return s.XF5XCDescriptionMed
+	}
+	if s.XF5XCDescriptionShort != "" {
+		return s.XF5XCDescriptionShort
+	}
+	return s.Description
+}
+
+// GetCategory returns the category for a schema (from x-f5xc-category).
+func (s *Schema) GetCategory() string {
+	return s.XF5XCCategory
+}
+
+// Helper functions
+
+func fileExists(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	return !info.IsDir()
+}
+
+func dirExists(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	return info.IsDir()
+}
+
+// =============================================================================
+// V2 Example Cache - For examples from x-f5xc-example extensions
+// =============================================================================
+
+// v2ExampleCache stores examples from v2 spec x-f5xc-example extensions.
+// Maps: resourceName -> fieldPath -> exampleValue
+// This is populated during spec parsing and used during example generation.
+var v2ExampleCache = make(map[string]map[string]string)
+var v2ExampleMutex sync.RWMutex
+
+// SetV2Example sets an example for a specific resource field from v2 spec metadata.
+// This should be called during spec parsing when x-f5xc-example is found.
+func SetV2Example(resourceName, fieldPath, example string) {
+	if example == "" {
+		return
+	}
+	v2ExampleMutex.Lock()
+	defer v2ExampleMutex.Unlock()
+	if v2ExampleCache[resourceName] == nil {
+		v2ExampleCache[resourceName] = make(map[string]string)
+	}
+	v2ExampleCache[resourceName][fieldPath] = example
+}
+
+// GetV2Example retrieves the v2 example for a specific resource field if set.
+func GetV2Example(resourceName, fieldPath string) (string, bool) {
+	v2ExampleMutex.RLock()
+	defer v2ExampleMutex.RUnlock()
+	if resourceExamples, ok := v2ExampleCache[resourceName]; ok {
+		if example, found := resourceExamples[fieldPath]; found {
+			return example, true
+		}
+	}
+	return "", false
+}
+
+// GetV2ResourceExamples retrieves all v2 examples for a specific resource.
+func GetV2ResourceExamples(resourceName string) (map[string]string, bool) {
+	v2ExampleMutex.RLock()
+	defer v2ExampleMutex.RUnlock()
+	examples, ok := v2ExampleCache[resourceName]
+	if !ok {
+		return nil, false
+	}
+	// Return a copy to prevent external modification
+	result := make(map[string]string, len(examples))
+	for k, v := range examples {
+		result[k] = v
+	}
+	return result, true
+}
+
+// ClearV2Examples clears all v2 example cache entries (for testing).
+func ClearV2Examples() {
+	v2ExampleMutex.Lock()
+	defer v2ExampleMutex.Unlock()
+	v2ExampleCache = make(map[string]map[string]string)
+}
+
+// V2ExampleCount returns the number of resources with v2 examples in cache.
+func V2ExampleCount() int {
+	v2ExampleMutex.RLock()
+	defer v2ExampleMutex.RUnlock()
+	return len(v2ExampleCache)
+}
+
+// V2ExampleFieldCount returns the total number of field examples in cache.
+func V2ExampleFieldCount() int {
+	v2ExampleMutex.RLock()
+	defer v2ExampleMutex.RUnlock()
+	count := 0
+	for _, fields := range v2ExampleCache {
+		count += len(fields)
+	}
+	return count
+}
+
+// =============================================================================
+// V2 Ves Example Cache - For examples from original x-ves-example extensions
+// =============================================================================
+
+// vesExampleCache stores examples from original x-ves-example extensions.
+// Maps: resourceName -> fieldPath -> exampleValue
+// This is the second priority after x-f5xc-example.
+var vesExampleCache = make(map[string]map[string]string)
+var vesExampleMutex sync.RWMutex
+
+// SetVesExample sets an example for a specific resource field from x-ves-example.
+func SetVesExample(resourceName, fieldPath, example string) {
+	if example == "" {
+		return
+	}
+	vesExampleMutex.Lock()
+	defer vesExampleMutex.Unlock()
+	if vesExampleCache[resourceName] == nil {
+		vesExampleCache[resourceName] = make(map[string]string)
+	}
+	vesExampleCache[resourceName][fieldPath] = example
+}
+
+// GetVesExample retrieves the ves example for a specific resource field if set.
+func GetVesExample(resourceName, fieldPath string) (string, bool) {
+	vesExampleMutex.RLock()
+	defer vesExampleMutex.RUnlock()
+	if resourceExamples, ok := vesExampleCache[resourceName]; ok {
+		if example, found := resourceExamples[fieldPath]; found {
+			return example, true
+		}
+	}
+	return "", false
+}
+
+// ClearVesExamples clears all ves example cache entries (for testing).
+func ClearVesExamples() {
+	vesExampleMutex.Lock()
+	defer vesExampleMutex.Unlock()
+	vesExampleCache = make(map[string]map[string]string)
+}
+
+// =============================================================================
+// Unified Example Lookup - Priority-based resolution
+// =============================================================================
+
+// GetBestExample returns the best available example for a resource field.
+// Priority: x-f5xc-example (v2) > x-ves-example (original) > empty string.
+// This function should be used by example generators for priority-based lookup.
+func GetBestExample(resourceName, fieldPath string) (string, string) {
+	// Priority 1: v2 x-f5xc-example
+	if example, ok := GetV2Example(resourceName, fieldPath); ok {
+		return example, "v2"
+	}
+	// Priority 2: original x-ves-example
+	if example, ok := GetVesExample(resourceName, fieldPath); ok {
+		return example, "ves"
+	}
+	return "", ""
+}
+
+// PopulateExamplesFromSchema extracts and caches examples from a parsed schema.
+// This should be called during spec parsing to populate the example caches.
+func PopulateExamplesFromSchema(resourceName string, schema *Schema, fieldPath string) {
+	if schema == nil {
+		return
+	}
+
+	// Cache x-f5xc-example if present
+	if schema.XF5XCExample != "" {
+		SetV2Example(resourceName, fieldPath, schema.XF5XCExample)
+	}
+
+	// Cache x-ves-example if present
+	if schema.XVesExample != "" {
+		SetVesExample(resourceName, fieldPath, schema.XVesExample)
+	}
+
+	// Recursively process properties
+	for propName, propSchema := range schema.Properties {
+		childPath := fieldPath
+		if childPath != "" {
+			childPath = childPath + "." + propName
+		} else {
+			childPath = propName
+		}
+		// Copy to avoid mutation issues
+		propSchemaCopy := propSchema
+		PopulateExamplesFromSchema(resourceName, &propSchemaCopy, childPath)
+	}
+
+	// Process array items
+	if schema.Items != nil {
+		PopulateExamplesFromSchema(resourceName, schema.Items, fieldPath)
+	}
 }

--- a/tools/pkg/openapi/types.go
+++ b/tools/pkg/openapi/types.go
@@ -27,11 +27,26 @@ type Schema struct {
 	Items                *Schema           `json:"items"`
 	Ref                  string            `json:"$ref"`
 	Required             []string          `json:"required"`
-	XDisplayName         string            `json:"x-displayname"`
-	XVesExample          string            `json:"x-ves-example"`
-	XVesValidationRules  map[string]string `json:"x-ves-validation-rules"`
-	XVesProtoMessage     string            `json:"x-ves-proto-message"`
 	AdditionalProperties interface{}       `json:"additionalProperties"`
+
+	// Original F5 vendor extensions (x-ves-*) - technical metadata from upstream
+	XDisplayName        string            `json:"x-displayname"`
+	XVesExample         string            `json:"x-ves-example"`
+	XVesValidationRules map[string]string `json:"x-ves-validation-rules"`
+	XVesProtoMessage    string            `json:"x-ves-proto-message"`
+
+	// Enrichment extensions (x-f5xc-*) - added by f5xc-api-enriched repository
+	XF5XCCategory         string   `json:"x-f5xc-category"`
+	XF5XCRequiresTier     string   `json:"x-f5xc-requires-tier"`
+	XF5XCComplexity       string   `json:"x-f5xc-complexity"`
+	XF5XCExample          string   `json:"x-f5xc-example"`
+	XF5XCDescriptionShort string   `json:"x-f5xc-description-short"`
+	XF5XCDescriptionMed   string   `json:"x-f5xc-description-medium"`
+	XF5XCUseCases         []string `json:"x-f5xc-use-cases"`
+	XF5XCRelatedDomains   []string `json:"x-f5xc-related-domains"`
+	XF5XCIsPreview        bool     `json:"x-f5xc-is-preview"`
+	XF5XCIcon             string   `json:"x-f5xc-icon"`
+	XF5XCCLIDomain        string   `json:"x-f5xc-cli-domain"`
 }
 
 // TerraformAttribute represents an attribute in a Terraform resource schema.
@@ -116,4 +131,97 @@ func (s *Schema) IsRequired(propertyName string) bool {
 // HasProperties returns true if the schema has properties defined.
 func (s *Schema) HasProperties() bool {
 	return len(s.Properties) > 0
+}
+
+// =============================================================================
+// V2 Spec Types - For parsing enriched API specifications from f5xc-api-enriched
+// =============================================================================
+
+// Index represents the index.json manifest file in v2 spec structure.
+// This file provides metadata about all domain specifications.
+type Index struct {
+	Version        string           `json:"version"`
+	GeneratedAt    string           `json:"generated_at"`
+	Specifications []DomainMetadata `json:"specifications"`
+}
+
+// DomainMetadata represents metadata about a domain specification file.
+type DomainMetadata struct {
+	Name              string             `json:"name"`
+	File              string             `json:"file"`
+	Category          string             `json:"category"`
+	Description       string             `json:"description"`
+	DescriptionShort  string             `json:"description_short"`
+	DescriptionMedium string             `json:"description_medium"`
+	Icon              string             `json:"icon"`
+	RequiresTier      string             `json:"requires_tier"`
+	Complexity        string             `json:"complexity"`
+	IsPreview         bool               `json:"is_preview"`
+	CLIDomain         string             `json:"cli_domain"`
+	RelatedDomains    []string           `json:"related_domains"`
+	UseCases          []string           `json:"use_cases"`
+	PrimaryResources  []ResourceMetadata `json:"primary_resources"`
+}
+
+// ResourceMetadata represents metadata about a resource within a domain.
+type ResourceMetadata struct {
+	Name                 string   `json:"name"`
+	Description          string   `json:"description"`
+	APIPath              string   `json:"api_path"`
+	RequiresTier         string   `json:"requires_tier"`
+	Complexity           string   `json:"complexity"`
+	Dependencies         []string `json:"dependencies"`
+	MinimumConfiguration string   `json:"minimum_configuration"`
+}
+
+// DomainSpec represents a parsed domain specification file (v2 format).
+// Each domain file contains multiple related resources.
+type DomainSpec struct {
+	OpenAPI    string                 `json:"openapi"`
+	Info       DomainInfo             `json:"info"`
+	Paths      map[string]interface{} `json:"paths"`
+	Components Components             `json:"components"`
+
+	// Domain-level enrichment metadata
+	XF5XCCategory       string   `json:"x-f5xc-category"`
+	XF5XCRequiresTier   string   `json:"x-f5xc-requires-tier"`
+	XF5XCComplexity     string   `json:"x-f5xc-complexity"`
+	XF5XCIsPreview      bool     `json:"x-f5xc-is-preview"`
+	XF5XCRelatedDomains []string `json:"x-f5xc-related-domains"`
+	XF5XCUseCases       []string `json:"x-f5xc-use-cases"`
+}
+
+// DomainInfo represents the info section of a domain spec.
+type DomainInfo struct {
+	Title       string `json:"title"`
+	Description string `json:"description"`
+	Version     string `json:"version"`
+
+	// Enrichment extensions at info level
+	XF5XCDescriptionShort  string `json:"x-f5xc-description-short"`
+	XF5XCDescriptionMedium string `json:"x-f5xc-description-medium"`
+	XF5XCIcon              string `json:"x-f5xc-icon"`
+	XF5XCLogoSVG           string `json:"x-f5xc-logo-svg"`
+}
+
+// SpecVersion represents the detected specification version.
+type SpecVersion string
+
+const (
+	// SpecVersionV1 represents the original v1 spec format (269 individual files).
+	SpecVersionV1 SpecVersion = "v1"
+	// SpecVersionV2 represents the new v2 spec format (38 domain-organized files).
+	SpecVersionV2 SpecVersion = "v2"
+	// SpecVersionUnknown represents an unrecognized spec format.
+	SpecVersionUnknown SpecVersion = "unknown"
+)
+
+// V2Categories maps domain categories from v2 specs.
+var V2Categories = map[string]string{
+	"security":       "Security",
+	"networking":     "Networking",
+	"infrastructure": "Infrastructure",
+	"platform":       "Platform",
+	"operations":     "Operations",
+	"ai":             "AI Services",
 }

--- a/tools/pkg/resource/categories.go
+++ b/tools/pkg/resource/categories.go
@@ -2,7 +2,52 @@
 // for code generation tools in the F5XC Terraform provider.
 package resource
 
-import "strings"
+import (
+	"strings"
+	"sync"
+)
+
+// =============================================================================
+// V2 Category Cache - For categories from x-f5xc-category extensions
+// =============================================================================
+
+// v2CategoryCache stores categories from v2 spec x-f5xc-category extensions.
+// This takes priority over overrides and pattern matching.
+var v2CategoryCache = make(map[string]string)
+var v2CategoryMutex sync.RWMutex
+
+// SetV2Category sets the category for a resource from v2 spec metadata.
+// This should be called during spec parsing when x-f5xc-category is found.
+func SetV2Category(resourceName string, category string) {
+	if category == "" {
+		return
+	}
+	v2CategoryMutex.Lock()
+	defer v2CategoryMutex.Unlock()
+	v2CategoryCache[resourceName] = category
+}
+
+// GetV2Category retrieves the v2 category for a resource if set.
+func GetV2Category(resourceName string) (string, bool) {
+	v2CategoryMutex.RLock()
+	defer v2CategoryMutex.RUnlock()
+	cat, ok := v2CategoryCache[resourceName]
+	return cat, ok
+}
+
+// ClearV2Categories clears all v2 category cache entries (for testing).
+func ClearV2Categories() {
+	v2CategoryMutex.Lock()
+	defer v2CategoryMutex.Unlock()
+	v2CategoryCache = make(map[string]string)
+}
+
+// V2CategoryCount returns the number of v2 categories in cache.
+func V2CategoryCount() int {
+	v2CategoryMutex.RLock()
+	defer v2CategoryMutex.RUnlock()
+	return len(v2CategoryCache)
+}
 
 // SubcategoryOverrides provides explicit category assignments for resources
 // that don't match any pattern or need a specific override.
@@ -154,16 +199,22 @@ var CategoryPatterns = []CategoryPattern{
 
 // GetCategory returns the category for a resource based on its name.
 // Uses a three-tier approach:
-// 1. Check explicit overrides first (for exceptions)
-// 2. Apply pattern matching (for automatic categorization)
-// 3. Default to "Uncategorized"
+// 1. Check v2 spec x-f5xc-category first (from API enrichment, most specific)
+// 2. Check explicit SubcategoryOverrides (for exceptions and manual overrides)
+// 3. Apply pattern matching (for automatic categorization)
+// 4. Default to "Uncategorized"
 func GetCategory(resourceName string) string {
-	// Check explicit overrides first
+	// Tier 1: Check v2 spec x-f5xc-category (preferred, from enriched API specs)
+	if category, ok := GetV2Category(resourceName); ok {
+		return category
+	}
+
+	// Tier 2: Check explicit overrides
 	if category, ok := SubcategoryOverrides[resourceName]; ok {
 		return category
 	}
 
-	// Apply pattern matching
+	// Tier 3: Apply pattern matching
 	for _, pattern := range CategoryPatterns {
 		if strings.Contains(resourceName, pattern.Pattern) {
 			return pattern.Category
@@ -172,6 +223,30 @@ func GetCategory(resourceName string) string {
 
 	// Default to Uncategorized
 	return "Uncategorized"
+}
+
+// GetCategorySource returns both the category and its source tier for debugging.
+// Returns (category, source) where source is "v2", "override", "pattern", or "default".
+func GetCategorySource(resourceName string) (string, string) {
+	// Tier 1: Check v2 spec x-f5xc-category
+	if category, ok := GetV2Category(resourceName); ok {
+		return category, "v2"
+	}
+
+	// Tier 2: Check explicit overrides
+	if category, ok := SubcategoryOverrides[resourceName]; ok {
+		return category, "override"
+	}
+
+	// Tier 3: Apply pattern matching
+	for _, pattern := range CategoryPatterns {
+		if strings.Contains(resourceName, pattern.Pattern) {
+			return pattern.Category, "pattern"
+		}
+	}
+
+	// Default to Uncategorized
+	return "Uncategorized", "default"
 }
 
 // AllCategories returns a list of all unique categories.


### PR DESCRIPTION
## Summary

Implements the F5XC API v2 migration infrastructure to support moving from v1 specs (269 individual files) to v2.0.11 specs (38 domain-organized files with enrichment extensions).

## Related Issue

Closes #630

## Changes Made

### Sync Workflow Updates (`.github/workflows/sync-openapi.yml`)
- Added workflow dispatch inputs for `spec_source` (v2/v1) and `spec_version`
- Added `ENRICHED_REPO` env var for robinmordasiewicz/f5xc-api-enriched
- V2 structure verification (index.json + domains/)
- V1 structure verification (*.ves-swagger.json)
- Updated PR body with v2 enrichment metadata details

### Generator Updates
- **types.go**: Added x-f5xc-* extension fields to Schema struct
- **parser.go**: V2 example cache (SetV2Example, GetV2Example, GetBestExample), ves example cache for x-ves-example
- **categories.go**: Three-tier GetCategory resolution (x-f5xc-category → overrides → patterns)
- **generate-all-schemas.go**: Dual-mode spec processing (v1 and v2 format detection)
- **generate-examples.go**: Priority-based example resolution
- **transform-docs.go**: V2 metadata support for subscription tier badges

### CI/CD Updates (`.github/workflows/ci.yml`)
- Added `migration-validation` job triggered by `v2-migration` label
- Captures baseline schemas before generating with current specs
- Runs schema comparison tool
- Uploads comparison report as artifact
- Fails if breaking changes detected

### New Files
- `tools/compare-schemas/main.go`: Schema comparison tool for detecting missing resources, new resources, type changes
- `templates/guides/v3-migration.md`: Migration guide for v3.0.0

## Extension Strategy

Both extension families are processed **complementarily**:

| Extension Family | Purpose | Examples |
| ---------------- | ------- | -------- |
| **x-f5xc-*** | Enrichment metadata | category, requires-tier, complexity, descriptions |
| **x-ves-*** | Original F5 technical | oneof-field-*, proto-message, validation-rules, example |

## Testing

To test the v2 migration:
1. This PR has the `v2-migration` label which triggers the migration-validation CI job
2. The CI job generates a comparison report as an artifact
3. Review the report for any breaking changes

To manually test v2 spec sync:
```bash
gh workflow run sync-openapi.yml --field spec_source=v2 --field spec_version=latest
```

## Checklist

- [x] Pre-commit hooks pass
- [x] Go build passes
- [x] Go vet passes
- [x] golangci-lint passes
- [x] Migration validation CI job configured

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)