### PR TITLE
fix(ci): auto-close stale server.json PRs before creating new ones

### DIFF
--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -735,6 +735,25 @@ jobs:
             echo "changed=true" >> $GITHUB_OUTPUT
           fi
 
+      - name: Close stale server.json PRs
+        if: steps.check-changes.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.AUTO_MERGE_TOKEN }}
+        run: |
+          echo "Checking for stale server.json PRs..."
+          # Find all open PRs with the mcp label that update server.json
+          STALE_PRS=$(gh pr list --state open --label "mcp" --json number,title --jq '.[] | select(.title | startswith("chore(mcp): update server.json")) | .number')
+
+          if [ -n "$STALE_PRS" ]; then
+            echo "Found stale PRs: $STALE_PRS"
+            for PR in $STALE_PRS; do
+              echo "Closing stale PR #$PR (superseded by v${{ steps.version.outputs.version }})"
+              gh pr close "$PR" --comment "Closing stale PR - superseded by v${{ steps.version.outputs.version }}" || true
+            done
+          else
+            echo "No stale server.json PRs found"
+          fi
+
       - name: Create Pull Request for server.json update
         if: steps.check-changes.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@v7


### PR DESCRIPTION
## Summary
Fixes the issue where stale server.json PRs accumulate when releases happen faster than PRs can merge.

## Related Issue
Closes #796

## Problem
When releases happen rapidly:
1. Release v3.10.2 → Creates PR #789 (server.json v3.10.2)
2. Release v3.10.3 → Creates PR #791 (server.json v3.10.3)
3. Release v3.10.4 → Creates PR #795 (server.json v3.10.4)

PR #789 becomes stale but stays open, requiring manual cleanup.

## Solution
Add a "Close stale server.json PRs" step before creating new ones:
- Finds open PRs with `mcp` label and `chore(mcp): update server.json` title pattern
- Closes them with a comment explaining they're superseded by the new version

## Changes Made
- Added cleanup step in `on-merge.yml` → `mcp-unified` job (line 738-755)

## Testing
- Verified the gh CLI command works locally
- The step uses `|| true` to prevent failures if no PRs exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)