### PR TITLE
chore(mcp): update server.json to v3.11.11

### DIFF
--- a/mcp-server/manifest.json
+++ b/mcp-server/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "f5xc-terraform-mcp",
   "display_name": "F5 Distributed Cloud Terraform Provider",
-  "version": "3.11.10",
+  "version": "3.11.11",
   "description": "MCP server providing AI assistants with access to F5 Distributed Cloud Terraform provider documentation, 270+ OpenAPI specifications, subscription tier information, and addon service activation workflows.",
   "author": {
     "name": "Robin Mordasiewicz",

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@robinmordasiewicz/f5xc-terraform-mcp",
-  "version": "3.11.10",
+  "version": "3.11.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@robinmordasiewicz/f5xc-terraform-mcp",
-      "version": "3.11.10",
+      "version": "3.11.11",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.25.2",

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robinmordasiewicz/f5xc-terraform-mcp",
-  "version": "3.11.10",
+  "version": "3.11.11",
   "description": "MCP server for F5 Distributed Cloud Terraform provider - documentation, 270+ OpenAPI specs, subscription info, and addon activation workflows for AI assistants",
   "type": "module",
   "main": "dist/index.js",

--- a/mcp-server/server.json
+++ b/mcp-server/server.json
@@ -3,12 +3,12 @@
   "name": "io.github.robinmordasiewicz/f5xc-terraform-mcp",
   "title": "F5 Distributed Cloud Terraform Provider",
   "description": "F5 Distributed Cloud Terraform provider docs, 270+ OpenAPI specs, and subscription info for AI.",
-  "version": "3.11.10",
+  "version": "3.11.11",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@robinmordasiewicz/f5xc-terraform-mcp",
-      "version": "3.11.10",
+      "version": "3.11.11",
       "transport": {
         "type": "stdio"
       },
@@ -16,12 +16,12 @@
     },
     {
       "registryType": "mcpb",
-      "identifier": "https://github.com/robinmordasiewicz/terraform-provider-f5xc/releases/download/v3.11.10/f5xc-terraform-mcp-3.11.10.mcpb",
-      "version": "3.11.10",
+      "identifier": "https://github.com/robinmordasiewicz/terraform-provider-f5xc/releases/download/v3.11.11/f5xc-terraform-mcp-3.11.11.mcpb",
+      "version": "3.11.11",
       "transport": {
         "type": "stdio"
       },
-      "fileSha256": "9c48545146be26672c9e087925849a40ce07839ee45bf4b4cda5336a767f70b2"
+      "fileSha256": "8755c6299c13a8c97143ec2462014e5ebcf2817d6d9980519d4a131c400485d3"
     }
   ],
   "repository": {


### PR DESCRIPTION
## Summary
Automated update of server.json for MCP Registry publication.

## Version
**Version**: 3.11.11
**SHA256**: `8755c6299c13a8c97143ec2462014e5ebcf2817d6d9980519d4a131c400485d3`

## Publication Status
- npm: Published
- MCP Registry: Published

🤖 Generated with [Claude Code](https://claude.com/claude-code)