### PR TITLE
feat(resilience): add rate limit retry logic to blindfold public key requests

### DIFF
--- a/internal/blindfold/publickey.go
+++ b/internal/blindfold/publickey.go
@@ -7,12 +7,20 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math"
 	"net/http"
+	"time"
 )
 
 const (
 	// PublicKeyEndpoint is the F5XC API endpoint for fetching the encryption public key
 	PublicKeyEndpoint = "/api/secret_management/get_public_key"
+
+	// Retry configuration for rate-limited requests
+	defaultMaxRetries     = 3
+	defaultRetryWaitMin   = 1 * time.Second
+	defaultRetryWaitMax   = 30 * time.Second
+	defaultRateLimitDelay = 60 * time.Second
 )
 
 // GetPublicKey fetches the encryption public key from F5XC Secret Management API.
@@ -30,8 +38,34 @@ func GetPublicKey(ctx context.Context, httpClient *http.Client, baseURL string) 
 	return GetPublicKeyWithVersion(ctx, httpClient, baseURL, 0)
 }
 
+// isRetryableStatus returns true if the HTTP status code indicates a retryable error
+func isRetryableStatus(statusCode int) bool {
+	switch statusCode {
+	case http.StatusTooManyRequests, // 429 - Rate limited
+		http.StatusServiceUnavailable, // 503
+		http.StatusGatewayTimeout,     // 504
+		http.StatusBadGateway:         // 502
+		return true
+	default:
+		return false
+	}
+}
+
+// calculateBackoff returns the backoff duration for a given attempt using exponential backoff
+func calculateBackoff(attempt int) time.Duration {
+	// Exponential backoff: min * 2^attempt, capped at max
+	backoff := float64(defaultRetryWaitMin) * math.Pow(2, float64(attempt))
+	if backoff > float64(defaultRetryWaitMax) {
+		backoff = float64(defaultRetryWaitMax)
+	}
+	return time.Duration(backoff)
+}
+
 // GetPublicKeyWithVersion fetches a specific version of the encryption public key.
 // Use version 0 or negative to get the current/latest key.
+//
+// This function includes retry logic with exponential backoff for handling
+// rate-limited (429) and temporary server errors (502, 503, 504).
 //
 // Parameters:
 //   - ctx: Context for cancellation and timeouts
@@ -41,7 +75,7 @@ func GetPublicKey(ctx context.Context, httpClient *http.Client, baseURL string) 
 //
 // Returns:
 //   - PublicKey containing RSA modulus and exponent
-//   - Error if the request fails or response is invalid
+//   - Error if the request fails after all retries or response is invalid
 func GetPublicKeyWithVersion(ctx context.Context, httpClient *http.Client, baseURL string, version int) (*PublicKey, error) {
 	if httpClient == nil {
 		return nil, fmt.Errorf("HTTP client is required")
@@ -56,50 +90,88 @@ func GetPublicKeyWithVersion(ctx context.Context, httpClient *http.Client, baseU
 		url = fmt.Sprintf("%s?key_version=%d", url, version)
 	}
 
-	// Create request
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
+	var lastErr error
 
-	req.Header.Set("Accept", "application/json")
-
-	// Execute request
-	resp, err := httpClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("request failed: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	// Read response body
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read response: %w", err)
-	}
-
-	// Check status code
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("unexpected status %d: %s", resp.StatusCode, string(body))
-	}
-
-	// Parse response - F5XC wraps responses in an envelope
-	var envelope APIEnvelope[PublicKey]
-	if err := json.Unmarshal(body, &envelope); err != nil {
-		// Try parsing without envelope (direct response)
-		var pubKey PublicKey
-		if err2 := json.Unmarshal(body, &pubKey); err2 != nil {
-			return nil, fmt.Errorf("failed to parse response: %w (envelope: %v)", err2, err)
+	for attempt := 0; attempt <= defaultMaxRetries; attempt++ {
+		// Check context before making request
+		if ctx.Err() != nil {
+			return nil, fmt.Errorf("context cancelled: %w", ctx.Err())
 		}
-		return &pubKey, nil
+
+		// Create request for each attempt (request body may be consumed)
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create request: %w", err)
+		}
+		req.Header.Set("Accept", "application/json")
+
+		// Execute request
+		resp, err := httpClient.Do(req)
+		if err != nil {
+			lastErr = fmt.Errorf("request failed: %w", err)
+			// Network errors are retryable
+			if attempt < defaultMaxRetries {
+				select {
+				case <-ctx.Done():
+					return nil, fmt.Errorf("context cancelled during retry: %w", ctx.Err())
+				case <-time.After(calculateBackoff(attempt)):
+					continue
+				}
+			}
+			return nil, lastErr
+		}
+
+		// Read response body
+		body, err := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		if err != nil {
+			return nil, fmt.Errorf("failed to read response: %w", err)
+		}
+
+		// Check for successful response
+		if resp.StatusCode == http.StatusOK {
+			// Parse response - F5XC wraps responses in an envelope
+			var envelope APIEnvelope[PublicKey]
+			if err := json.Unmarshal(body, &envelope); err != nil {
+				// Try parsing without envelope (direct response)
+				var pubKey PublicKey
+				if err2 := json.Unmarshal(body, &pubKey); err2 != nil {
+					return nil, fmt.Errorf("failed to parse response: %w (envelope: %v)", err2, err)
+				}
+				return &pubKey, nil
+			}
+
+			// Validate the response
+			if envelope.Data.ModulusBase64 == "" {
+				return nil, fmt.Errorf("response missing modulus")
+			}
+			if envelope.Data.PublicExponentBase64 == "" {
+				return nil, fmt.Errorf("response missing public exponent")
+			}
+
+			return &envelope.Data, nil
+		}
+
+		// Check if error is retryable
+		lastErr = fmt.Errorf("unexpected status %d: %s", resp.StatusCode, string(body))
+		if !isRetryableStatus(resp.StatusCode) || attempt >= defaultMaxRetries {
+			return nil, lastErr
+		}
+
+		// Calculate backoff (use longer delay for rate limiting)
+		backoff := calculateBackoff(attempt)
+		if resp.StatusCode == http.StatusTooManyRequests {
+			backoff = defaultRateLimitDelay
+		}
+
+		// Wait before retry
+		select {
+		case <-ctx.Done():
+			return nil, fmt.Errorf("context cancelled during retry: %w", ctx.Err())
+		case <-time.After(backoff):
+			continue
+		}
 	}
 
-	// Validate the response
-	if envelope.Data.ModulusBase64 == "" {
-		return nil, fmt.Errorf("response missing modulus")
-	}
-	if envelope.Data.PublicExponentBase64 == "" {
-		return nil, fmt.Errorf("response missing public exponent")
-	}
-
-	return &envelope.Data, nil
+	return nil, lastErr
 }


### PR DESCRIPTION
## Summary

Add exponential backoff retry logic to the blindfold package's `GetPublicKeyWithVersion()` function to handle rate-limited (429) and temporary server errors (502, 503, 504).

## Related Issue

Closes #855

## Changes Made

### Implementation (`internal/blindfold/publickey.go`)

- Added retry configuration constants matching the main API client:
  - `defaultMaxRetries = 3`
  - `defaultRetryWaitMin = 1 * time.Second`
  - `defaultRetryWaitMax = 30 * time.Second`
  - `defaultRateLimitDelay = 60 * time.Second`

- Added helper functions:
  - `isRetryableStatus()` - identifies retryable HTTP status codes (429, 502, 503, 504)
  - `calculateBackoff()` - exponential backoff calculation

- Updated `GetPublicKeyWithVersion()` with retry loop:
  - Retries on network errors and retryable status codes
  - Uses 60s delay for rate limiting (429) to respect API limits
  - Uses exponential backoff (1s → 2s → 4s → 8s → ...) for other retryable errors
  - Respects context cancellation during retries

### Tests (`internal/blindfold/publickey_test.go`)

- `TestGetPublicKey_RetryOnRateLimit` - verifies 429 triggers retry with success on second attempt
- `TestGetPublicKey_RetryOnServerError` - verifies 502/503/504 trigger retry
- `TestGetPublicKey_NoRetryOnClientError` - verifies 4xx client errors fail immediately
- `TestGetPublicKey_MaxRetriesExceeded` - verifies failure after max retries
- `TestIsRetryableStatus` - unit tests for status code classification
- `TestCalculateBackoff` - unit tests for exponential backoff calculation

## Design Decisions

1. **Consistent with existing patterns** - Retry logic mirrors `internal/client/client.go` implementation
2. **60s rate limit delay** - Matches F5XC API expectations for rate-limited requests
3. **Exponential backoff** - Prevents thundering herd on temporary failures
4. **Context-aware** - All retries check for context cancellation

## Testing

- [x] Build succeeds: `go build ./...`
- [x] Unit tests pass: `go test ./internal/blindfold/... -v`
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)