### PR TITLE
feat(mcp): integrate f5xc-auth shared package for profile-aware documentation

### DIFF
--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,15 +1,17 @@
 {
   "name": "@robinmordasiewicz/f5xc-terraform-mcp",
-  "version": "3.8.27",
+  "version": "3.8.29",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@robinmordasiewicz/f5xc-terraform-mcp",
-      "version": "3.8.27",
+      "version": "3.8.29",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.25.2",
+        "@robinmordasiewicz/f5xc-auth": "^1.0.0",
+        "axios": "^1.7.0",
         "glob": "^11.0.0",
         "zod": "^3.23.8"
       },
@@ -556,6 +558,19 @@
         }
       }
     },
+    "node_modules/@robinmordasiewicz/f5xc-auth": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@robinmordasiewicz/f5xc-auth/-/f5xc-auth-1.0.0.tgz",
+      "integrity": "sha512-x1EGgy2XLqk2jPwSov5oTXCgjyHy4ZAtzUY9P//TO7AyHotOgeHAWIUSqKLUIjX10AgZrerY+a9ptY3C/0P3pA==",
+      "license": "MIT",
+      "dependencies": {
+        "axios": "^1.7.0",
+        "yaml": "^2.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@types/node": {
       "version": "22.19.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.2.tgz",
@@ -634,6 +649,23 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.2.tgz",
+      "integrity": "sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.4",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/body-parser": {
@@ -715,6 +747,18 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/content-disposition": {
       "version": "1.0.1",
@@ -800,6 +844,15 @@
         }
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -875,6 +928,21 @@
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -1059,6 +1127,26 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/foreground-child": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
@@ -1073,6 +1161,43 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/forwarded": {
@@ -1207,6 +1332,21 @@
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -1560,6 +1700,12 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/qs": {
       "version": "6.14.1",
@@ -2087,6 +2233,21 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
+      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/zod": {
       "version": "3.25.76",

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -55,6 +55,8 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.25.2",
+    "@robinmordasiewicz/f5xc-auth": "^1.0.0",
+    "axios": "^1.7.0",
     "glob": "^11.0.0",
     "zod": "^3.23.8"
   },

--- a/mcp-server/src/schemas/common.ts
+++ b/mcp-server/src/schemas/common.ts
@@ -288,6 +288,20 @@ export const MetadataSchema = z.object({
   response_format: ResponseFormatSchema,
 }).strict();
 
+/**
+ * Auth tool schema
+ * Provides authentication status, profile management, and credential validation
+ */
+export const AuthSchema = z.object({
+  operation: z.enum(['status', 'list', 'switch', 'validate'])
+    .describe(COMMON_PARAM_DESCRIPTIONS.operation),
+  profile_name: z.string()
+    .min(1)
+    .optional()
+    .describe('Profile name to switch to (for switch operation)'),
+  response_format: ResponseFormatSchema,
+}).strict();
+
 // =============================================================================
 // TYPE EXPORTS
 // =============================================================================
@@ -298,3 +312,4 @@ export type ApiInput = z.infer<typeof ApiSchema>;
 export type SubscriptionInput = z.infer<typeof SubscriptionSchema>;
 export type AddonInput = z.infer<typeof AddonSchema>;
 export type MetadataInput = z.infer<typeof MetadataSchema>;
+export type AuthInput = z.infer<typeof AuthSchema>;

--- a/mcp-server/src/tools/auth.ts
+++ b/mcp-server/src/tools/auth.ts
@@ -1,0 +1,451 @@
+/**
+ * Authentication Tool Handler
+ *
+ * Provides authentication status, profile management, and credential validation
+ * for the F5XC Terraform MCP server.
+ *
+ * Uses the shared @robinmordasiewicz/f5xc-auth package for unified authentication
+ * across F5XC MCP servers.
+ *
+ * Tool: f5xc_terraform_auth
+ */
+
+import axios from 'axios';
+import { AuthInput } from '../schemas/common.js';
+import { ResponseFormat } from '../types.js';
+import {
+  CredentialManager,
+  AuthMode,
+  getProfileManager,
+  type Profile,
+} from '@robinmordasiewicz/f5xc-auth';
+
+// =============================================================================
+// TOOL DEFINITION
+// =============================================================================
+
+export const AUTH_TOOL_DEFINITION = {
+  name: 'f5xc_terraform_auth',
+  description: 'Check authentication status, list/switch profiles, validate credentials',
+};
+
+// =============================================================================
+// MODULE-LEVEL STATE
+// =============================================================================
+
+let credentialManager: CredentialManager | null = null;
+
+/**
+ * Initialize the credential manager (called from server startup)
+ */
+export async function initializeAuth(): Promise<CredentialManager> {
+  credentialManager = new CredentialManager();
+  await credentialManager.initialize();
+  return credentialManager;
+}
+
+/**
+ * Get the current credential manager instance
+ */
+export function getCredentialManager(): CredentialManager | null {
+  return credentialManager;
+}
+
+// =============================================================================
+// HANDLER
+// =============================================================================
+
+/**
+ * Handles the f5xc_terraform_auth tool invocation
+ */
+export async function handleAuth(input: AuthInput): Promise<string> {
+  const { operation, profile_name, response_format } = input;
+
+  switch (operation) {
+    case 'status':
+      return handleStatus(response_format);
+    case 'list':
+      return handleList(response_format);
+    case 'switch':
+      return handleSwitch(profile_name, response_format);
+    case 'validate':
+      return handleValidate(response_format);
+    default:
+      throw new Error(`Unknown operation: ${operation}`);
+  }
+}
+
+// =============================================================================
+// OPERATION HANDLERS
+// =============================================================================
+
+/**
+ * Handle 'status' operation - show current auth state
+ */
+async function handleStatus(format: ResponseFormat): Promise<string> {
+  if (!credentialManager) {
+    throw new Error('Auth not initialized. Server startup issue.');
+  }
+
+  const profileManager = getProfileManager();
+  const activeProfile = await profileManager.getActive();
+
+  const status = {
+    mode: credentialManager.getAuthMode(),
+    authenticated: credentialManager.isAuthenticated(),
+    tenant: credentialManager.getTenant(),
+    api_url: credentialManager.getApiUrl(),
+    namespace: credentialManager.getNamespace(),
+    active_profile: activeProfile,
+    source: getAuthSource(credentialManager),
+  };
+
+  if (format === ResponseFormat.JSON) {
+    return JSON.stringify(status, null, 2);
+  }
+
+  return formatStatusMarkdown(status);
+}
+
+function getAuthSource(cm: CredentialManager): string {
+  if (cm.getAuthMode() === AuthMode.NONE) {
+    return 'none (documentation mode)';
+  }
+
+  // Check for environment variables
+  if (process.env.F5XC_API_TOKEN || process.env.F5XC_P12_FILE || process.env.F5XC_CERT) {
+    return 'environment variables';
+  }
+
+  return 'profile';
+}
+
+function formatStatusMarkdown(status: {
+  mode: string;
+  authenticated: boolean;
+  tenant: string | null;
+  api_url: string | null;
+  namespace: string | null;
+  active_profile: string | null;
+  source: string;
+}): string {
+  const lines = [
+    '# F5XC Authentication Status',
+    '',
+    '| Property | Value |',
+    '|----------|-------|',
+    `| **Mode** | ${status.mode} |`,
+    `| **Authenticated** | ${status.authenticated ? 'Yes' : 'No'} |`,
+    `| **Source** | ${status.source} |`,
+  ];
+
+  if (status.tenant) {
+    lines.push(`| **Tenant** | ${status.tenant} |`);
+  }
+
+  if (status.api_url) {
+    lines.push(`| **API URL** | ${status.api_url} |`);
+  }
+
+  if (status.namespace) {
+    lines.push(`| **Default Namespace** | ${status.namespace} |`);
+  }
+
+  if (status.active_profile) {
+    lines.push(`| **Active Profile** | ${status.active_profile} |`);
+  }
+
+  lines.push('');
+
+  if (!status.authenticated) {
+    lines.push('> **Documentation Mode**: No credentials configured.');
+    lines.push('> The MCP server is operating in documentation-only mode.');
+    lines.push('> To enable API access, configure credentials via environment variables or profiles.');
+    lines.push('');
+    lines.push('## Configuration Options');
+    lines.push('');
+    lines.push('### Environment Variables');
+    lines.push('```bash');
+    lines.push('export F5XC_API_URL="https://your-tenant.console.ves.volterra.io"');
+    lines.push('export F5XC_API_TOKEN="your-api-token"');
+    lines.push('```');
+    lines.push('');
+    lines.push('### Profile Configuration');
+    lines.push('```bash');
+    lines.push('# Create profile at ~/.config/f5xc/profiles/<name>.json');
+    lines.push('```');
+  }
+
+  return lines.join('\n');
+}
+
+/**
+ * Handle 'list' operation - list available profiles
+ */
+async function handleList(format: ResponseFormat): Promise<string> {
+  const profileManager = getProfileManager();
+  const profiles = await profileManager.list();
+  const activeProfile = await profileManager.getActive();
+
+  const profileList = profiles.map((p) => ({
+    name: p.name,
+    api_url: p.apiUrl,
+    tenant: extractTenant(p.apiUrl),
+    namespace: p.defaultNamespace || null,
+    auth_method: getProfileAuthMethod(p),
+    is_active: p.name === activeProfile,
+  }));
+
+  if (format === ResponseFormat.JSON) {
+    return JSON.stringify({ profiles: profileList, active: activeProfile }, null, 2);
+  }
+
+  return formatProfileListMarkdown(profileList, activeProfile);
+}
+
+function extractTenant(apiUrl: string): string | null {
+  const match = apiUrl.match(/https:\/\/([^.]+)\.console\.ves\.volterra\.io/);
+  return match ? match[1] : null;
+}
+
+function getProfileAuthMethod(profile: Profile): string {
+  if (profile.apiToken) return 'token';
+  if (profile.p12Bundle) return 'p12';
+  if (profile.cert && profile.key) return 'cert';
+  return 'none';
+}
+
+function formatProfileListMarkdown(
+  profiles: Array<{
+    name: string;
+    api_url: string;
+    tenant: string | null;
+    namespace: string | null;
+    auth_method: string;
+    is_active: boolean;
+  }>,
+  activeProfile: string | null,
+): string {
+  if (profiles.length === 0) {
+    return [
+      '# F5XC Profiles',
+      '',
+      'No profiles configured.',
+      '',
+      'Create a profile at `~/.config/f5xc/profiles/<name>.json`:',
+      '',
+      '```json',
+      '{',
+      '  "name": "production",',
+      '  "apiUrl": "https://your-tenant.console.ves.volterra.io/api",',
+      '  "apiToken": "your-api-token",',
+      '  "defaultNamespace": "my-namespace"',
+      '}',
+      '```',
+    ].join('\n');
+  }
+
+  const lines = [
+    '# F5XC Profiles',
+    '',
+    `Active: ${activeProfile || 'none'}`,
+    '',
+    '| Profile | Tenant | Namespace | Auth | Active |',
+    '|---------|--------|-----------|------|--------|',
+  ];
+
+  for (const p of profiles) {
+    const active = p.is_active ? '**Yes**' : 'No';
+    lines.push(
+      `| ${p.name} | ${p.tenant || '-'} | ${p.namespace || '-'} | ${p.auth_method} | ${active} |`,
+    );
+  }
+
+  lines.push('');
+  lines.push(
+    '> Use `operation: "switch", profile_name: "<name>"` to change the active profile.',
+  );
+
+  return lines.join('\n');
+}
+
+/**
+ * Handle 'switch' operation - switch to a different profile
+ */
+async function handleSwitch(
+  profileName: string | undefined,
+  format: ResponseFormat,
+): Promise<string> {
+  if (!profileName) {
+    throw new Error('profile_name is required for switch operation');
+  }
+
+  const profileManager = getProfileManager();
+
+  // Check if profile exists
+  const profile = await profileManager.get(profileName);
+  if (!profile) {
+    throw new Error(`Profile '${profileName}' not found`);
+  }
+
+  // Set as active profile
+  const result = await profileManager.setActive(profileName);
+  if (!result.success) {
+    throw new Error(`Failed to switch profile: ${result.message}`);
+  }
+
+  // Reload credential manager with new profile
+  if (credentialManager) {
+    await credentialManager.reload();
+  }
+
+  const response = {
+    success: true,
+    profile: profileName,
+    message: `Switched to profile '${profileName}'`,
+    tenant: credentialManager?.getTenant() || null,
+    authenticated: credentialManager?.isAuthenticated() || false,
+  };
+
+  if (format === ResponseFormat.JSON) {
+    return JSON.stringify(response, null, 2);
+  }
+
+  const lines = [
+    '# Profile Switched',
+    '',
+    `Successfully switched to profile: **${profileName}**`,
+    '',
+  ];
+
+  if (response.authenticated) {
+    lines.push(`- Tenant: ${response.tenant}`);
+    lines.push('- Status: Authenticated');
+  } else {
+    lines.push('- Status: Not authenticated (check credentials)');
+  }
+
+  return lines.join('\n');
+}
+
+/**
+ * Handle 'validate' operation - test API connectivity
+ */
+async function handleValidate(format: ResponseFormat): Promise<string> {
+  if (!credentialManager) {
+    throw new Error('Auth not initialized. Server startup issue.');
+  }
+
+  if (!credentialManager.isAuthenticated()) {
+    const response = {
+      valid: false,
+      mode: credentialManager.getAuthMode(),
+      error: 'No credentials configured (documentation mode)',
+      suggestion: 'Configure F5XC_API_TOKEN environment variable or create a profile',
+    };
+
+    if (format === ResponseFormat.JSON) {
+      return JSON.stringify(response, null, 2);
+    }
+
+    return [
+      '# Credential Validation',
+      '',
+      '**Result**: Not validated',
+      '',
+      'No credentials are configured. The MCP server is operating in documentation mode.',
+      '',
+      '## To enable API access:',
+      '',
+      '1. Set environment variables:',
+      '   ```bash',
+      '   export F5XC_API_URL="https://your-tenant.console.ves.volterra.io"',
+      '   export F5XC_API_TOKEN="your-api-token"',
+      '   ```',
+      '',
+      '2. Or create a profile at `~/.config/f5xc/profiles/<name>.json`',
+    ].join('\n');
+  }
+
+  // Test API connectivity
+  const apiUrl = credentialManager.getApiUrl();
+  const token = credentialManager.getToken();
+
+  if (!apiUrl || !token) {
+    throw new Error('Missing API URL or token');
+  }
+
+  try {
+    // Make a simple API call to verify credentials
+    const response = await axios.get(`${apiUrl}/web/namespaces`, {
+      headers: {
+        Authorization: `APIToken ${token}`,
+        'Content-Type': 'application/json',
+      },
+      timeout: 10000,
+    });
+
+    const namespaceCount = response.data?.items?.length || 0;
+
+    const result = {
+      valid: true,
+      tenant: credentialManager.getTenant(),
+      api_url: apiUrl,
+      namespaces_found: namespaceCount,
+      message: `Successfully connected to F5XC API. Found ${namespaceCount} namespace(s).`,
+    };
+
+    if (format === ResponseFormat.JSON) {
+      return JSON.stringify(result, null, 2);
+    }
+
+    return [
+      '# Credential Validation',
+      '',
+      '**Result**: Valid',
+      '',
+      '| Property | Value |',
+      '|----------|-------|',
+      `| **Tenant** | ${result.tenant} |`,
+      `| **API URL** | ${result.api_url} |`,
+      `| **Namespaces Found** | ${result.namespaces_found} |`,
+      '',
+      'Credentials are valid and API is accessible.',
+    ].join('\n');
+  } catch (error) {
+    const axiosError = error as { response?: { status: number; data?: { message?: string } }; message?: string };
+
+    const result = {
+      valid: false,
+      tenant: credentialManager.getTenant(),
+      api_url: apiUrl,
+      error: axiosError.response?.data?.message || axiosError.message || 'Unknown error',
+      status_code: axiosError.response?.status || null,
+    };
+
+    if (format === ResponseFormat.JSON) {
+      return JSON.stringify(result, null, 2);
+    }
+
+    return [
+      '# Credential Validation',
+      '',
+      '**Result**: Failed',
+      '',
+      '| Property | Value |',
+      '|----------|-------|',
+      `| **Tenant** | ${result.tenant} |`,
+      `| **API URL** | ${result.api_url} |`,
+      `| **Error** | ${result.error} |`,
+      result.status_code ? `| **Status Code** | ${result.status_code} |` : '',
+      '',
+      '## Troubleshooting',
+      '',
+      '- Verify your API token is valid and not expired',
+      '- Check that the API URL is correct',
+      '- Ensure network connectivity to F5 Distributed Cloud',
+    ]
+      .filter((l) => l)
+      .join('\n');
+  }
+}

--- a/mcp-server/src/tools/discover.ts
+++ b/mcp-server/src/tools/discover.ts
@@ -9,7 +9,7 @@
 
 import { DiscoverInput } from '../schemas/common.js';
 import { ResponseFormat } from '../types.js';
-import { DocsSchema, ApiSchema, SubscriptionSchema, AddonSchema } from '../schemas/common.js';
+import { DocsSchema, ApiSchema, SubscriptionSchema, AddonSchema, AuthSchema } from '../schemas/common.js';
 
 // =============================================================================
 // TOOL METADATA
@@ -18,7 +18,7 @@ import { DocsSchema, ApiSchema, SubscriptionSchema, AddonSchema } from '../schem
 interface ToolInfo {
   name: string;
   description: string;
-  category: 'docs' | 'api' | 'subscription' | 'addon' | 'summary';
+  category: 'docs' | 'api' | 'subscription' | 'addon' | 'auth' | 'summary';
   operations?: string[];
 }
 
@@ -51,6 +51,12 @@ const TOOL_REGISTRY: ToolInfo[] = [
     name: 'f5xc_terraform_get_summary',
     description: 'Get provider documentation summary',
     category: 'summary',
+  },
+  {
+    name: 'f5xc_terraform_auth',
+    description: 'Authentication status, profiles, and validation',
+    category: 'auth',
+    operations: ['status', 'list', 'switch', 'validate'],
   },
 ];
 
@@ -233,6 +239,8 @@ function getSchemaForTool(toolName: string): object {
       return schemaToJson(AddonSchema);
     case 'f5xc_terraform_get_summary':
       return { response_format: { type: 'string', enum: ['markdown', 'json'] } };
+    case 'f5xc_terraform_auth':
+      return schemaToJson(AuthSchema);
     default:
       return {};
   }


### PR DESCRIPTION
## Summary

Integrate the shared `@robinmordasiewicz/f5xc-auth` npm package into the terraform-provider-f5xc MCP server to enable profile-aware documentation features and unified authentication across F5XC MCP servers.

## Related Issue

Closes #772

## Changes Made

### Dependencies Added
- `@robinmordasiewicz/f5xc-auth` (v1.0.0) - Shared authentication package
- `axios` (v1.7.0) - For API validation

### New Tool: `f5xc_terraform_auth`
Operations:
- **status** - Show current auth state, mode, tenant, and active profile
- **list** - List available profiles with masked credentials
- **switch** - Change active profile and reload credentials
- **validate** - Test API connectivity with current credentials

### Files Modified
- `mcp-server/package.json` - Add dependencies
- `mcp-server/src/schemas/common.ts` - Add AuthSchema
- `mcp-server/src/tools/auth.ts` - NEW: Auth tool handler
- `mcp-server/src/tools/discover.ts` - Add auth tool to registry
- `mcp-server/src/index.ts` - Register tool and initialize auth

## Features

- **XDG-compliant profile system** at `~/.config/f5xc/`
- **Priority cascade**: Environment vars → Profile → Documentation mode
- **Multiple auth methods**: Token, P12 certificate, Cert+Key
- **Credential validation**: Tests API connectivity
- **Profile sharing**: Same profiles work with f5xc-api-mcp server

## Testing

- [x] Build passes (`npm run build`)
- [x] Server starts correctly
- [x] Credentials loaded from existing profile
- [x] Pre-commit hooks pass

## Example Usage

```bash
# Check authentication status
f5xc_terraform_auth operation="status"

# List available profiles
f5xc_terraform_auth operation="list"

# Switch to a different profile
f5xc_terraform_auth operation="switch" profile_name="production"

# Validate credentials
f5xc_terraform_auth operation="validate"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)