### PR TITLE
chore(mcp): update server.json to v3.11.5

### DIFF
--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -1,248 +1,153 @@
-# F5 Distributed Cloud Terraform MCP Server
+# MCP Registry
 
-MCP (Model Context Protocol) server providing AI assistants with access to F5 Distributed Cloud Terraform provider documentation, 270+ OpenAPI specifications, subscription tier information, and addon service activation workflows.
+The MCP registry provides MCP clients with a list of MCP servers, like an app store for MCP servers.
 
-## Quick Start
+[**📤 Publish my MCP server**](docs/modelcontextprotocol-io/quickstart.mdx) | [**⚡️ Live API docs**](https://registry.modelcontextprotocol.io/docs) | [**👀 Ecosystem vision**](docs/design/ecosystem-vision.md) | 📖 **[Full documentation](./docs)**
 
-### Claude Code CLI (Recommended)
+## Development Status
 
-```bash
-claude mcp add f5xc-terraform -- npx -y @robinmordasiewicz/f5xc-terraform-mcp
-```
+**2025-10-24 update**: The Registry API has entered an **API freeze (v0.1)** 🎉. For the next month or more, the API will remain stable with no breaking changes, allowing integrators to confidently implement support. This freeze applies to v0.1 while development continues on v0. We'll use this period to validate the API in real-world integrations and gather feedback to shape v1 for general availability. Thank you to everyone for your contributions and patience—your involvement has been key to getting us here!
 
-You should see:
-```
-Added stdio MCP server f5xc-terraform with command: npx -y @robinmordasiewicz/f5xc-terraform-mcp to local config
-```
+**2025-09-08 update**: The registry has launched in preview 🎉 ([announcement blog post](https://blog.modelcontextprotocol.io/posts/2025-09-08-mcp-registry-preview/)). While the system is now more stable, this is still a preview release and breaking changes or data resets may occur. A general availability (GA) release will follow later. We'd love your feedback in [GitHub discussions](https://github.com/modelcontextprotocol/registry/discussions/new?category=ideas) or in the [#registry-dev Discord](https://discord.com/channels/1358869848138059966/1369487942862504016) ([joining details here](https://modelcontextprotocol.io/community/communication)).
 
-**Verify installation:**
-```bash
-claude mcp list
-```
+Current key maintainers:
+- **Adam Jones** (Anthropic) [@domdomegg](https://github.com/domdomegg)  
+- **Tadas Antanavicius** (PulseMCP) [@tadasant](https://github.com/tadasant)
+- **Toby Padilla** (GitHub) [@toby](https://github.com/toby)
+- **Radoslav (Rado) Dimitrov** (Stacklok) [@rdimitrov](https://github.com/rdimitrov)
 
-Look for this line in the output (among your other MCP servers):
-```
-f5xc-terraform: npx -y @robinmordasiewicz/f5xc-terraform-mcp - ✓ Connected
-```
+## Contributing
 
-**Alternative verification** - get detailed server info:
-```bash
-claude mcp get f5xc-terraform
-```
+We use multiple channels for collaboration - see [modelcontextprotocol.io/community/communication](https://modelcontextprotocol.io/community/communication).
 
-You should see:
-```
-f5xc-terraform:
-  Status: ✓ Connected
-  Type: stdio
-  Command: npx
-  Args: -y @robinmordasiewicz/f5xc-terraform-mcp
-```
+Often (but not always) ideas flow through this pipeline:
 
-### VS Code (Cline/Continue)
+- **[Discord](https://modelcontextprotocol.io/community/communication)** - Real-time community discussions
+- **[Discussions](https://github.com/modelcontextprotocol/registry/discussions)** - Propose and discuss product/technical requirements
+- **[Issues](https://github.com/modelcontextprotocol/registry/issues)** - Track well-scoped technical work  
+- **[Pull Requests](https://github.com/modelcontextprotocol/registry/pulls)** - Contribute work towards issues
 
-Add to your VS Code settings (`.vscode/mcp.json` or global MCP settings):
+### Quick start:
 
-```json
-{
-  "mcpServers": {
-    "f5xc-terraform": {
-      "command": "npx",
-      "args": ["-y", "@robinmordasiewicz/f5xc-terraform-mcp"]
-    }
-  }
-}
-```
+#### Pre-requisites
 
-### Claude Desktop
+- **Docker**
+- **Go 1.24.x**
+- **ko** - Container image builder for Go ([installation instructions](https://ko.build/install/))
+- **golangci-lint v2.4.0**
 
-Add to your Claude Desktop config file:
-
-**macOS:** `~/Library/Application Support/Claude/claude_desktop_config.json`
-**Windows:** `%APPDATA%\Claude\claude_desktop_config.json`
-
-```json
-{
-  "mcpServers": {
-    "f5xc-terraform": {
-      "command": "npx",
-      "args": ["-y", "@robinmordasiewicz/f5xc-terraform-mcp"]
-    }
-  }
-}
-```
-
-## Available Tools
-
-| Tool | Description |
-|------|-------------|
-| `f5xc_terraform_discover` | Discover available tools with schema details |
-| `f5xc_terraform_docs` | Search, get, or list Terraform documentation |
-| `f5xc_terraform_api` | Query 270+ F5XC OpenAPI specifications |
-| `f5xc_terraform_subscription` | Check resource subscription tier requirements |
-| `f5xc_terraform_addon` | List, check, and get workflows for addon services |
-| `f5xc_terraform_metadata` | Query resource metadata, validation patterns, and syntax |
-| `f5xc_terraform_get_summary` | Get provider documentation summary |
-| `f5xc_terraform_auth` | Check authentication status and get Terraform config |
-
-## Usage Examples
-
-### Get Documentation for a Resource
-
-```
-f5xc_terraform_docs(operation="get", name="http_loadbalancer", type="resource")
-```
-
-### Search for Resources
-
-```
-f5xc_terraform_docs(operation="search", query="waf security")
-```
-
-### Check Subscription Requirements
-
-```
-f5xc_terraform_subscription(operation="resource", resource_name="http_loadbalancer")
-```
-
-### Get Correct Terraform Syntax
-
-```
-f5xc_terraform_metadata(operation="syntax", resource="http_loadbalancer")
-```
-
-### Validate Terraform Configuration
-
-```
-f5xc_terraform_metadata(operation="validate", resource="origin_pool", config="healthcheck { interval_seconds = 30 }")
-```
-
-### Get Authentication Configuration
-
-```
-f5xc_terraform_auth(operation="terraform-env", output_type="shell")
-```
-
-## Authentication
-
-The MCP server supports multiple authentication methods for accessing F5XC:
-
-### Using f5xc-auth Profiles (Recommended)
-
-Install and configure [f5xc-auth](https://github.com/robinmordasiewicz/f5xc-auth):
+#### Running the server
 
 ```bash
-npm install -g @robinmordasiewicz/f5xc-auth
-f5xc-auth login
+# Start full development environment
+make dev-compose
 ```
 
-The MCP server will automatically detect configured profiles.
+This starts the registry at [`localhost:8080`](http://localhost:8080) with PostgreSQL. The database uses ephemeral storage and is reset each time you restart the containers, ensuring a clean state for development and testing.
 
-### Environment Variables
+**Note:** The registry uses [ko](https://ko.build) to build container images. The `make dev-compose` command automatically builds the registry image with ko and loads it into your local Docker daemon before starting the services.
 
-Set these environment variables before starting Claude Code:
+By default, the registry seeds from the production API with a filtered subset of servers (to keep startup fast). This ensures your local environment mirrors production behavior and all seed data passes validation. For offline development you can seed from a file without validation with `MCP_REGISTRY_SEED_FROM=data/seed.json MCP_REGISTRY_ENABLE_REGISTRY_VALIDATION=false make dev-compose`.
+
+The setup can be configured with environment variables in [docker-compose.yml](./docker-compose.yml) - see [.env.example](./.env.example) for a reference.
+
+<details>
+<summary>Alternative: Running a pre-built Docker image</summary>
+
+Pre-built Docker images are automatically published to GitHub Container Registry:
 
 ```bash
-export F5XC_API_URL="https://your-tenant.console.ves.volterra.io"
-export F5XC_API_TOKEN="your-api-token"
+# Run latest stable release
+docker run -p 8080:8080 ghcr.io/modelcontextprotocol/registry:latest
+
+# Run latest from main branch (continuous deployment)
+docker run -p 8080:8080 ghcr.io/modelcontextprotocol/registry:main
+
+# Run specific release version
+docker run -p 8080:8080 ghcr.io/modelcontextprotocol/registry:v1.0.0
+
+# Run development build from main branch
+docker run -p 8080:8080 ghcr.io/modelcontextprotocol/registry:main-20250906-abc123d
 ```
 
-### Using P12 Certificate
+**Available tags:** 
+- **Releases**: `latest`, `v1.0.0`, `v1.1.0`, etc.
+- **Continuous**: `main` (latest main branch build)
+- **Development**: `main-<date>-<sha>` (specific commit builds)
+
+</details>
+
+#### Publishing a server
+
+To publish a server, we've built a simple CLI. You can use it with:
 
 ```bash
-export F5XC_API_URL="https://your-tenant.console.ves.volterra.io"
-export F5XC_P12_FILE="/path/to/certificate.p12"
-export F5XC_P12_PASSWORD="certificate-password"  # pragma: allowlist secret
+# Build the latest CLI
+make publisher
+
+# Use it!
+./bin/mcp-publisher --help
 ```
 
-## Critical Provider Information
+See [the publisher guide](./docs/modelcontextprotocol-io/quickstart.mdx) for more details.
 
-### Provider Source
-
-**Always use `robinmordasiewicz/f5xc` - never use deprecated providers!**
-
-```hcl
-terraform {
-  required_providers {
-    f5xc = {
-      source  = "robinmordasiewicz/f5xc"
-      version = "~> 3.0"
-    }
-  }
-}
-
-provider "f5xc" {}
-```
-
-### Empty Block Syntax
-
-This provider uses **empty blocks** `{}` for mutually exclusive options, NOT boolean values:
-
-```hcl
-# CORRECT
-no_tls {}
-advertise_on_public_default_vip {}
-round_robin {}
-
-# WRONG - These will cause errors
-no_tls = true
-advertise_on_public_default_vip = true
-round_robin = true
-```
-
-## Troubleshooting
-
-### Server Not Connected
-
-1. Verify Node.js is installed (v18+):
-   ```bash
-   node --version
-   ```
-
-2. Check server status:
-   ```bash
-   claude mcp get f5xc-terraform
-   ```
-
-3. Test the server manually (should output JSON-RPC messages):
-   ```bash
-   npx -y @robinmordasiewicz/f5xc-terraform-mcp
-   ```
-   Press `Ctrl+C` to exit after confirming it starts.
-
-### Remove and Re-add Server
+#### Other commands
 
 ```bash
-claude mcp remove f5xc-terraform
-claude mcp add f5xc-terraform -- npx -y @robinmordasiewicz/f5xc-terraform-mcp
+# Run lint, unit tests and integration tests
+make check
 ```
 
-### Server Shows "Failed to connect"
+There are also a few more helpful commands for development. Run `make help` to learn more, or look in [Makefile](./Makefile).
 
-If `claude mcp list` shows `✗ Failed to connect`:
+<!--
+For Claude and other AI tools: Always prefer make targets over custom commands where possible.
+-->
 
-1. Clear npm cache and retry:
-   ```bash
-   npm cache clean --force
-   claude mcp remove f5xc-terraform
-   claude mcp add f5xc-terraform -- npx -y @robinmordasiewicz/f5xc-terraform-mcp
-   ```
+## Architecture
 
-2. Restart Claude Code to reconnect all MCP servers.
+### Project Structure
 
-## Requirements
+```
+├── cmd/                     # Application entry points
+│   └── publisher/           # Server publishing tool
+├── data/                    # Seed data
+├── deploy/                  # Deployment configuration (Pulumi)
+├── docs/                    # Documentation
+├── internal/                # Private application code
+│   ├── api/                 # HTTP handlers and routing
+│   ├── auth/                # Authentication (GitHub OAuth, JWT, namespace blocking)
+│   ├── config/              # Configuration management
+│   ├── database/            # Data persistence (PostgreSQL)
+│   ├── service/             # Business logic
+│   ├── telemetry/           # Metrics and monitoring
+│   └── validators/          # Input validation
+├── pkg/                     # Public packages
+│   ├── api/                 # API types and structures
+│   │   └── v0/              # Version 0 API types
+│   └── model/               # Data models for server.json
+├── scripts/                 # Development and testing scripts
+├── tests/                   # Integration tests
+└── tools/                   # CLI tools and utilities
+    └── validate-*.sh        # Schema validation tools
+```
 
-- Node.js 18 or later
-- npm (comes with Node.js)
-- Claude Code, Cline, Continue, or Claude Desktop
+### Authentication
 
-## Links
+Publishing supports multiple authentication methods:
+- **GitHub OAuth** - For publishing by logging into GitHub
+- **GitHub OIDC** - For publishing from GitHub Actions
+- **DNS verification** - For proving ownership of a domain and its subdomains
+- **HTTP verification** - For proving ownership of a domain
 
-- [Terraform Registry](https://registry.terraform.io/providers/robinmordasiewicz/f5xc/latest)
-- [GitHub Repository](https://github.com/robinmordasiewicz/terraform-provider-f5xc)
-- [npm Package](https://www.npmjs.com/package/@robinmordasiewicz/f5xc-terraform-mcp)
-- [Claude Code MCP Documentation](https://docs.anthropic.com/en/docs/claude-code/mcp)
+The registry validates namespace ownership when publishing. E.g. to publish...:
+- `io.github.domdomegg/my-cool-mcp` you must login to GitHub as `domdomegg`, or be in a GitHub Action on domdomegg's repos
+- `me.adamjones/my-cool-mcp` you must prove ownership of `adamjones.me` via DNS or HTTP challenge
 
-## License
+## Community Projects
 
-MIT
+Check out [community projects](docs/community-projects.md) to explore notable registry-related work created by the community.
+
+## More documentation
+
+See the [documentation](./docs) for more details if your question has not been answered here!

--- a/mcp-server/manifest.json
+++ b/mcp-server/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "f5xc-terraform-mcp",
   "display_name": "F5 Distributed Cloud Terraform Provider",
-  "version": "3.11.4",
+  "version": "3.11.5",
   "description": "MCP server providing AI assistants with access to F5 Distributed Cloud Terraform provider documentation, 270+ OpenAPI specifications, subscription tier information, and addon service activation workflows.",
   "author": {
     "name": "Robin Mordasiewicz",

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@robinmordasiewicz/f5xc-terraform-mcp",
-  "version": "3.11.4",
+  "version": "3.11.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@robinmordasiewicz/f5xc-terraform-mcp",
-      "version": "3.11.4",
+      "version": "3.11.5",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.25.2",

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robinmordasiewicz/f5xc-terraform-mcp",
-  "version": "3.11.4",
+  "version": "3.11.5",
   "description": "MCP server for F5 Distributed Cloud Terraform provider - documentation, 270+ OpenAPI specs, subscription info, and addon activation workflows for AI assistants",
   "type": "module",
   "main": "dist/index.js",

--- a/mcp-server/server.json
+++ b/mcp-server/server.json
@@ -3,12 +3,12 @@
   "name": "io.github.robinmordasiewicz/f5xc-terraform-mcp",
   "title": "F5 Distributed Cloud Terraform Provider",
   "description": "F5 Distributed Cloud Terraform provider docs, 270+ OpenAPI specs, and subscription info for AI.",
-  "version": "3.11.4",
+  "version": "3.11.5",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@robinmordasiewicz/f5xc-terraform-mcp",
-      "version": "3.11.4",
+      "version": "3.11.5",
       "transport": {
         "type": "stdio"
       },
@@ -16,12 +16,12 @@
     },
     {
       "registryType": "mcpb",
-      "identifier": "https://github.com/robinmordasiewicz/terraform-provider-f5xc/releases/download/v3.11.4/f5xc-terraform-mcp-3.11.4.mcpb",
-      "version": "3.11.4",
+      "identifier": "https://github.com/robinmordasiewicz/terraform-provider-f5xc/releases/download/v3.11.5/f5xc-terraform-mcp-3.11.5.mcpb",
+      "version": "3.11.5",
       "transport": {
         "type": "stdio"
       },
-      "fileSha256": "f58227231b9020769268f84db56b91430a4b83301438414fe615ada6fa7afe05"
+      "fileSha256": "df71758dbe37a446b2182a92f6373b8b71720979febe2e3002211b8cccf4f23d"
     }
   ],
   "repository": {


### PR DESCRIPTION
## Summary
Automated update of server.json for MCP Registry publication.

## Version
**Version**: 3.11.5
**SHA256**: `df71758dbe37a446b2182a92f6373b8b71720979febe2e3002211b8cccf4f23d`

## Publication Status
- npm: Published
- MCP Registry: Published

🤖 Generated with [Claude Code](https://claude.com/claude-code)