### PR TITLE
fix: add namespace to Object Reference computed attributes

### DIFF
--- a/tools/generate-all-schemas.go
+++ b/tools/generate-all-schemas.go
@@ -1184,13 +1184,13 @@ func extractNestedAttributes(schema SchemaDefinition, spec *OpenAPI3Spec, depth 
 		}
 		attr := convertToTerraformAttributeWithDepth(propName, propSchema, requiredSet[propName], "", spec, depth, nestedPath)
 
-		// Mark 'tenant', 'uid', and 'kind' fields as Computed in nested Object Reference blocks.
+		// Mark 'namespace', 'tenant', 'uid', and 'kind' fields as Computed in nested Object Reference blocks.
 		// The API always returns these values even when not specified in config,
 		// which causes state drift if not marked as Computed.
 		// Object Reference types have pattern: kind, name, namespace, tenant, uid
 		// Using UseStateForUnknown plan modifier prevents perpetual drift.
 		propNameLower := strings.ToLower(propName)
-		if (propNameLower == "tenant" || propNameLower == "uid" || propNameLower == "kind") && !attr.Required {
+		if (propNameLower == "namespace" || propNameLower == "tenant" || propNameLower == "uid" || propNameLower == "kind") && !attr.Required {
 			attr.Computed = true
 			attr.Optional = true
 			attr.PlanModifier = "UseStateForUnknown"


### PR DESCRIPTION
## Summary

Fixed a bug in the resource schema generator where the 'namespace' field in Object Reference blocks was not marked as Computed, causing state inconsistency errors during Terraform apply.

## Changes

- **File**: `tools/generate-all-schemas.go`
- **Lines**: 1187, 1193
- Added `namespace` to the Object Reference computed attribute check

## Problem

When creating resources with Object Reference fields (like `f5xc_origin_pool.healthcheck.namespace`), Terraform reported:

```
Error: Provider produced inconsistent result after apply
.healthcheck[0].namespace: was null, but now cty.StringVal("system").
```

## Solution

The generator had special handling for Object Reference computed attributes but was missing `namespace` from the condition check, even though the comment documented all 5 fields (kind, name, namespace, tenant, uid).

## Verification

- ✅ Generator runs without errors (98 resources)
- ✅ Pre-commit hooks pass
- ✅ go build check passes
- ✅ go vet check passes

---

Closes #824
