### PR TITLE
chore(mcp): update server.json to v3.12.2

### DIFF
--- a/mcp-server/manifest.json
+++ b/mcp-server/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "@robinmordasiewicz/f5xc-terraform-mcp",
   "display_name": "F5 Distributed Cloud Terraform Provider",
-  "version": "3.12.1",
+  "version": "3.12.2",
   "description": "MCP server providing AI assistants with access to F5 Distributed Cloud Terraform provider documentation, 270+ OpenAPI specifications, subscription tier information, and addon service activation workflows.",
   "long_description": "Model Context Protocol (MCP) server for F5 Distributed Cloud (F5XC) Terraform provider. Provides AI assistants with comprehensive access to:\n\n- **Terraform Documentation**: Search, retrieve, and explore F5XC resources, data sources, functions, and guides\n- **OpenAPI Specifications**: Query 270+ F5 Distributed Cloud API specs with endpoint discovery and schema definitions\n- **Subscription Intelligence**: Check resource subscription tier requirements (STANDARD, ADVANCED, PREMIUM)\n- **Addon Service Workflows**: List, check activation status, and get activation workflows for F5XC addon services\n- **Metadata & Patterns**: Access validation patterns, oneof constraints, default values, and common configuration mistakes\n\nDesigned for infrastructure-as-code workflows, enabling intelligent Terraform configuration generation with subscription compliance and best practices built-in.",
   "author": {

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@robinmordasiewicz/f5xc-terraform-mcp",
-  "version": "3.12.1",
+  "version": "3.12.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@robinmordasiewicz/f5xc-terraform-mcp",
-      "version": "3.12.1",
+      "version": "3.12.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.25.2",

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robinmordasiewicz/f5xc-terraform-mcp",
-  "version": "3.12.1",
+  "version": "3.12.2",
   "description": "MCP server for F5 Distributed Cloud Terraform provider - documentation, 270+ OpenAPI specs, subscription info, and addon activation workflows for AI assistants",
   "type": "module",
   "main": "dist/index.js",

--- a/mcp-server/server.json
+++ b/mcp-server/server.json
@@ -3,12 +3,12 @@
   "name": "io.github.robinmordasiewicz/f5xc-terraform-mcp",
   "title": "F5 Distributed Cloud Terraform Provider",
   "description": "F5 Distributed Cloud Terraform provider docs, 270+ OpenAPI specs, and subscription info for AI.",
-  "version": "3.12.1",
+  "version": "3.12.2",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@robinmordasiewicz/f5xc-terraform-mcp",
-      "version": "3.12.1",
+      "version": "3.12.2",
       "transport": {
         "type": "stdio"
       },
@@ -16,12 +16,12 @@
     },
     {
       "registryType": "mcpb",
-      "identifier": "https://github.com/robinmordasiewicz/terraform-provider-f5xc/releases/download/v3.12.1/f5xc-terraform-mcp-3.12.1.mcpb",
-      "version": "3.12.1",
+      "identifier": "https://github.com/robinmordasiewicz/terraform-provider-f5xc/releases/download/v3.12.2/f5xc-terraform-mcp-3.12.2.mcpb",
+      "version": "3.12.2",
       "transport": {
         "type": "stdio"
       },
-      "fileSha256": "a00319993d7799dafe13e95e034a18ccfb14dfbb58af185b89f2ffa36919e000"
+      "fileSha256": "0e6ba7105e160bdfb58e268e9442b3927c188501e1355db5550d0cb1d6b623d3"
     }
   ],
   "repository": {


### PR DESCRIPTION
## Summary
Automated update of server.json for MCP Registry publication.

## Version
**Version**: 3.12.2
**SHA256**: `0e6ba7105e160bdfb58e268e9442b3927c188501e1355db5550d0cb1d6b623d3`

## Publication Status
- npm: Published
- MCP Registry: Published

🤖 Generated with [Claude Code](https://claude.com/claude-code)