### PR TITLE
chore(mcp): update server.json to v3.6.3

### DIFF
--- a/mcp-server/manifest.json
+++ b/mcp-server/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "f5xc-terraform-mcp",
   "display_name": "F5 Distributed Cloud Terraform Provider",
-  "version": "3.6.2",
+  "version": "3.6.3",
   "description": "MCP server providing AI assistants with access to F5 Distributed Cloud Terraform provider documentation, 270+ OpenAPI specifications, subscription tier information, and addon service activation workflows.",
   "author": {
     "name": "Robin Mordasiewicz",

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@robinmordasiewicz/f5xc-terraform-mcp",
-  "version": "3.6.2",
+  "version": "3.6.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@robinmordasiewicz/f5xc-terraform-mcp",
-      "version": "3.6.2",
+      "version": "3.6.3",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.6.1",

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robinmordasiewicz/f5xc-terraform-mcp",
-  "version": "3.6.2",
+  "version": "3.6.3",
   "description": "MCP server for F5 Distributed Cloud Terraform provider - documentation, 270+ OpenAPI specs, subscription info, and addon activation workflows for AI assistants",
   "type": "module",
   "main": "dist/index.js",

--- a/mcp-server/server.json
+++ b/mcp-server/server.json
@@ -3,12 +3,12 @@
   "name": "io.github.robinmordasiewicz/f5xc-terraform-mcp",
   "title": "F5 Distributed Cloud Terraform Provider",
   "description": "F5 Distributed Cloud Terraform provider docs, 270+ OpenAPI specs, and subscription info for AI.",
-  "version": "3.6.2",
+  "version": "3.6.3",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@robinmordasiewicz/f5xc-terraform-mcp",
-      "version": "3.6.2",
+      "version": "3.6.3",
       "transport": {
         "type": "stdio"
       },
@@ -16,12 +16,12 @@
     },
     {
       "registryType": "mcpb",
-      "identifier": "https://github.com/robinmordasiewicz/terraform-provider-f5xc/releases/download/v3.6.2/f5xc-terraform-mcp-3.6.2.mcpb",
-      "version": "3.6.2",
+      "identifier": "https://github.com/robinmordasiewicz/terraform-provider-f5xc/releases/download/v3.6.3/f5xc-terraform-mcp-3.6.3.mcpb",
+      "version": "3.6.3",
       "transport": {
         "type": "stdio"
       },
-      "fileSha256": "b0a317c324647999331b8366e8ea1d70219ae46e7c1219400d95f2dd99dfca4d"
+      "fileSha256": "54b4c238301e7ad5ec4938f3744db594b6b66ee75aba0dc605d2aaf0520ec90b"
     }
   ],
   "repository": {


### PR DESCRIPTION
## Summary
Automated update of server.json for MCP Registry publication.

## Version
**Version**: 3.6.3
**SHA256**: `54b4c238301e7ad5ec4938f3744db594b6b66ee75aba0dc605d2aaf0520ec90b`

## Publication Status
- npm: Published
- MCP Registry: Published

🤖 Generated with [Claude Code](https://claude.com/claude-code)