### PR TITLE
fix(docs): add index.md templates to prevent deletion during regeneration

### DIFF
--- a/docs/data-sources/index.md
+++ b/docs/data-sources/index.md
@@ -1,0 +1,17 @@
+# Data Sources
+
+Terraform data sources for querying existing F5 Distributed Cloud infrastructure.
+
+## Overview
+
+Data sources allow you to reference existing F5XC resources in your Terraform configurations without managing them.
+
+## Finding Data Sources
+
+Use the navigation menu or search function to find specific data sources.
+
+## Related Documentation
+
+- [Guides](../guides/index.md) - Step-by-step tutorials
+- [Resources](../resources/index.md) - Manage infrastructure
+- [Functions](../functions/index.md) - Provider functions

--- a/docs/functions/index.md
+++ b/docs/functions/index.md
@@ -1,0 +1,18 @@
+# Functions
+
+Provider-defined functions for F5 Distributed Cloud operations.
+
+## Overview
+
+Functions provide utility operations not available through standard resources.
+
+## Available Functions
+
+- **[blindfold](blindfold.md)** - Encrypt plaintext using F5XC blindfold encryption
+- **[blindfold_file](blindfold_file.md)** - Encrypt file contents using F5XC blindfold encryption
+
+## Related Documentation
+
+- [Guides](../guides/index.md) - Step-by-step tutorials
+- [Resources](../resources/index.md) - Manage infrastructure
+- [Data Sources](../data-sources/index.md) - Query existing infrastructure

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -1,0 +1,18 @@
+# Guides
+
+Step-by-step tutorials for common F5 Distributed Cloud scenarios.
+
+## Available Guides
+
+- [HTTP Load Balancer](http-loadbalancer.md) - Deploy a basic HTTP Load Balancer
+- [Advanced HTTP Load Balancer Security](advanced-http-loadbalancer.md) - Production-ready security features
+- [Authentication](authentication.md) - Configure provider authentication
+- [Blindfold Encryption](blindfold.md) - Secure secret management
+- [Addon Service Activation](addon-activation.md) - Activate and manage addon services
+- [v3.0.0 Migration](v3-migration.md) - Upgrade from v2.x to v3.0.0
+
+## Related Documentation
+
+- [Resources](../resources/index.md)
+- [Data Sources](../data-sources/index.md)
+- [Functions](../functions/index.md)

--- a/docs/resources/index.md
+++ b/docs/resources/index.md
@@ -1,0 +1,22 @@
+# Resources
+
+Terraform resources for managing F5 Distributed Cloud infrastructure.
+
+## Overview
+
+This provider includes 150+ resources across all F5XC domains:
+
+- **Security**: WAF, DDoS protection, certificates
+- **Networking**: Load balancers, origin pools, DNS
+- **Infrastructure**: Sites, service mesh, cloud infrastructure
+- **Platform**: Tenants, identity, authentication
+
+## Finding Resources
+
+Use the navigation menu or search function to find specific resources.
+
+## Related Documentation
+
+- [Guides](../guides/index.md) - Step-by-step tutorials
+- [Data Sources](../data-sources/index.md) - Read existing infrastructure
+- [Functions](../functions/index.md) - Provider functions

--- a/templates/data-sources/index.md
+++ b/templates/data-sources/index.md
@@ -1,0 +1,17 @@
+# Data Sources
+
+Terraform data sources for querying existing F5 Distributed Cloud infrastructure.
+
+## Overview
+
+Data sources allow you to reference existing F5XC resources in your Terraform configurations without managing them.
+
+## Finding Data Sources
+
+Use the navigation menu or search function to find specific data sources.
+
+## Related Documentation
+
+- [Guides](../guides/index.md) - Step-by-step tutorials
+- [Resources](../resources/index.md) - Manage infrastructure
+- [Functions](../functions/index.md) - Provider functions

--- a/templates/functions/index.md
+++ b/templates/functions/index.md
@@ -1,0 +1,18 @@
+# Functions
+
+Provider-defined functions for F5 Distributed Cloud operations.
+
+## Overview
+
+Functions provide utility operations not available through standard resources.
+
+## Available Functions
+
+- **[blindfold](blindfold.md)** - Encrypt plaintext using F5XC blindfold encryption
+- **[blindfold_file](blindfold_file.md)** - Encrypt file contents using F5XC blindfold encryption
+
+## Related Documentation
+
+- [Guides](../guides/index.md) - Step-by-step tutorials
+- [Resources](../resources/index.md) - Manage infrastructure
+- [Data Sources](../data-sources/index.md) - Query existing infrastructure

--- a/templates/guides/index.md
+++ b/templates/guides/index.md
@@ -1,0 +1,18 @@
+# Guides
+
+Step-by-step tutorials for common F5 Distributed Cloud scenarios.
+
+## Available Guides
+
+- [HTTP Load Balancer](http-loadbalancer.md) - Deploy a basic HTTP Load Balancer
+- [Advanced HTTP Load Balancer Security](advanced-http-loadbalancer.md) - Production-ready security features
+- [Authentication](authentication.md) - Configure provider authentication
+- [Blindfold Encryption](blindfold.md) - Secure secret management
+- [Addon Service Activation](addon-activation.md) - Activate and manage addon services
+- [v3.0.0 Migration](v3-migration.md) - Upgrade from v2.x to v3.0.0
+
+## Related Documentation
+
+- [Resources](../resources/index.md)
+- [Data Sources](../data-sources/index.md)
+- [Functions](../functions/index.md)

--- a/templates/resources/index.md
+++ b/templates/resources/index.md
@@ -1,0 +1,22 @@
+# Resources
+
+Terraform resources for managing F5 Distributed Cloud infrastructure.
+
+## Overview
+
+This provider includes 150+ resources across all F5XC domains:
+
+- **Security**: WAF, DDoS protection, certificates
+- **Networking**: Load balancers, origin pools, DNS
+- **Infrastructure**: Sites, service mesh, cloud infrastructure
+- **Platform**: Tenants, identity, authentication
+
+## Finding Resources
+
+Use the navigation menu or search function to find specific resources.
+
+## Related Documentation
+
+- [Guides](../guides/index.md) - Step-by-step tutorials
+- [Data Sources](../data-sources/index.md) - Read existing infrastructure
+- [Functions](../functions/index.md) - Provider functions


### PR DESCRIPTION
## Summary
Fixes MkDocs documentation build failure by adding index.md templates that persist through documentation regeneration.

## Related Issue
Closes #844

## Problem
The previous fix (d0ebd0c6) added index.md files to `docs/` but not to `templates/`. When `tfplugindocs generate` runs, it cleans the `docs/` directory and rebuilds from `templates/`, deleting these manually-maintained files.

## Solution
Add index.md files to `templates/` directories so they are copied to `docs/` during regeneration:
- `templates/guides/index.md` → `docs/guides/index.md`
- `templates/resources/index.md` → `docs/resources/index.md`
- `templates/data-sources/index.md` → `docs/data-sources/index.md`
- `templates/functions/index.md` → `docs/functions/index.md`

## Testing
- [x] Pre-commit hooks pass
- [x] Files are properly staged in both templates/ and docs/

🤖 Generated with [Claude Code](https://claude.com/claude-code)