### PR TITLE
feat(generator): surface x-f5xc-server-default in docs and examples

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1743,9 +1743,9 @@
         "filename": "tools/generate-examples.go",
         "hashed_secret": "25910f981e85ca04baf359199dd0bd4a3ae738b6",
         "is_verified": false,
-        "line_number": 695
+        "line_number": 725
       }
     ]
   },
-  "generated_at": "2026-01-16T20:55:01Z"
+  "generated_at": "2026-01-17T00:12:27Z"
 }

--- a/tools/transform-docs.go
+++ b/tools/transform-docs.go
@@ -395,6 +395,28 @@ func isAdvancedFeatureProperty(resourceName, propertyName string) bool {
 
 const advancedIndicator = "**(Advanced subscription required)**"
 
+// serverDefaultIndicator marks fields where F5XC server applies sensible defaults when omitted
+const serverDefaultIndicator = "⚙️ **Server Default**"
+
+// serverDefaultMarker is the text pattern added by generate-all-schemas.go to identify server default fields
+const serverDefaultMarker = "Server applies default when omitted."
+
+// formatServerDefaultNote transforms the server default marker in descriptions into a visual indicator.
+// The marker "Server applies default when omitted." is replaced with a styled badge.
+func formatServerDefaultNote(description string) string {
+	if !strings.Contains(description, serverDefaultMarker) {
+		return description
+	}
+	// Remove the marker text and add the visual indicator
+	desc := strings.Replace(description, serverDefaultMarker, "", 1)
+	desc = strings.TrimSpace(desc)
+	desc = strings.TrimSuffix(desc, ".")
+	if desc == "" {
+		return serverDefaultIndicator
+	}
+	return desc + " " + serverDefaultIndicator
+}
+
 // appendSubscriptionIndicator adds the Advanced subscription indicator to a description
 // if the property matches an advanced feature. Idempotent - won't add if already present.
 func appendSubscriptionIndicator(resourceName, propertyName, description string) string {
@@ -1574,6 +1596,8 @@ func transformDoc(filePath string) error {
 
 		// Add description on next line (if any)
 		if desc != "" {
+			// Format server default note into visual indicator (x-f5xc-server-default extension)
+			desc = formatServerDefaultNote(desc)
 			// Annotate advanced feature properties with subscription tier indicator
 			desc = appendSubscriptionIndicator(resourceName, attr.name, desc)
 			result.WriteString("<br>" + desc)
@@ -1886,6 +1910,8 @@ func transformDoc(filePath string) error {
 
 					// Add description on next line (if any)
 					if desc != "" {
+						// Format server default note into visual indicator (x-f5xc-server-default extension)
+						desc = formatServerDefaultNote(desc)
 						result.WriteString("<br>" + desc)
 					}
 


### PR DESCRIPTION
## Summary

Enhance the Terraform provider to surface `x-f5xc-server-default` information in resource documentation, field descriptions, and examples.

This PR implements support for the `x-f5xc-server-default: true` extension that marks fields where the F5XC server applies sensible defaults when users omit them. The MCP server already consumes this data; now the Terraform provider surfaces this information to users.

## Related Issue

Closes #888

## Changes Made

### Phase 1: Generate-all-schemas.go
- Add `XF5XCServerDefault` field to `SchemaDefinition` struct to capture the extension
- Add `ServerDefault` field to `TerraformAttribute` struct to propagate the flag
- Preserve extensions when resolving `$ref` references
- Append "Server applies default when omitted." to field descriptions when flag is true

### Phase 2: Transform-docs.go
- Add `formatServerDefaultNote()` function to transform the marker into a visual indicator
- Replace "Server applies default when omitted." with ⚙️ **Server Default** badge
- Apply transformation in both main attribute and nested attribute description handling

### Phase 3: Generate-examples.go
- Add `ServerDefault` field to `AttributeInfo` and `BlockInfo` structs
- Detect server default marker in descriptions during parsing
- Add comment section at end of generated examples listing fields with server defaults

## Resources with Server Defaults

- `app_firewall`: monitoring, default_bot_setting, default_detection_settings, etc.
- `healthcheck`: jitter_percent
- `rate_limiter`: burst_multiplier
- `api_definition`: various validation fields

## Testing

- [x] Provider builds successfully
- [x] All pre-commit hooks pass
- [x] golangci-lint passes
- [x] Preview lint on generated code passes
- [x] All tests pass

## Example Output

Field descriptions will now show:
```
monitoring - Enable this option ⚙️ **Server Default**
```

Example files will include:
```hcl
# The following optional fields have server-applied defaults and can be omitted:
# - monitoring
# - default_bot_setting
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)