### PR TITLE
feat(testing): add generic CheckResourceDisappears helper

### DIFF
--- a/internal/provider/tenant_configuration_resource_test.go
+++ b/internal/provider/tenant_configuration_resource_test.go
@@ -435,8 +435,7 @@ func TestAccTenantConfigurationResource_disappears(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					acctest.CheckResourceExists(resourceName),
 					// Delete the resource outside of Terraform
-					// TODO: add generic CheckResourceDisappears helper
-					// acctest.CheckResourceExists(resourceName),
+					acctest.CheckResourceDisappears("f5xc_tenant_configuration", resourceName),
 				),
 				// Expect the plan to show the resource needs to be recreated
 				ExpectNonEmptyPlan: true,

--- a/internal/provider/voltshare_admin_policy_resource_test.go
+++ b/internal/provider/voltshare_admin_policy_resource_test.go
@@ -273,8 +273,7 @@ func TestAccVoltshareAdminPolicyResource_disappears(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					acctest.CheckResourceExists(resourceName),
 					// Delete the resource outside of Terraform
-					// TODO: add generic CheckResourceDisappears helper
-					// acctest.CheckResourceExists(resourceName),
+					acctest.CheckResourceDisappears("f5xc_voltshare_admin_policy", resourceName),
 				),
 				// Expect the plan to show the resource needs to be recreated
 				ExpectNonEmptyPlan: true,


### PR DESCRIPTION
## Summary

Implements a registry-based generic `CheckResourceDisappears` helper function for testing resource disappearance scenarios. This allows acceptance tests to verify that Terraform properly detects when resources are deleted externally (outside of Terraform).

## Related Issue

Closes #851

## Changes Made

- Added `ResourceDeleter` type as function signature for delete operations
- Added `resourceDeleterRegistry` with ~70 resource delete functions covering all testable resources
- Added `CheckResourceDisappears(resourceType, resourceName string)` generic test helper
- Added helper functions:
  - `RegisterResourceDeleter()` - runtime registration of additional deleters
  - `GetRegisteredDeleterTypes()` - list all registered resource types
  - `GetDeleterRegistrySize()` - get count of registered deleters
- Enabled disappears tests for `tenant_configuration` and `voltshare_admin_policy` resources

## Design Decisions

- **Registry Pattern**: Matches existing `CheckResourceDestroyed` implementation for consistency
- **Two Parameters**: `resourceType` + `resourceName` for explicit resource identification  
- **Not Found Tolerance**: Ignores 404 errors since resource may already be deleted
- **60s Timeout**: Matches existing helpers for API operations
- **Default Namespace**: Falls back to "system" like existing implementations

## Usage

```go
{
    Config: testAccResourceConfig_basic(rName),
    Check: resource.ComposeTestCheckFunc(
        acctest.CheckResourceExists(resourceName),
        acctest.CheckResourceDisappears("f5xc_namespace", resourceName),
    ),
    ExpectNonEmptyPlan: true,
},
```

## Testing

- [x] Build succeeds: `go build ./...`
- [x] Unit tests pass: `go test ./internal/acctest/...`
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)