### PR TITLE
test(mcp): add end-to-end validation for @robinmordasiewicz/f5xc-auth integration

### DIFF
--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -20,9 +20,71 @@
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
+        "@vitest/coverage-v8": "^4.0.16",
         "tsx": "^4.19.2",
-        "typescript": "^5.7.2"
+        "typescript": "^5.7.2",
+        "vitest": "^4.0.16"
       },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.5.tgz",
+      "integrity": "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.5"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.5.tgz",
+      "integrity": "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       }
@@ -519,6 +581,34 @@
         "node": ">=12"
       }
     },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.25.2",
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.25.2.tgz",
@@ -571,6 +661,388 @@
         "node": ">=18"
       }
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.55.1.tgz",
+      "integrity": "sha512-9R0DM/ykwfGIlNu6+2U09ga0WXeZ9MRC2Ter8jnz8415VbuIykVuc6bhdrbORFZANDmTDvq26mJrEVTl8TdnDg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.55.1.tgz",
+      "integrity": "sha512-eFZCb1YUqhTysgW3sj/55du5cG57S7UTNtdMjCW7LwVcj3dTTcowCsC8p7uBdzKsZYa8J7IDE8lhMI+HX1vQvg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.55.1.tgz",
+      "integrity": "sha512-p3grE2PHcQm2e8PSGZdzIhCKbMCw/xi9XvMPErPhwO17vxtvCN5FEA2mSLgmKlCjHGMQTP6phuQTYWUnKewwGg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.55.1.tgz",
+      "integrity": "sha512-rDUjG25C9qoTm+e02Esi+aqTKSBYwVTaoS1wxcN47/Luqef57Vgp96xNANwt5npq9GDxsH7kXxNkJVEsWEOEaQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.55.1.tgz",
+      "integrity": "sha512-+JiU7Jbp5cdxekIgdte0jfcu5oqw4GCKr6i3PJTlXTCU5H5Fvtkpbs4XJHRmWNXF+hKmn4v7ogI5OQPaupJgOg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.55.1.tgz",
+      "integrity": "sha512-V5xC1tOVWtLLmr3YUk2f6EJK4qksksOYiz/TCsFHu/R+woubcLWdC9nZQmwjOAbmExBIVKsm1/wKmEy4z4u4Bw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.55.1.tgz",
+      "integrity": "sha512-Rn3n+FUk2J5VWx+ywrG/HGPTD9jXNbicRtTM11e/uorplArnXZYsVifnPPqNNP5BsO3roI4n8332ukpY/zN7rQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.55.1.tgz",
+      "integrity": "sha512-grPNWydeKtc1aEdrJDWk4opD7nFtQbMmV7769hiAaYyUKCT1faPRm2av8CX1YJsZ4TLAZcg9gTR1KvEzoLjXkg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.55.1.tgz",
+      "integrity": "sha512-a59mwd1k6x8tXKcUxSyISiquLwB5pX+fJW9TkWU46lCqD/GRDe9uDN31jrMmVP3feI3mhAdvcCClhV8V5MhJFQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.55.1.tgz",
+      "integrity": "sha512-puS1MEgWX5GsHSoiAsF0TYrpomdvkaXm0CofIMG5uVkP6IBV+ZO9xhC5YEN49nsgYo1DuuMquF9+7EDBVYu4uA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.55.1.tgz",
+      "integrity": "sha512-r3Wv40in+lTsULSb6nnoudVbARdOwb2u5fpeoOAZjFLznp6tDU8kd+GTHmJoqZ9lt6/Sys33KdIHUaQihFcu7g==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.55.1.tgz",
+      "integrity": "sha512-MR8c0+UxAlB22Fq4R+aQSPBayvYa3+9DrwG/i1TKQXFYEaoW3B5b/rkSRIypcZDdWjWnpcvxbNaAJDcSbJU3Lw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.55.1.tgz",
+      "integrity": "sha512-3KhoECe1BRlSYpMTeVrD4sh2Pw2xgt4jzNSZIIPLFEsnQn9gAnZagW9+VqDqAHgm1Xc77LzJOo2LdigS5qZ+gw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.55.1.tgz",
+      "integrity": "sha512-ziR1OuZx0vdYZZ30vueNZTg73alF59DicYrPViG0NEgDVN8/Jl87zkAPu4u6VjZST2llgEUjaiNl9JM6HH1Vdw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.55.1.tgz",
+      "integrity": "sha512-uW0Y12ih2XJRERZ4jAfKamTyIHVMPQnTZcQjme2HMVDAHY4amf5u414OqNYC+x+LzRdRcnIG1YodLrrtA8xsxw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.55.1.tgz",
+      "integrity": "sha512-u9yZ0jUkOED1BFrqu3BwMQoixvGHGZ+JhJNkNKY/hyoEgOwlqKb62qu+7UjbPSHYjiVy8kKJHvXKv5coH4wDeg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.55.1.tgz",
+      "integrity": "sha512-/0PenBCmqM4ZUd0190j7J0UsQ/1nsi735iPRakO8iPciE7BQ495Y6msPzaOmvx0/pn+eJVVlZrNrSh4WSYLxNg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.55.1.tgz",
+      "integrity": "sha512-a8G4wiQxQG2BAvo+gU6XrReRRqj+pLS2NGXKm8io19goR+K8lw269eTrPkSdDTALwMmJp4th2Uh0D8J9bEV1vg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.55.1.tgz",
+      "integrity": "sha512-bD+zjpFrMpP/hqkfEcnjXWHMw5BIghGisOKPj+2NaNDuVT+8Ds4mPf3XcPHuat1tz89WRL+1wbcxKY3WSbiT7w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.55.1.tgz",
+      "integrity": "sha512-eLXw0dOiqE4QmvikfQ6yjgkg/xDM+MdU9YJuP4ySTibXU0oAvnEWXt7UDJmD4UkYialMfOGFPJnIHSe/kdzPxg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.55.1.tgz",
+      "integrity": "sha512-xzm44KgEP11te3S2HCSyYf5zIzWmx3n8HDCc7EE59+lTcswEWNpvMLfd9uJvVX8LCg9QWG67Xt75AuHn4vgsXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.55.1.tgz",
+      "integrity": "sha512-yR6Bl3tMC/gBok5cz/Qi0xYnVbIxGx5Fcf/ca0eB6/6JwOY+SRUcJfI0OpeTpPls7f194as62thCt/2BjxYN8g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.55.1.tgz",
+      "integrity": "sha512-3fZBidchE0eY0oFZBnekYCfg+5wAB0mbpCBuofh5mZuzIU/4jIVkbESmd2dOsFNS78b53CYv3OAtwqkZZmU5nA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.55.1.tgz",
+      "integrity": "sha512-xGGY5pXj69IxKb4yv/POoocPy/qmEGhimy/FoTpTSVju3FYXUQQMFCaZZXJVidsmGxRioZAwpThl/4zX41gRKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.55.1.tgz",
+      "integrity": "sha512-SPEpaL6DX4rmcXtnhdrQYgzQ5W2uW3SCJch88lB2zImhJRhIIK44fkUrgIV/Q8yUNfw5oyZ5vkeQsZLhCb06lw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "22.19.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.2.tgz",
@@ -579,6 +1051,149 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.0.16",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.0.16.tgz",
+      "integrity": "sha512-2rNdjEIsPRzsdu6/9Eq0AYAzYdpP6Bx9cje9tL3FE5XzXRQF1fNU9pe/1yE8fCrS0HD+fBtt6gLPh6LI57tX7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.0.16",
+        "ast-v8-to-istanbul": "^0.3.8",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.1",
+        "obug": "^2.1.1",
+        "std-env": "^3.10.0",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.0.16",
+        "vitest": "4.0.16"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.0.16",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.16.tgz",
+      "integrity": "sha512-eshqULT2It7McaJkQGLkPjPjNph+uevROGuIMJdG3V+0BSR2w9u6J9Lwu+E8cK5TETlfou8GRijhafIMhXsimA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.0.16",
+        "@vitest/utils": "4.0.16",
+        "chai": "^6.2.1",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.0.16",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.16.tgz",
+      "integrity": "sha512-yb6k4AZxJTB+q9ycAvsoxGn+j/po0UaPgajllBgt1PzoMAAmJGYFdDk0uCcRcxb3BrME34I6u8gHZTQlkqSZpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.0.16",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.0.16",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.16.tgz",
+      "integrity": "sha512-eNCYNsSty9xJKi/UdVD8Ou16alu7AYiS2fCPRs0b1OdhJiV89buAXQLpTbe+X8V9L6qrs9CqyvU7OaAopJYPsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.0.16",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.16.tgz",
+      "integrity": "sha512-VWEDm5Wv9xEo80ctjORcTQRJ539EGPB3Pb9ApvVRAY1U/WkHXmmYISqU5E79uCwcW7xYUV38gwZD+RV755fu3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.0.16",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.0.16",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.16.tgz",
+      "integrity": "sha512-sf6NcrYhYBsSYefxnry+DR8n3UV4xWZwWxYbCJUt2YdvtqzSPR7VfGrY0zsv090DAbjFZsi7ZaMi1KnSRyK1XA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.16",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.0.16",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.16.tgz",
+      "integrity": "sha512-4jIOWjKP0ZUaEmJm00E0cOBLU+5WE0BpeNr3XN6TEF05ltro6NJqHWxXD0kA8/Zc8Nh23AT8WQxwNG+WeROupw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.0.16",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.16.tgz",
+      "integrity": "sha512-h8z9yYhV3e1LEfaQ3zdypIrnAg/9hguReGZoS7Gl0aBG5xgA410zBqECqmaF/+RkTggRsfnzc1XaAHA6bmUufA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.16",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/accepts": {
@@ -649,6 +1264,28 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "0.3.10",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.10.tgz",
+      "integrity": "sha512-p4K7vMz2ZSk3wN8l5o3y2bJAoZXT3VuJI5OLTATY/01CYWumWvwkUw0SqDBnNq6IiTO3qDa1eSQDibAV8g7XOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^9.0.1"
       }
     },
     "node_modules/asynckit": {
@@ -728,6 +1365,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/color-convert": {
@@ -921,6 +1568,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -996,6 +1650,16 @@
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "license": "MIT"
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
@@ -1024,6 +1688,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/express": {
@@ -1105,6 +1779,24 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
     },
     "node_modules/finalhandler": {
       "version": "2.1.1",
@@ -1327,6 +2019,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/has-symbols": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
@@ -1375,6 +2077,13 @@
       "engines": {
         "node": ">=16.9.0"
       }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/http-errors": {
       "version": "2.0.1",
@@ -1448,6 +2157,60 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/jackspeak": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.1.1.tgz",
@@ -1472,6 +2235,13 @@
         "url": "https://github.com/sponsors/panva"
       }
     },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
@@ -1491,6 +2261,44 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.1.tgz",
+      "integrity": "sha512-xrHS24IxaLrvuo613F719wvOIv9xPHFWQHuvGUBmPnCA/3MQxKI3b+r7n1jAoDHmsbC5bRhTZYR77invLAxVnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.28.5",
+        "@babel/types": "^7.28.5",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/math-intrinsics": {
@@ -1578,6 +2386,25 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
     "node_modules/negotiator": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
@@ -1607,6 +2434,17 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
     },
     "node_modules/on-finished": {
       "version": "2.4.1",
@@ -1679,6 +2517,33 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/pkce-challenge": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
@@ -1686,6 +2551,35 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.20.0"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/proxy-addr": {
@@ -1765,6 +2659,51 @@
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
+    "node_modules/rollup": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.55.1.tgz",
+      "integrity": "sha512-wDv/Ht1BNHB4upNbK74s9usvl7hObDnvVzknxqY/E/O3X6rW1U1rV1aENEfJ54eFZDTNo7zv1f5N4edCluH7+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.55.1",
+        "@rollup/rollup-android-arm64": "4.55.1",
+        "@rollup/rollup-darwin-arm64": "4.55.1",
+        "@rollup/rollup-darwin-x64": "4.55.1",
+        "@rollup/rollup-freebsd-arm64": "4.55.1",
+        "@rollup/rollup-freebsd-x64": "4.55.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.55.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.55.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.55.1",
+        "@rollup/rollup-linux-arm64-musl": "4.55.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.55.1",
+        "@rollup/rollup-linux-loong64-musl": "4.55.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.55.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.55.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.55.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.55.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.55.1",
+        "@rollup/rollup-linux-x64-gnu": "4.55.1",
+        "@rollup/rollup-linux-x64-musl": "4.55.1",
+        "@rollup/rollup-openbsd-x64": "4.55.1",
+        "@rollup/rollup-openharmony-arm64": "4.55.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.55.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.55.1",
+        "@rollup/rollup-win32-x64-gnu": "4.55.1",
+        "@rollup/rollup-win32-x64-msvc": "4.55.1",
+        "fsevents": "~2.3.2"
+      }
+    },
     "node_modules/router": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
@@ -1786,6 +2725,19 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/send": {
       "version": "1.2.0",
@@ -1923,6 +2875,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -1935,6 +2894,23 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -1943,6 +2919,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string-width": {
       "version": "5.1.2",
@@ -2040,6 +3023,63 @@
         "node": ">=8"
       }
     },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
+      "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
+      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -2122,6 +3162,159 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/vite": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
+      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.0.16",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.16.tgz",
+      "integrity": "sha512-E4t7DJ9pESL6E3I8nFjPa4xGUd3PmiWDLsDztS2qXSJWfHtbQnwAWylaBvSNY48I3vr8PTqIZlyK8TE3V3CA4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.0.16",
+        "@vitest/mocker": "4.0.16",
+        "@vitest/pretty-format": "4.0.16",
+        "@vitest/runner": "4.0.16",
+        "@vitest/snapshot": "4.0.16",
+        "@vitest/spy": "4.0.16",
+        "@vitest/utils": "4.0.16",
+        "es-module-lexer": "^1.7.0",
+        "expect-type": "^1.2.2",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^3.10.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.0.3",
+        "vite": "^6.0.0 || ^7.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.0.16",
+        "@vitest/browser-preview": "4.0.16",
+        "@vitest/browser-webdriverio": "4.0.16",
+        "@vitest/ui": "4.0.16",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -2135,6 +3328,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wrap-ansi": {

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -22,7 +22,12 @@
     "dev": "tsx watch src/index.ts",
     "clean": "rm -rf dist",
     "lint": "eslint src/**/*.ts",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
+    "test:acceptance": "vitest run tests/acceptance/",
+    "validate:auth": "tsx scripts/validate-auth-integration.ts"
   },
   "keywords": [
     "mcp",
@@ -62,8 +67,10 @@
   },
   "devDependencies": {
     "@types/node": "^22.10.0",
+    "@vitest/coverage-v8": "^4.0.16",
     "tsx": "^4.19.2",
-    "typescript": "^5.7.2"
+    "typescript": "^5.7.2",
+    "vitest": "^4.0.16"
   },
   "mcpName": "io.github.robinmordasiewicz/f5xc-terraform-mcp"
 }

--- a/mcp-server/scripts/validate-auth-integration.ts
+++ b/mcp-server/scripts/validate-auth-integration.ts
@@ -1,0 +1,541 @@
+#!/usr/bin/env npx tsx
+/**
+ * Auth Integration Validation Script
+ *
+ * Idempotent script to validate the @robinmordasiewicz/f5xc-auth integration
+ * in the F5XC Terraform MCP server.
+ *
+ * Usage:
+ *   npx tsx scripts/validate-auth-integration.ts [options]
+ *
+ * Options:
+ *   --verbose       Show detailed output for each validation step
+ *   --test-real-api Test against real F5XC API (requires F5XC_TEST_API_URL and F5XC_TEST_API_TOKEN)
+ *   --help          Show this help message
+ *
+ * Exit codes:
+ *   0 - All validations passed
+ *   1 - One or more validations failed
+ */
+
+import { execSync, spawn } from 'child_process';
+import { existsSync, readFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const ROOT_DIR = join(__dirname, '..');
+
+// =============================================================================
+// CONFIGURATION
+// =============================================================================
+
+interface ValidationResult {
+  name: string;
+  passed: boolean;
+  message: string;
+  details?: string;
+  duration?: number;
+}
+
+const results: ValidationResult[] = [];
+let verbose = false;
+let testRealApi = false;
+
+// =============================================================================
+// COLORS
+// =============================================================================
+
+const colors = {
+  reset: '\x1b[0m',
+  bright: '\x1b[1m',
+  red: '\x1b[31m',
+  green: '\x1b[32m',
+  yellow: '\x1b[33m',
+  blue: '\x1b[34m',
+  cyan: '\x1b[36m',
+};
+
+function log(message: string, color: string = colors.reset): void {
+  console.log(`${color}${message}${colors.reset}`);
+}
+
+function logHeader(message: string): void {
+  console.log('');
+  log(`${'='.repeat(60)}`, colors.cyan);
+  log(message, colors.bright + colors.cyan);
+  log(`${'='.repeat(60)}`, colors.cyan);
+}
+
+function logStep(message: string): void {
+  log(`\n>>> ${message}`, colors.blue);
+}
+
+function logSuccess(message: string): void {
+  log(`  ✅ ${message}`, colors.green);
+}
+
+function logFailure(message: string): void {
+  log(`  ❌ ${message}`, colors.red);
+}
+
+function logWarning(message: string): void {
+  log(`  ⚠️  ${message}`, colors.yellow);
+}
+
+function logInfo(message: string): void {
+  if (verbose) {
+    log(`  ℹ️  ${message}`, colors.reset);
+  }
+}
+
+// =============================================================================
+// UTILITIES
+// =============================================================================
+
+function exec(command: string, options: { cwd?: string; silent?: boolean } = {}): string {
+  const cwd = options.cwd || ROOT_DIR;
+  try {
+    const result = execSync(command, {
+      cwd,
+      encoding: 'utf-8',
+      stdio: options.silent ? 'pipe' : 'inherit',
+    });
+    return result || '';
+  } catch (error) {
+    if (error instanceof Error && 'stdout' in error) {
+      return (error as any).stdout || '';
+    }
+    throw error;
+  }
+}
+
+function execAsync(command: string, args: string[], cwd: string): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  return new Promise((resolve) => {
+    const proc = spawn(command, args, { cwd, shell: true });
+    let stdout = '';
+    let stderr = '';
+
+    proc.stdout?.on('data', (data) => {
+      stdout += data.toString();
+      if (verbose) process.stdout.write(data);
+    });
+
+    proc.stderr?.on('data', (data) => {
+      stderr += data.toString();
+      if (verbose) process.stderr.write(data);
+    });
+
+    proc.on('close', (exitCode) => {
+      resolve({ stdout, stderr, exitCode: exitCode || 0 });
+    });
+  });
+}
+
+async function validate(
+  name: string,
+  testFn: () => Promise<{ passed: boolean; message: string; details?: string }>
+): Promise<void> {
+  logStep(name);
+  const startTime = Date.now();
+
+  try {
+    const result = await testFn();
+    const duration = Date.now() - startTime;
+
+    results.push({
+      name,
+      ...result,
+      duration,
+    });
+
+    if (result.passed) {
+      logSuccess(result.message);
+    } else {
+      logFailure(result.message);
+    }
+
+    if (result.details && verbose) {
+      logInfo(result.details);
+    }
+  } catch (error) {
+    const duration = Date.now() - startTime;
+    const message = error instanceof Error ? error.message : String(error);
+
+    results.push({
+      name,
+      passed: false,
+      message: `Error: ${message}`,
+      duration,
+    });
+
+    logFailure(`Error: ${message}`);
+  }
+}
+
+// =============================================================================
+// VALIDATIONS
+// =============================================================================
+
+async function validateDependency(): Promise<{ passed: boolean; message: string; details?: string }> {
+  const packageJsonPath = join(ROOT_DIR, 'package.json');
+
+  if (!existsSync(packageJsonPath)) {
+    return { passed: false, message: 'package.json not found' };
+  }
+
+  const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8'));
+  const authDep = packageJson.dependencies?.['@robinmordasiewicz/f5xc-auth'];
+
+  if (!authDep) {
+    return { passed: false, message: '@robinmordasiewicz/f5xc-auth not found in dependencies' };
+  }
+
+  return {
+    passed: true,
+    message: `@robinmordasiewicz/f5xc-auth found: ${authDep}`,
+  };
+}
+
+async function validateTypeScript(): Promise<{ passed: boolean; message: string; details?: string }> {
+  try {
+    exec('npm run typecheck', { silent: !verbose });
+    return { passed: true, message: 'TypeScript compilation successful' };
+  } catch {
+    return { passed: false, message: 'TypeScript compilation failed' };
+  }
+}
+
+async function validateBuild(): Promise<{ passed: boolean; message: string; details?: string }> {
+  try {
+    exec('npm run build', { silent: !verbose });
+    return { passed: true, message: 'Build successful' };
+  } catch {
+    return { passed: false, message: 'Build failed' };
+  }
+}
+
+async function validateUnitTests(): Promise<{ passed: boolean; message: string; details?: string }> {
+  const result = await execAsync('npx', ['vitest', 'run', '--reporter=verbose'], ROOT_DIR);
+
+  if (result.exitCode === 0) {
+    // Extract test count from output
+    const match = result.stdout.match(/(\d+)\s+passed/);
+    const testCount = match ? match[1] : 'all';
+    return { passed: true, message: `Unit tests passed (${testCount} tests)` };
+  }
+
+  return { passed: false, message: 'Unit tests failed', details: result.stderr };
+}
+
+async function validateAuthImports(): Promise<{ passed: boolean; message: string; details?: string }> {
+  const authToolPath = join(ROOT_DIR, 'src/tools/auth.ts');
+
+  if (!existsSync(authToolPath)) {
+    return { passed: false, message: 'auth.ts not found' };
+  }
+
+  const content = readFileSync(authToolPath, 'utf-8');
+
+  const requiredImports = [
+    'CredentialManager',
+    'AuthMode',
+    'getProfileManager',
+  ];
+
+  const missingImports = requiredImports.filter((imp) => !content.includes(imp));
+
+  if (missingImports.length > 0) {
+    return {
+      passed: false,
+      message: `Missing imports: ${missingImports.join(', ')}`,
+    };
+  }
+
+  if (!content.includes('@robinmordasiewicz/f5xc-auth')) {
+    return {
+      passed: false,
+      message: 'Not importing from @robinmordasiewicz/f5xc-auth',
+    };
+  }
+
+  return {
+    passed: true,
+    message: 'All required imports present from shared package',
+  };
+}
+
+async function validateAuthSchemaExports(): Promise<{ passed: boolean; message: string; details?: string }> {
+  const schemaPath = join(ROOT_DIR, 'src/schemas/common.ts');
+
+  if (!existsSync(schemaPath)) {
+    return { passed: false, message: 'common.ts schema not found' };
+  }
+
+  const content = readFileSync(schemaPath, 'utf-8');
+
+  if (!content.includes('AuthSchema')) {
+    return { passed: false, message: 'AuthSchema not found in common.ts' };
+  }
+
+  if (!content.includes('AuthInput')) {
+    return { passed: false, message: 'AuthInput type not found in common.ts' };
+  }
+
+  return {
+    passed: true,
+    message: 'Auth schema and types properly defined',
+  };
+}
+
+async function validateDocumentationModeInit(): Promise<{ passed: boolean; message: string; details?: string }> {
+  // Clear any existing credentials
+  const originalEnv = { ...process.env };
+  delete process.env.F5XC_API_URL;
+  delete process.env.F5XC_API_TOKEN;
+  delete process.env.F5XC_P12_FILE;
+  delete process.env.F5XC_CERT;
+  process.env.XDG_CONFIG_HOME = '/tmp/__nonexistent_test_config__';
+
+  try {
+    const { CredentialManager, AuthMode } = await import('@robinmordasiewicz/f5xc-auth');
+    const cm = new CredentialManager();
+    await cm.initialize();
+
+    const mode = cm.getAuthMode();
+    const isAuth = cm.isAuthenticated();
+
+    if (mode !== AuthMode.NONE || isAuth) {
+      return {
+        passed: false,
+        message: `Expected NONE mode, got ${mode} (authenticated: ${isAuth})`,
+      };
+    }
+
+    return {
+      passed: true,
+      message: 'Documentation mode initializes correctly with NONE auth',
+    };
+  } catch (error) {
+    return {
+      passed: false,
+      message: `Failed to initialize: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  } finally {
+    process.env = originalEnv;
+  }
+}
+
+async function validateTokenModeInit(): Promise<{ passed: boolean; message: string; details?: string }> {
+  const originalEnv = { ...process.env };
+
+  try {
+    process.env.F5XC_API_URL = 'https://test.console.ves.volterra.io';
+    process.env.F5XC_API_TOKEN = 'test-token-12345';
+    process.env.XDG_CONFIG_HOME = '/tmp/__nonexistent_test_config__';
+
+    const { CredentialManager, AuthMode } = await import('@robinmordasiewicz/f5xc-auth');
+    const cm = new CredentialManager();
+    await cm.initialize();
+
+    const mode = cm.getAuthMode();
+    const isAuth = cm.isAuthenticated();
+    const tenant = cm.getTenant();
+
+    if (mode !== AuthMode.TOKEN) {
+      return { passed: false, message: `Expected TOKEN mode, got ${mode}` };
+    }
+
+    if (!isAuth) {
+      return { passed: false, message: 'Expected authenticated, got false' };
+    }
+
+    if (tenant !== 'test') {
+      return { passed: false, message: `Expected tenant 'test', got '${tenant}'` };
+    }
+
+    return {
+      passed: true,
+      message: 'Token mode initializes correctly with authenticated state',
+    };
+  } catch (error) {
+    return {
+      passed: false,
+      message: `Failed to initialize: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  } finally {
+    process.env = originalEnv;
+  }
+}
+
+async function validateProfileManagerAvailable(): Promise<{ passed: boolean; message: string; details?: string }> {
+  try {
+    const { getProfileManager } = await import('@robinmordasiewicz/f5xc-auth');
+    const pm = getProfileManager();
+
+    if (!pm) {
+      return { passed: false, message: 'getProfileManager returned null' };
+    }
+
+    if (typeof pm.list !== 'function') {
+      return { passed: false, message: 'ProfileManager.list is not a function' };
+    }
+
+    if (typeof pm.get !== 'function') {
+      return { passed: false, message: 'ProfileManager.get is not a function' };
+    }
+
+    if (typeof pm.getActive !== 'function') {
+      return { passed: false, message: 'ProfileManager.getActive is not a function' };
+    }
+
+    return {
+      passed: true,
+      message: 'ProfileManager available with all required methods',
+    };
+  } catch (error) {
+    return {
+      passed: false,
+      message: `Failed to get ProfileManager: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
+}
+
+async function validateRealApiConnection(): Promise<{ passed: boolean; message: string; details?: string }> {
+  if (!testRealApi) {
+    return {
+      passed: true,
+      message: 'Skipped (use --test-real-api to enable)',
+    };
+  }
+
+  const apiUrl = process.env.F5XC_TEST_API_URL;
+  const apiToken = process.env.F5XC_TEST_API_TOKEN;
+
+  if (!apiUrl || !apiToken) {
+    return {
+      passed: false,
+      message: 'F5XC_TEST_API_URL and F5XC_TEST_API_TOKEN required for real API test',
+    };
+  }
+
+  try {
+    const { CredentialManager } = await import('@robinmordasiewicz/f5xc-auth');
+
+    const originalEnv = { ...process.env };
+    process.env.F5XC_API_URL = apiUrl;
+    process.env.F5XC_API_TOKEN = apiToken;
+
+    const cm = new CredentialManager();
+    await cm.initialize();
+
+    const tenant = cm.getTenant();
+    const isAuth = cm.isAuthenticated();
+
+    process.env = originalEnv;
+
+    if (!isAuth) {
+      return { passed: false, message: 'Failed to authenticate with real credentials' };
+    }
+
+    return {
+      passed: true,
+      message: `Successfully authenticated to tenant: ${tenant}`,
+    };
+  } catch (error) {
+    return {
+      passed: false,
+      message: `API connection failed: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
+}
+
+// =============================================================================
+// MAIN
+// =============================================================================
+
+function showHelp(): void {
+  console.log(`
+Auth Integration Validation Script
+
+Usage:
+  npx tsx scripts/validate-auth-integration.ts [options]
+
+Options:
+  --verbose       Show detailed output for each validation step
+  --test-real-api Test against real F5XC API
+                  (requires F5XC_TEST_API_URL and F5XC_TEST_API_TOKEN)
+  --help          Show this help message
+
+Exit codes:
+  0 - All validations passed
+  1 - One or more validations failed
+`);
+}
+
+function printSummary(): void {
+  logHeader('VALIDATION SUMMARY');
+
+  const passed = results.filter((r) => r.passed).length;
+  const failed = results.filter((r) => !r.passed).length;
+  const total = results.length;
+
+  console.log('');
+  for (const result of results) {
+    const icon = result.passed ? '✅' : '❌';
+    const time = result.duration ? ` (${result.duration}ms)` : '';
+    console.log(`  ${icon} ${result.name}${time}`);
+  }
+
+  console.log('');
+  log(`${'─'.repeat(60)}`, colors.cyan);
+
+  if (failed === 0) {
+    log(`\n  🎉 All ${total} validations PASSED\n`, colors.green);
+  } else {
+    log(`\n  ⚠️  ${passed}/${total} passed, ${failed} FAILED\n`, colors.red);
+  }
+}
+
+async function main(): Promise<void> {
+  // Parse arguments
+  const args = process.argv.slice(2);
+
+  if (args.includes('--help') || args.includes('-h')) {
+    showHelp();
+    process.exit(0);
+  }
+
+  verbose = args.includes('--verbose') || args.includes('-v');
+  testRealApi = args.includes('--test-real-api');
+
+  logHeader('F5XC Auth Integration Validation');
+  log(`\nRunning from: ${ROOT_DIR}`);
+  log(`Verbose: ${verbose}`);
+  log(`Test Real API: ${testRealApi}`);
+
+  // Run validations
+  await validate('1. Dependency Check', validateDependency);
+  await validate('2. TypeScript Compilation', validateTypeScript);
+  await validate('3. Build', validateBuild);
+  await validate('4. Unit Tests', validateUnitTests);
+  await validate('5. Auth Tool Imports', validateAuthImports);
+  await validate('6. Auth Schema Exports', validateAuthSchemaExports);
+  await validate('7. Documentation Mode Initialization', validateDocumentationModeInit);
+  await validate('8. Token Mode Initialization', validateTokenModeInit);
+  await validate('9. ProfileManager Availability', validateProfileManagerAvailable);
+  await validate('10. Real API Connection', validateRealApiConnection);
+
+  // Print summary
+  printSummary();
+
+  // Exit with appropriate code
+  const failed = results.filter((r) => !r.passed).length;
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+main().catch((error) => {
+  console.error('Fatal error:', error);
+  process.exit(1);
+});

--- a/mcp-server/tests/acceptance/auth-integration.test.ts
+++ b/mcp-server/tests/acceptance/auth-integration.test.ts
@@ -1,0 +1,412 @@
+/**
+ * End-to-End Auth Integration Tests
+ *
+ * Validates the @robinmordasiewicz/f5xc-auth package integration
+ * in the F5XC Terraform MCP server.
+ *
+ * Test Matrix:
+ * - Unauthenticated (Documentation Mode)
+ * - Authenticated (Execution Mode) with Token
+ * - Profile-based authentication
+ * - Environment variable priority cascade
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  CredentialManager,
+  AuthMode,
+  getProfileManager,
+} from '@robinmordasiewicz/f5xc-auth';
+import {
+  clearF5XCEnvVars,
+  setupDocumentationModeEnv,
+  setupAuthenticatedModeEnv,
+} from '../utils/ci-environment.js';
+
+describe('Auth Integration Tests', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  // ===========================================================================
+  // SCENARIO 1: Documentation Mode (No Credentials)
+  // ===========================================================================
+  describe('Scenario: Documentation Mode (Unauthenticated)', () => {
+    beforeEach(() => {
+      setupDocumentationModeEnv();
+    });
+
+    it('should initialize CredentialManager in NONE mode', async () => {
+      const credentialManager = new CredentialManager();
+      await credentialManager.initialize();
+
+      expect(credentialManager.getAuthMode()).toBe(AuthMode.NONE);
+      expect(credentialManager.isAuthenticated()).toBe(false);
+    });
+
+    it('should return null for API URL when not authenticated', async () => {
+      const credentialManager = new CredentialManager();
+      await credentialManager.initialize();
+
+      expect(credentialManager.getApiUrl()).toBeNull();
+    });
+
+    it('should return null for tenant when not authenticated', async () => {
+      const credentialManager = new CredentialManager();
+      await credentialManager.initialize();
+
+      expect(credentialManager.getTenant()).toBeNull();
+    });
+
+    it('should return null for token when not authenticated', async () => {
+      const credentialManager = new CredentialManager();
+      await credentialManager.initialize();
+
+      expect(credentialManager.getToken()).toBeNull();
+    });
+
+    it('should return null for namespace when not configured', async () => {
+      const credentialManager = new CredentialManager();
+      await credentialManager.initialize();
+
+      expect(credentialManager.getNamespace()).toBeNull();
+    });
+  });
+
+  // ===========================================================================
+  // SCENARIO 2: Token Authentication
+  // ===========================================================================
+  describe('Scenario: Token Authentication', () => {
+    beforeEach(() => {
+      setupAuthenticatedModeEnv();
+    });
+
+    it('should initialize CredentialManager in TOKEN mode', async () => {
+      const credentialManager = new CredentialManager();
+      await credentialManager.initialize();
+
+      expect(credentialManager.getAuthMode()).toBe(AuthMode.TOKEN);
+      expect(credentialManager.isAuthenticated()).toBe(true);
+    });
+
+    it('should return configured API URL', async () => {
+      const credentialManager = new CredentialManager();
+      await credentialManager.initialize();
+
+      // Note: f5xc-auth normalizes API URLs to include /api path
+      expect(credentialManager.getApiUrl()).toBe('https://test.console.ves.volterra.io/api');
+    });
+
+    it('should extract tenant from API URL', async () => {
+      const credentialManager = new CredentialManager();
+      await credentialManager.initialize();
+
+      expect(credentialManager.getTenant()).toBe('test');
+    });
+
+    it('should return configured token', async () => {
+      const credentialManager = new CredentialManager();
+      await credentialManager.initialize();
+
+      expect(credentialManager.getToken()).toBe('test-token');
+    });
+
+    it('should handle custom namespace', async () => {
+      process.env.F5XC_NAMESPACE = 'custom-namespace';
+
+      const credentialManager = new CredentialManager();
+      await credentialManager.initialize();
+
+      expect(credentialManager.getNamespace()).toBe('custom-namespace');
+    });
+  });
+
+  // ===========================================================================
+  // SCENARIO 3: Environment Variable Priority
+  // ===========================================================================
+  describe('Scenario: Environment Variable Priority Cascade', () => {
+    it('should prioritize env vars over profile settings', async () => {
+      // Set up env vars with specific values
+      setupAuthenticatedModeEnv({
+        apiUrl: 'https://env-tenant.console.ves.volterra.io',
+        apiToken: 'env-token',
+      });
+
+      const credentialManager = new CredentialManager();
+      await credentialManager.initialize();
+
+      // Env vars should take priority (note: f5xc-auth normalizes with /api)
+      expect(credentialManager.getApiUrl()).toBe('https://env-tenant.console.ves.volterra.io/api');
+      expect(credentialManager.getToken()).toBe('env-token');
+      expect(credentialManager.getTenant()).toBe('env-tenant');
+    });
+
+    it('should fall back to documentation mode when no credentials', async () => {
+      clearF5XCEnvVars();
+      setupDocumentationModeEnv();
+
+      const credentialManager = new CredentialManager();
+      await credentialManager.initialize();
+
+      expect(credentialManager.getAuthMode()).toBe(AuthMode.NONE);
+    });
+  });
+
+  // ===========================================================================
+  // SCENARIO 4: Credential Manager Reload
+  // ===========================================================================
+  describe('Scenario: Credential Manager Reload', () => {
+    it('should reload credentials when environment changes', async () => {
+      // Start in documentation mode
+      setupDocumentationModeEnv();
+
+      const credentialManager = new CredentialManager();
+      await credentialManager.initialize();
+
+      expect(credentialManager.getAuthMode()).toBe(AuthMode.NONE);
+
+      // Change to authenticated mode
+      setupAuthenticatedModeEnv();
+      await credentialManager.reload();
+
+      expect(credentialManager.getAuthMode()).toBe(AuthMode.TOKEN);
+      expect(credentialManager.isAuthenticated()).toBe(true);
+    });
+
+    it('should transition from authenticated to documentation mode', async () => {
+      // Start in authenticated mode
+      setupAuthenticatedModeEnv();
+
+      const credentialManager = new CredentialManager();
+      await credentialManager.initialize();
+
+      expect(credentialManager.getAuthMode()).toBe(AuthMode.TOKEN);
+
+      // Clear credentials
+      setupDocumentationModeEnv();
+      await credentialManager.reload();
+
+      expect(credentialManager.getAuthMode()).toBe(AuthMode.NONE);
+      expect(credentialManager.isAuthenticated()).toBe(false);
+    });
+  });
+
+  // ===========================================================================
+  // SCENARIO 5: Multiple Credential Manager Instances
+  // ===========================================================================
+  describe('Scenario: Multiple Credential Manager Instances', () => {
+    it('should allow multiple independent instances', async () => {
+      setupAuthenticatedModeEnv({
+        apiUrl: 'https://tenant-a.console.ves.volterra.io',
+        apiToken: 'token-a',
+      });
+
+      const manager1 = new CredentialManager();
+      await manager1.initialize();
+
+      // Change environment
+      setupAuthenticatedModeEnv({
+        apiUrl: 'https://tenant-b.console.ves.volterra.io',
+        apiToken: 'token-b',
+      });
+
+      const manager2 = new CredentialManager();
+      await manager2.initialize();
+
+      // First instance should retain original values
+      expect(manager1.getTenant()).toBe('tenant-a');
+
+      // Second instance should have new values
+      expect(manager2.getTenant()).toBe('tenant-b');
+    });
+  });
+
+  // ===========================================================================
+  // SCENARIO 6: Profile Manager Integration
+  // ===========================================================================
+  describe('Scenario: Profile Manager Integration', () => {
+    it('should access ProfileManager from shared package', () => {
+      const profileManager = getProfileManager();
+
+      expect(profileManager).toBeDefined();
+      expect(typeof profileManager.list).toBe('function');
+      expect(typeof profileManager.get).toBe('function');
+      expect(typeof profileManager.getActive).toBe('function');
+      expect(typeof profileManager.setActive).toBe('function');
+    });
+
+    it('should list profiles (may be empty)', async () => {
+      setupDocumentationModeEnv();
+
+      const profileManager = getProfileManager();
+      const profiles = await profileManager.list();
+
+      expect(Array.isArray(profiles)).toBe(true);
+    });
+
+    it('should get active profile (may be null)', async () => {
+      setupDocumentationModeEnv();
+
+      const profileManager = getProfileManager();
+      const active = await profileManager.getActive();
+
+      // In test environment, no active profile expected
+      expect(active === null || typeof active === 'string').toBe(true);
+    });
+  });
+
+  // ===========================================================================
+  // SCENARIO 7: Error Handling
+  // ===========================================================================
+  describe('Scenario: Error Handling', () => {
+    it('should handle invalid API URL gracefully', async () => {
+      process.env.F5XC_API_URL = 'not-a-valid-url';
+      process.env.F5XC_API_TOKEN = 'test-token';
+
+      const credentialManager = new CredentialManager();
+      await credentialManager.initialize();
+
+      // Should still initialize but may have issues with URL parsing
+      // The credential manager should not throw
+      expect(credentialManager).toBeDefined();
+    });
+
+    it('should handle empty token gracefully', async () => {
+      process.env.F5XC_API_URL = 'https://test.console.ves.volterra.io';
+      process.env.F5XC_API_TOKEN = '';
+
+      const credentialManager = new CredentialManager();
+      await credentialManager.initialize();
+
+      // Empty token should result in documentation mode
+      expect(credentialManager.getAuthMode()).toBe(AuthMode.NONE);
+    });
+
+    it('should handle missing API URL with token', async () => {
+      delete process.env.F5XC_API_URL;
+      process.env.F5XC_API_TOKEN = 'test-token';
+
+      const credentialManager = new CredentialManager();
+      await credentialManager.initialize();
+
+      // Without API URL, should be in documentation mode
+      expect(credentialManager.getAuthMode()).toBe(AuthMode.NONE);
+    });
+  });
+
+  // ===========================================================================
+  // SCENARIO 8: AuthMode Enum Values
+  // ===========================================================================
+  describe('Scenario: AuthMode Enum Validation', () => {
+    it('should have correct string values for AuthMode', () => {
+      expect(AuthMode.NONE).toBe('none');
+      expect(AuthMode.TOKEN).toBe('token');
+      expect(AuthMode.CERTIFICATE).toBe('certificate');
+    });
+
+    it('should return string mode values (not numeric)', async () => {
+      setupAuthenticatedModeEnv();
+
+      const credentialManager = new CredentialManager();
+      await credentialManager.initialize();
+
+      const mode = credentialManager.getAuthMode();
+
+      // Mode should be a string, not a number
+      expect(typeof mode).toBe('string');
+      expect(['none', 'token', 'certificate']).toContain(mode);
+    });
+  });
+});
+
+// ===========================================================================
+// ACCEPTANCE TEST MATRIX
+// ===========================================================================
+describe('Auth Integration Test Matrix', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  const testMatrix: Array<{
+    name: string;
+    setup: () => void;
+    expectedMode: AuthMode;
+    expectedAuthenticated: boolean;
+    expectedTenant: string | null;
+  }> = [
+    {
+      name: 'No credentials → Documentation mode',
+      setup: () => setupDocumentationModeEnv(),
+      expectedMode: AuthMode.NONE,
+      expectedAuthenticated: false,
+      expectedTenant: null,
+    },
+    {
+      name: 'Token only → Execution mode',
+      setup: () => setupAuthenticatedModeEnv(),
+      expectedMode: AuthMode.TOKEN,
+      expectedAuthenticated: true,
+      expectedTenant: 'test',
+    },
+    {
+      name: 'Custom tenant URL → Extract tenant',
+      setup: () => setupAuthenticatedModeEnv({
+        apiUrl: 'https://custom-tenant.console.ves.volterra.io',
+        apiToken: 'custom-token',
+      }),
+      expectedMode: AuthMode.TOKEN,
+      expectedAuthenticated: true,
+      expectedTenant: 'custom-tenant',
+    },
+    {
+      name: 'Missing token → Documentation mode',
+      setup: () => {
+        clearF5XCEnvVars();
+        process.env.F5XC_API_URL = 'https://test.console.ves.volterra.io';
+        // No token set
+        process.env.XDG_CONFIG_HOME = '/tmp/__nonexistent_test_config__';
+      },
+      expectedMode: AuthMode.NONE,
+      expectedAuthenticated: false,
+      expectedTenant: null,
+    },
+    {
+      name: 'Empty token → Documentation mode',
+      setup: () => {
+        clearF5XCEnvVars();
+        process.env.F5XC_API_URL = 'https://test.console.ves.volterra.io';
+        process.env.F5XC_API_TOKEN = '';
+        process.env.XDG_CONFIG_HOME = '/tmp/__nonexistent_test_config__';
+      },
+      expectedMode: AuthMode.NONE,
+      expectedAuthenticated: false,
+      expectedTenant: null,
+    },
+  ];
+
+  testMatrix.forEach(({ name, setup, expectedMode, expectedAuthenticated, expectedTenant }) => {
+    it(`Matrix: ${name}`, async () => {
+      setup();
+
+      const credentialManager = new CredentialManager();
+      await credentialManager.initialize();
+
+      expect(credentialManager.getAuthMode()).toBe(expectedMode);
+      expect(credentialManager.isAuthenticated()).toBe(expectedAuthenticated);
+      expect(credentialManager.getTenant()).toBe(expectedTenant);
+    });
+  });
+});

--- a/mcp-server/tests/acceptance/auth-tool.test.ts
+++ b/mcp-server/tests/acceptance/auth-tool.test.ts
@@ -1,0 +1,445 @@
+/**
+ * Auth Tool Acceptance Tests
+ *
+ * Tests the f5xc_terraform_auth tool behavior under different authentication states:
+ * - Status operation in documentation vs authenticated mode
+ * - List operation for profiles
+ * - Validate operation with/without credentials
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  CredentialManager,
+  AuthMode,
+  getProfileManager,
+} from '@robinmordasiewicz/f5xc-auth';
+import {
+  clearF5XCEnvVars,
+  setupDocumentationModeEnv,
+  setupAuthenticatedModeEnv,
+} from '../utils/ci-environment.js';
+import {
+  handleAuth,
+  initializeAuth,
+  getCredentialManager,
+} from '../../src/tools/auth.js';
+import { ResponseFormat } from '../../src/types.js';
+
+describe('Auth Tool Acceptance Tests', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  // ===========================================================================
+  // STATUS OPERATION TESTS
+  // ===========================================================================
+  describe('Status Operation', () => {
+    describe('Documentation Mode', () => {
+      beforeEach(async () => {
+        setupDocumentationModeEnv();
+        await initializeAuth();
+      });
+
+      it('should return documentation mode status as JSON', async () => {
+        const result = await handleAuth({
+          operation: 'status',
+          response_format: ResponseFormat.JSON,
+        });
+
+        const data = JSON.parse(result);
+        expect(data.mode).toBe('none');
+        expect(data.authenticated).toBe(false);
+        expect(data.tenant).toBeNull();
+        expect(data.api_url).toBeNull();
+        expect(data.source).toBe('none (documentation mode)');
+      });
+
+      it('should return documentation mode status as markdown', async () => {
+        const result = await handleAuth({
+          operation: 'status',
+          response_format: ResponseFormat.MARKDOWN,
+        });
+
+        expect(result).toContain('# F5XC Authentication Status');
+        expect(result).toContain('**Mode** | none');
+        expect(result).toContain('**Authenticated** | No');
+        expect(result).toContain('Documentation Mode');
+      });
+    });
+
+    describe('Authenticated Mode', () => {
+      beforeEach(async () => {
+        setupAuthenticatedModeEnv();
+        await initializeAuth();
+      });
+
+      it('should return authenticated status as JSON', async () => {
+        const result = await handleAuth({
+          operation: 'status',
+          response_format: ResponseFormat.JSON,
+        });
+
+        const data = JSON.parse(result);
+        expect(data.mode).toBe('token');
+        expect(data.authenticated).toBe(true);
+        expect(data.tenant).toBe('test');
+        expect(data.api_url).toBe('https://test.console.ves.volterra.io/api');
+        expect(data.source).toBe('environment variables');
+      });
+
+      it('should return authenticated status as markdown', async () => {
+        const result = await handleAuth({
+          operation: 'status',
+          response_format: ResponseFormat.MARKDOWN,
+        });
+
+        expect(result).toContain('# F5XC Authentication Status');
+        expect(result).toContain('**Mode** | token');
+        expect(result).toContain('**Authenticated** | Yes');
+        expect(result).toContain('**Tenant** | test');
+      });
+    });
+
+    describe('Custom Tenant', () => {
+      beforeEach(async () => {
+        setupAuthenticatedModeEnv({
+          apiUrl: 'https://production.console.ves.volterra.io',
+          apiToken: 'prod-token',
+          namespace: 'prod-namespace',
+        });
+        await initializeAuth();
+      });
+
+      it('should extract tenant correctly', async () => {
+        const result = await handleAuth({
+          operation: 'status',
+          response_format: ResponseFormat.JSON,
+        });
+
+        const data = JSON.parse(result);
+        expect(data.tenant).toBe('production');
+        expect(data.namespace).toBe('prod-namespace');
+      });
+    });
+  });
+
+  // ===========================================================================
+  // LIST OPERATION TESTS
+  // ===========================================================================
+  describe('List Operation', () => {
+    beforeEach(async () => {
+      setupDocumentationModeEnv();
+      await initializeAuth();
+    });
+
+    it('should return profile list as JSON', async () => {
+      const result = await handleAuth({
+        operation: 'list',
+        response_format: ResponseFormat.JSON,
+      });
+
+      const data = JSON.parse(result);
+      expect(data).toHaveProperty('profiles');
+      expect(Array.isArray(data.profiles)).toBe(true);
+      expect(data).toHaveProperty('active');
+    });
+
+    it('should return profile list as markdown', async () => {
+      const result = await handleAuth({
+        operation: 'list',
+        response_format: ResponseFormat.MARKDOWN,
+      });
+
+      expect(result).toContain('# F5XC Profiles');
+      // May contain "No profiles configured" or a table
+      expect(
+        result.includes('No profiles configured') || result.includes('| Profile |')
+      ).toBe(true);
+    });
+  });
+
+  // ===========================================================================
+  // VALIDATE OPERATION TESTS
+  // ===========================================================================
+  describe('Validate Operation', () => {
+    describe('Without Credentials', () => {
+      beforeEach(async () => {
+        setupDocumentationModeEnv();
+        await initializeAuth();
+      });
+
+      it('should return validation failed as JSON', async () => {
+        const result = await handleAuth({
+          operation: 'validate',
+          response_format: ResponseFormat.JSON,
+        });
+
+        const data = JSON.parse(result);
+        expect(data.valid).toBe(false);
+        expect(data.mode).toBe('none');
+        expect(data.error).toContain('No credentials configured');
+        expect(data.suggestion).toBeDefined();
+      });
+
+      it('should return validation failed as markdown', async () => {
+        const result = await handleAuth({
+          operation: 'validate',
+          response_format: ResponseFormat.MARKDOWN,
+        });
+
+        expect(result).toContain('# Credential Validation');
+        expect(result).toContain('**Result**: Not validated');
+        expect(result).toContain('documentation mode');
+      });
+    });
+
+    describe('With Credentials (Mock)', () => {
+      beforeEach(async () => {
+        setupAuthenticatedModeEnv();
+        await initializeAuth();
+      });
+
+      it('should have initialized credential manager', () => {
+        const credManager = getCredentialManager();
+        expect(credManager).not.toBeNull();
+        expect(credManager?.isAuthenticated()).toBe(true);
+      });
+    });
+  });
+
+  // ===========================================================================
+  // SWITCH OPERATION TESTS
+  // ===========================================================================
+  describe('Switch Operation', () => {
+    beforeEach(async () => {
+      setupDocumentationModeEnv();
+      await initializeAuth();
+    });
+
+    it('should require profile_name parameter', async () => {
+      await expect(
+        handleAuth({
+          operation: 'switch',
+          response_format: ResponseFormat.JSON,
+        })
+      ).rejects.toThrow('profile_name is required');
+    });
+
+    it('should throw for non-existent profile', async () => {
+      await expect(
+        handleAuth({
+          operation: 'switch',
+          profile_name: 'nonexistent-profile',
+          response_format: ResponseFormat.JSON,
+        })
+      ).rejects.toThrow("Profile 'nonexistent-profile' not found");
+    });
+  });
+
+  // ===========================================================================
+  // ERROR HANDLING TESTS
+  // ===========================================================================
+  describe('Error Handling', () => {
+    beforeEach(async () => {
+      setupDocumentationModeEnv();
+      await initializeAuth();
+    });
+
+    it('should throw for unknown operation', async () => {
+      await expect(
+        handleAuth({
+          operation: 'unknown' as any,
+          response_format: ResponseFormat.JSON,
+        })
+      ).rejects.toThrow('Unknown operation');
+    });
+  });
+
+  // ===========================================================================
+  // CREDENTIAL MANAGER ACCESS TESTS
+  // ===========================================================================
+  describe('Credential Manager Access', () => {
+    it('should expose credential manager after init', async () => {
+      setupDocumentationModeEnv();
+      await initializeAuth();
+
+      const credManager = getCredentialManager();
+      expect(credManager).not.toBeNull();
+      expect(credManager).toBeInstanceOf(CredentialManager);
+    });
+
+    it('should return unauthenticated credential manager in doc mode', async () => {
+      setupDocumentationModeEnv();
+      await initializeAuth();
+
+      const credManager = getCredentialManager();
+      expect(credManager?.getAuthMode()).toBe(AuthMode.NONE);
+      expect(credManager?.isAuthenticated()).toBe(false);
+    });
+
+    it('should return authenticated credential manager in auth mode', async () => {
+      setupAuthenticatedModeEnv();
+      await initializeAuth();
+
+      const credManager = getCredentialManager();
+      expect(credManager?.getAuthMode()).toBe(AuthMode.TOKEN);
+      expect(credManager?.isAuthenticated()).toBe(true);
+    });
+  });
+});
+
+// ===========================================================================
+// AUTH TOOL CAPABILITY MATRIX
+// ===========================================================================
+describe('Auth Tool Capability Matrix', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  const capabilityMatrix: Array<{
+    name: string;
+    setup: () => void;
+    expectedMode: string;
+    expectedAuth: boolean;
+    expectedSource: string;
+  }> = [
+    {
+      name: 'Unauthenticated → Documentation mode',
+      setup: () => setupDocumentationModeEnv(),
+      expectedMode: 'none',
+      expectedAuth: false,
+      expectedSource: 'none (documentation mode)',
+    },
+    {
+      name: 'Token authenticated → Execution mode',
+      setup: () => setupAuthenticatedModeEnv(),
+      expectedMode: 'token',
+      expectedAuth: true,
+      expectedSource: 'environment variables',
+    },
+    {
+      name: 'Custom tenant → Full capabilities',
+      setup: () => setupAuthenticatedModeEnv({
+        apiUrl: 'https://production.console.ves.volterra.io',
+        apiToken: 'prod-token',
+      }),
+      expectedMode: 'token',
+      expectedAuth: true,
+      expectedSource: 'environment variables',
+    },
+  ];
+
+  capabilityMatrix.forEach(({ name, setup, expectedMode, expectedAuth, expectedSource }) => {
+    it(`Capability Matrix: ${name}`, async () => {
+      setup();
+      await initializeAuth();
+
+      const result = await handleAuth({
+        operation: 'status',
+        response_format: ResponseFormat.JSON,
+      });
+
+      const data = JSON.parse(result);
+      expect(data.mode).toBe(expectedMode);
+      expect(data.authenticated).toBe(expectedAuth);
+      expect(data.source).toBe(expectedSource);
+    });
+  });
+});
+
+// ===========================================================================
+// STATE TRANSITION TESTS
+// ===========================================================================
+describe('Auth State Transitions', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('should transition from documentation to authenticated mode', async () => {
+    // Start in documentation mode
+    setupDocumentationModeEnv();
+    await initializeAuth();
+
+    let result = await handleAuth({
+      operation: 'status',
+      response_format: ResponseFormat.JSON,
+    });
+    let data = JSON.parse(result);
+    expect(data.authenticated).toBe(false);
+
+    // Change to authenticated mode
+    setupAuthenticatedModeEnv();
+    await initializeAuth();
+
+    result = await handleAuth({
+      operation: 'status',
+      response_format: ResponseFormat.JSON,
+    });
+    data = JSON.parse(result);
+    expect(data.authenticated).toBe(true);
+  });
+
+  it('should transition from authenticated to documentation mode', async () => {
+    // Start in authenticated mode
+    setupAuthenticatedModeEnv();
+    await initializeAuth();
+
+    let result = await handleAuth({
+      operation: 'status',
+      response_format: ResponseFormat.JSON,
+    });
+    let data = JSON.parse(result);
+    expect(data.authenticated).toBe(true);
+
+    // Change to documentation mode
+    setupDocumentationModeEnv();
+    await initializeAuth();
+
+    result = await handleAuth({
+      operation: 'status',
+      response_format: ResponseFormat.JSON,
+    });
+    data = JSON.parse(result);
+    expect(data.authenticated).toBe(false);
+  });
+
+  it('should handle multiple tenant switches', async () => {
+    const tenants = ['tenant-a', 'tenant-b', 'tenant-c'];
+
+    for (const tenant of tenants) {
+      setupAuthenticatedModeEnv({
+        apiUrl: `https://${tenant}.console.ves.volterra.io`,
+        apiToken: `${tenant}-token`,
+      });
+      await initializeAuth();
+
+      const result = await handleAuth({
+        operation: 'status',
+        response_format: ResponseFormat.JSON,
+      });
+      const data = JSON.parse(result);
+      expect(data.tenant).toBe(tenant);
+    }
+  });
+});

--- a/mcp-server/tests/utils/ci-environment.ts
+++ b/mcp-server/tests/utils/ci-environment.ts
@@ -1,0 +1,93 @@
+/**
+ * CI Environment Utilities
+ *
+ * Helpers for detecting CI environment and setting up test scenarios
+ * for authenticated vs unauthenticated testing.
+ */
+
+/**
+ * Detect if running in CI environment
+ */
+export function isCI(): boolean {
+  return (
+    process.env.CI === 'true' ||
+    process.env.GITHUB_ACTIONS === 'true' ||
+    process.env.GITLAB_CI === 'true' ||
+    process.env.JENKINS_URL !== undefined ||
+    process.env.CIRCLECI === 'true'
+  );
+}
+
+/**
+ * List of F5XC environment variables that affect authentication
+ */
+const F5XC_ENV_VARS = [
+  'F5XC_API_URL',
+  'F5XC_API_TOKEN',
+  'F5XC_P12_FILE',
+  'F5XC_P12_PASSWORD',
+  'F5XC_CERT',
+  'F5XC_KEY',
+  'F5XC_NAMESPACE',
+  'F5XC_TENANT',
+  'F5XC_PROFILE',
+];
+
+/**
+ * Clear all F5XC-related environment variables
+ */
+export function clearF5XCEnvVars(): void {
+  for (const envVar of F5XC_ENV_VARS) {
+    delete process.env[envVar];
+  }
+}
+
+/**
+ * Set up environment for documentation mode (no credentials)
+ */
+export function setupDocumentationModeEnv(): void {
+  clearF5XCEnvVars();
+  // Set XDG_CONFIG_HOME to a non-existent path to prevent profile loading
+  process.env.XDG_CONFIG_HOME = '/tmp/__nonexistent_test_config__';
+}
+
+/**
+ * Set up environment for authenticated mode with token
+ */
+export function setupAuthenticatedModeEnv(options?: {
+  apiUrl?: string;
+  apiToken?: string;
+  namespace?: string;
+}): void {
+  clearF5XCEnvVars();
+  process.env.F5XC_API_URL = options?.apiUrl || 'https://test.console.ves.volterra.io';
+  process.env.F5XC_API_TOKEN = options?.apiToken || 'test-token';
+  if (options?.namespace) {
+    process.env.F5XC_NAMESPACE = options.namespace;
+  }
+  // Set XDG_CONFIG_HOME to a non-existent path to prevent profile interference
+  process.env.XDG_CONFIG_HOME = '/tmp/__nonexistent_test_config__';
+}
+
+/**
+ * Check if real API testing is possible (has valid credentials)
+ */
+export function hasRealCredentials(): boolean {
+  return Boolean(
+    process.env.F5XC_TEST_API_URL &&
+    process.env.F5XC_TEST_API_TOKEN
+  );
+}
+
+/**
+ * Get real test credentials if available
+ */
+export function getRealCredentials(): { apiUrl: string; apiToken: string } | null {
+  if (!hasRealCredentials()) {
+    return null;
+  }
+  return {
+    apiUrl: process.env.F5XC_TEST_API_URL!,
+    apiToken: process.env.F5XC_TEST_API_TOKEN!,
+  };
+}

--- a/mcp-server/vitest.config.ts
+++ b/mcp-server/vitest.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['tests/**/*.test.ts'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'html'],
+      include: ['src/**/*.ts'],
+      exclude: ['src/**/*.d.ts', 'src/services/**'],
+    },
+    testTimeout: 30000,
+    hookTimeout: 30000,
+  },
+});


### PR DESCRIPTION
## Summary

Add comprehensive test suite to validate the authentication refactoring in the MCP server that migrated to the shared `@robinmordasiewicz/f5xc-auth` npm package.

## Related Issue

Closes #776

## Changes Made

### Test Infrastructure Setup
- Added vitest as a dev dependency
- Created `vitest.config.ts` with proper configuration
- Added npm scripts: `test`, `test:watch`, `test:coverage`, `test:acceptance`, `validate:auth`

### Auth Integration Tests (28 tests)

**`tests/acceptance/auth-integration.test.ts`**:
- Documentation mode (no credentials) - 5 tests
- Token authentication - 5 tests
- Environment variable priority cascade - 2 tests
- Credential manager reload - 2 tests
- Multiple credential manager instances - 1 test
- Profile manager integration - 3 tests
- Error handling (invalid URLs, empty tokens) - 3 tests
- AuthMode enum validation - 2 tests
- Test matrix with 5 scenarios

### Auth Tool Acceptance Tests (22 tests)

**`tests/acceptance/auth-tool.test.ts`**:
- Status operation in documentation vs authenticated mode - 5 tests
- List operation for profiles - 2 tests
- Validate operation with/without credentials - 4 tests
- Switch operation error handling - 2 tests
- Credential manager access - 3 tests
- Capability matrix - 3 tests
- State transitions - 3 tests

### Automation Script

**`scripts/validate-auth-integration.ts`** - Idempotent validation script with:
- 10 comprehensive validation checks
- CLI options: `--verbose`, `--test-real-api`, `--help`
- Color-coded output with summary

## Testing

- [x] All 50 acceptance tests pass
- [x] Pre-commit hooks pass
- [x] TypeScript compilation passes

## Test Matrix

| Scenario | Expected Mode | Expected Auth | Expected Tenant |
|----------|---------------|---------------|-----------------|
| No credentials | NONE | false | null |
| Token only | TOKEN | true | test |
| Custom tenant URL | TOKEN | true | custom-tenant |
| Missing token | NONE | false | null |
| Empty token | NONE | false | null |

🤖 Generated with [Claude Code](https://claude.com/claude-code)