### PR TITLE
chore(mcp): update server.json to v3.6.6

### DIFF
--- a/mcp-server/manifest.json
+++ b/mcp-server/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "f5xc-terraform-mcp",
   "display_name": "F5 Distributed Cloud Terraform Provider",
-  "version": "3.6.5",
+  "version": "3.6.6",
   "description": "MCP server providing AI assistants with access to F5 Distributed Cloud Terraform provider documentation, 270+ OpenAPI specifications, subscription tier information, and addon service activation workflows.",
   "author": {
     "name": "Robin Mordasiewicz",

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@robinmordasiewicz/f5xc-terraform-mcp",
-  "version": "3.6.5",
+  "version": "3.6.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@robinmordasiewicz/f5xc-terraform-mcp",
-      "version": "3.6.5",
+      "version": "3.6.6",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.6.1",

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robinmordasiewicz/f5xc-terraform-mcp",
-  "version": "3.6.5",
+  "version": "3.6.6",
   "description": "MCP server for F5 Distributed Cloud Terraform provider - documentation, 270+ OpenAPI specs, subscription info, and addon activation workflows for AI assistants",
   "type": "module",
   "main": "dist/index.js",

--- a/mcp-server/server.json
+++ b/mcp-server/server.json
@@ -3,12 +3,12 @@
   "name": "io.github.robinmordasiewicz/f5xc-terraform-mcp",
   "title": "F5 Distributed Cloud Terraform Provider",
   "description": "F5 Distributed Cloud Terraform provider docs, 270+ OpenAPI specs, and subscription info for AI.",
-  "version": "3.6.5",
+  "version": "3.6.6",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@robinmordasiewicz/f5xc-terraform-mcp",
-      "version": "3.6.5",
+      "version": "3.6.6",
       "transport": {
         "type": "stdio"
       },
@@ -16,12 +16,12 @@
     },
     {
       "registryType": "mcpb",
-      "identifier": "https://github.com/robinmordasiewicz/terraform-provider-f5xc/releases/download/v3.6.5/f5xc-terraform-mcp-3.6.5.mcpb",
-      "version": "3.6.5",
+      "identifier": "https://github.com/robinmordasiewicz/terraform-provider-f5xc/releases/download/v3.6.6/f5xc-terraform-mcp-3.6.6.mcpb",
+      "version": "3.6.6",
       "transport": {
         "type": "stdio"
       },
-      "fileSha256": "8ffeeb251c3e6cdd48b091b2d695d970adec0a50792f61a778d84f80fcd2103f"
+      "fileSha256": "e5e3709eb4b4b5a60d6355e11ff3884be98273fcf3cb7cb84f7aa6d36f83263f"
     }
   ],
   "repository": {


### PR DESCRIPTION
## Summary
Automated update of server.json for MCP Registry publication.

## Version
**Version**: 3.6.6
**SHA256**: `e5e3709eb4b4b5a60d6355e11ff3884be98273fcf3cb7cb84f7aa6d36f83263f`

## Publication Status
- npm: Published
- MCP Registry: Published

🤖 Generated with [Claude Code](https://claude.com/claude-code)