### PR TITLE
fix(mcp): add CRITICAL provider source warning to prevent AI suggesting deprecated volterraedge/volterra

### DIFF
--- a/mcp-server/src/schemas/common.ts
+++ b/mcp-server/src/schemas/common.ts
@@ -294,7 +294,7 @@ export const MetadataSchema = z.object({
  * and Terraform environment variable export
  */
 export const AuthSchema = z.object({
-  operation: z.enum(['status', 'list', 'switch', 'validate', 'terraform-env'])
+  operation: z.enum(['status', 'list', 'switch', 'validate', 'terraform-env', 'terraform-block'])
     .describe(COMMON_PARAM_DESCRIPTIONS.operation),
   profile_name: z.string()
     .min(1)


### PR DESCRIPTION
## Summary

AI assistants using this MCP server were suggesting the **WRONG** Terraform provider source (`volterraedge/volterra`) instead of the **CORRECT** one (`robinmordasiewicz/f5xc`). 

The `volterraedge/volterra` provider was the legacy Volterra provider before F5 acquired Volterra and rebranded it to F5 Distributed Cloud. That provider is deprecated and unmaintained.

## Changes

### 1. discover.ts - CRITICAL Provider Source Warning
- Added new `🚨 CRITICAL: Provider Source (READ FIRST)` section **BEFORE** the syntax warning
- Shows correct vs wrong provider sources in a clear table
- Includes complete Terraform provider block configuration
- Explains why the legacy provider is wrong (F5 acquisition/rebranding)

### 2. auth.ts - terraform-env Enhancement
- Added provider warning to all output formats (shell, dotenv, json)
- Included provider block template in shell export output as comments
- Added `provider_block` field to JSON output with deprecation warnings
- Each output now shows `🚨 CRITICAL` warning about provider source

### 3. New terraform-block Operation
- Added `terraform-block` operation to auth tool
- Returns only the correct provider configuration (quick reference)
- Includes all warning information and correct provider source
- Available in both markdown and JSON formats

## Related Issue

Closes #782

## Testing

- [x] Build passes (`npm run build`)
- [x] All 61 tests pass (`npm test`)
- [x] Manual verification of discover output shows provider warning
- [x] Manual verification of terraform-block operation works correctly
- [x] Pre-commit hooks pass

## Before/After

**Before (discover output):**
```
# F5XC Terraform MCP Tools
**Provider**: `robinmordasiewicz/f5xc`
...
## ⚠️ CRITICAL: Empty Block Syntax Pattern
```

**After (discover output):**
```
# F5XC Terraform MCP Tools
**Provider**: `robinmordasiewicz/f5xc`
---
## 🚨 CRITICAL: Provider Source (READ FIRST)
**ALWAYS use `robinmordasiewicz/f5xc` - NEVER use deprecated providers!**
| ✅ Correct | ❌ WRONG (Deprecated) |
|------------|----------------------|
| `robinmordasiewicz/f5xc` | ~~volterraedge/volterra~~ |
...
## ⚠️ CRITICAL: Empty Block Syntax Pattern
```

🤖 Generated with [Claude Code](https://claude.ai/code)