### PR TITLE
feat(generator): add v2.0.33 operation-level metadata support

### DIFF
--- a/mcp-server/src/services/operations.ts
+++ b/mcp-server/src/services/operations.ts
@@ -1,0 +1,275 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
+/**
+ * Operation Metadata Service for F5 XC MCP Server
+ *
+ * Provides access to operation-level metadata from v2.0.33 API specifications.
+ * This includes danger levels, side effects, response times, and best practices.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import {
+  OperationsMetadataCollection,
+  ResourceOperationInfo,
+  OperationMetadata,
+  DangerLevel,
+  SideEffectsInfo,
+  BestPracticesInfo,
+  GuidedWorkflowInfo,
+  ResponseTimeInfo,
+} from '../types.js';
+
+export class OperationsService {
+  private operationsMetadata: OperationsMetadataCollection | null = null;
+  private metadataPath: string;
+  private loaded = false;
+
+  constructor(basePath: string = process.cwd()) {
+    // Try multiple paths to find operations-metadata.json
+    const possiblePaths = [
+      path.join(basePath, 'tools', 'metadata', 'operations-metadata.json'),
+      path.join(basePath, '..', 'tools', 'metadata', 'operations-metadata.json'),
+      path.join(__dirname, '..', '..', '..', 'tools', 'metadata', 'operations-metadata.json'),
+    ];
+
+    this.metadataPath = possiblePaths[0];
+    for (const p of possiblePaths) {
+      if (fs.existsSync(p)) {
+        this.metadataPath = p;
+        break;
+      }
+    }
+  }
+
+  /**
+   * Load operations metadata from JSON file
+   */
+  private async loadMetadata(): Promise<void> {
+    if (this.loaded) return;
+
+    try {
+      if (fs.existsSync(this.metadataPath)) {
+        const content = fs.readFileSync(this.metadataPath, 'utf-8');
+        this.operationsMetadata = JSON.parse(content);
+        this.loaded = true;
+      } else {
+        // Initialize with empty collection if file doesn't exist
+        this.operationsMetadata = {
+          generated_at: new Date().toISOString(),
+          version: '1.0.0',
+          resources: {},
+        };
+        this.loaded = true;
+      }
+    } catch (error) {
+      console.error('Failed to load operations metadata:', error);
+      this.operationsMetadata = {
+        generated_at: new Date().toISOString(),
+        version: '1.0.0',
+        resources: {},
+      };
+      this.loaded = true;
+    }
+  }
+
+  /**
+   * Get all operation metadata for a resource
+   */
+  async getResourceOperations(resource: string): Promise<ResourceOperationInfo | null> {
+    await this.loadMetadata();
+    return this.operationsMetadata?.resources[resource] || null;
+  }
+
+  /**
+   * Get danger level for a specific operation
+   */
+  async getDangerLevel(
+    resource: string,
+    operation: 'create' | 'read' | 'update' | 'delete' | 'list',
+  ): Promise<DangerLevel | undefined> {
+    const resourceOps = await this.getResourceOperations(resource);
+    return resourceOps?.operations[operation]?.danger_level;
+  }
+
+  /**
+   * Get side effects for a specific operation
+   */
+  async getSideEffects(
+    resource: string,
+    operation: 'create' | 'read' | 'update' | 'delete' | 'list',
+  ): Promise<SideEffectsInfo | undefined> {
+    const resourceOps = await this.getResourceOperations(resource);
+    return resourceOps?.operations[operation]?.side_effects;
+  }
+
+  /**
+   * Get response time metrics for a specific operation
+   */
+  async getResponseTime(
+    resource: string,
+    operation: 'create' | 'read' | 'update' | 'delete' | 'list',
+  ): Promise<ResponseTimeInfo | undefined> {
+    const resourceOps = await this.getResourceOperations(resource);
+    return resourceOps?.operations[operation]?.discovered_response_time;
+  }
+
+  /**
+   * Check if an operation requires confirmation
+   */
+  async requiresConfirmation(
+    resource: string,
+    operation: 'create' | 'read' | 'update' | 'delete' | 'list',
+  ): Promise<boolean> {
+    const resourceOps = await this.getResourceOperations(resource);
+    return resourceOps?.operations[operation]?.confirmation_required || false;
+  }
+
+  /**
+   * Get required fields for an operation
+   */
+  async getRequiredFields(
+    resource: string,
+    operation: 'create' | 'read' | 'update' | 'delete' | 'list',
+  ): Promise<string[]> {
+    const resourceOps = await this.getResourceOperations(resource);
+    return resourceOps?.operations[operation]?.required_fields || [];
+  }
+
+  /**
+   * Get best practices for a resource
+   */
+  async getBestPractices(resource: string): Promise<BestPracticesInfo | undefined> {
+    const resourceOps = await this.getResourceOperations(resource);
+    return resourceOps?.best_practices;
+  }
+
+  /**
+   * Get guided workflows for a resource
+   */
+  async getGuidedWorkflows(resource: string): Promise<GuidedWorkflowInfo[]> {
+    const resourceOps = await this.getResourceOperations(resource);
+    return resourceOps?.guided_workflows || [];
+  }
+
+  /**
+   * Get complete operation metadata for a specific operation
+   */
+  async getOperationMetadata(
+    resource: string,
+    operation: 'create' | 'read' | 'update' | 'delete' | 'list',
+  ): Promise<OperationMetadata | undefined> {
+    const resourceOps = await this.getResourceOperations(resource);
+    return resourceOps?.operations[operation];
+  }
+
+  /**
+   * Get all high-danger operations across all resources
+   */
+  async getHighDangerOperations(): Promise<
+    Array<{ resource: string; operation: string; metadata: OperationMetadata }>
+  > {
+    await this.loadMetadata();
+    const results: Array<{
+      resource: string;
+      operation: string;
+      metadata: OperationMetadata;
+    }> = [];
+
+    if (!this.operationsMetadata) return results;
+
+    for (const [resourceName, resourceOps] of Object.entries(
+      this.operationsMetadata.resources,
+    )) {
+      for (const [opName, opMeta] of Object.entries(resourceOps.operations)) {
+        if (opMeta.danger_level === 'high' || opMeta.danger_level === 'critical') {
+          results.push({
+            resource: resourceName,
+            operation: opName,
+            metadata: opMeta,
+          });
+        }
+      }
+    }
+
+    return results;
+  }
+
+  /**
+   * Get all operations requiring confirmation
+   */
+  async getConfirmationRequiredOperations(): Promise<
+    Array<{ resource: string; operation: string; metadata: OperationMetadata }>
+  > {
+    await this.loadMetadata();
+    const results: Array<{
+      resource: string;
+      operation: string;
+      metadata: OperationMetadata;
+    }> = [];
+
+    if (!this.operationsMetadata) return results;
+
+    for (const [resourceName, resourceOps] of Object.entries(
+      this.operationsMetadata.resources,
+    )) {
+      for (const [opName, opMeta] of Object.entries(resourceOps.operations)) {
+        if (opMeta.confirmation_required) {
+          results.push({
+            resource: resourceName,
+            operation: opName,
+            metadata: opMeta,
+          });
+        }
+      }
+    }
+
+    return results;
+  }
+
+  /**
+   * Get all resources with operation metadata
+   */
+  async getResourcesWithOperationMetadata(): Promise<string[]> {
+    await this.loadMetadata();
+    return Object.keys(this.operationsMetadata?.resources || {});
+  }
+
+  /**
+   * Get summary statistics about operation metadata
+   */
+  async getSummary(): Promise<{
+    totalResources: number;
+    totalOperations: number;
+    byDangerLevel: Record<string, number>;
+    confirmationRequired: number;
+  }> {
+    await this.loadMetadata();
+
+    const summary = {
+      totalResources: 0,
+      totalOperations: 0,
+      byDangerLevel: {} as Record<string, number>,
+      confirmationRequired: 0,
+    };
+
+    if (!this.operationsMetadata) return summary;
+
+    summary.totalResources = Object.keys(this.operationsMetadata.resources).length;
+
+    for (const resourceOps of Object.values(this.operationsMetadata.resources)) {
+      for (const opMeta of Object.values(resourceOps.operations)) {
+        summary.totalOperations++;
+        if (opMeta.danger_level) {
+          summary.byDangerLevel[opMeta.danger_level] =
+            (summary.byDangerLevel[opMeta.danger_level] || 0) + 1;
+        }
+        if (opMeta.confirmation_required) {
+          summary.confirmationRequired++;
+        }
+      }
+    }
+
+    return summary;
+  }
+}

--- a/mcp-server/src/types.ts
+++ b/mcp-server/src/types.ts
@@ -149,3 +149,103 @@ export enum ResponseFormat {
   MARKDOWN = 'markdown',
   JSON = 'json'
 }
+
+// =============================================================================
+// Operation Metadata Types (v2.0.33 extensions)
+// =============================================================================
+
+/**
+ * Danger level classification for operations
+ */
+export type DangerLevel = 'low' | 'medium' | 'high' | 'critical';
+
+/**
+ * Collection of operation metadata for all resources
+ */
+export interface OperationsMetadataCollection {
+  generated_at: string;
+  version: string;
+  resources: Record<string, ResourceOperationInfo>;
+}
+
+/**
+ * Operation metadata for a single resource
+ */
+export interface ResourceOperationInfo {
+  resource: string;
+  base_path?: string;
+  operations: Record<string, OperationMetadata>;  // key: "create" | "read" | "update" | "delete" | "list"
+  best_practices?: BestPracticesInfo;
+  guided_workflows?: GuidedWorkflowInfo[];
+}
+
+/**
+ * Operation-level metadata from x-f5xc-* extensions
+ */
+export interface OperationMetadata {
+  method: string;  // HTTP method (POST, GET, PUT, DELETE)
+  path: string;    // API path
+  danger_level?: DangerLevel;
+  discovered_response_time?: ResponseTimeInfo;
+  required_fields?: string[];
+  confirmation_required?: boolean;
+  side_effects?: SideEffectsInfo;
+  purpose?: string;
+}
+
+/**
+ * Response time metrics from API discovery
+ */
+export interface ResponseTimeInfo {
+  p50_ms: number;
+  p95_ms: number;
+  p99_ms: number;
+  sample_count: number;
+  source: 'measured' | 'estimate';
+}
+
+/**
+ * Side effects of an operation
+ */
+export interface SideEffectsInfo {
+  creates?: string[];
+  modifies?: string[];
+  deletes?: string[];
+}
+
+/**
+ * Best practices information
+ */
+export interface BestPracticesInfo {
+  common_errors?: CommonErrorInfo[];
+}
+
+/**
+ * Common error and its resolution
+ */
+export interface CommonErrorInfo {
+  code: number;
+  message: string;
+  resolution: string;
+  prevention?: string;
+}
+
+/**
+ * Guided workflow for resource creation
+ */
+export interface GuidedWorkflowInfo {
+  name: string;
+  description: string;
+  steps: WorkflowStepInfo[];
+}
+
+/**
+ * Step in a guided workflow
+ */
+export interface WorkflowStepInfo {
+  order: number;
+  action: string;
+  description?: string;
+  fields?: string[];
+  validation?: string;
+}

--- a/tools/metadata/operations-metadata.json
+++ b/tools/metadata/operations-metadata.json
@@ -1,0 +1,10683 @@
+{
+  "generated_at": "2026-01-17T09:45:45Z",
+  "version": "1.0.0",
+  "resources": {
+    "address_allocator": {
+      "resource": "address_allocator",
+      "base_path": "/api/config/namespaces/{namespace}/address_allocators",
+      "operations": {
+        "create": {
+          "method": "POST",
+          "path": "/api/config/namespaces/{metadata.namespace}/address_allocators",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 1000,
+            "p95_ms": 3000,
+            "p99_ms": 8000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "metadata.name",
+            "metadata.namespace",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "creates": [
+              "address-allocator"
+            ]
+          },
+          "purpose": "Create Address Allocator."
+        },
+        "delete": {
+          "method": "DELETE",
+          "path": "/api/config/namespaces/{namespace}/address_allocators/{name}",
+          "danger_level": "high",
+          "discovered_response_time": {
+            "p50_ms": 500,
+            "p95_ms": 1500,
+            "p99_ms": 4000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "confirmation_required": true,
+          "side_effects": {
+            "deletes": [
+              "address-allocator",
+              "contained_resources"
+            ]
+          },
+          "purpose": "DELETE Address Allocator."
+        },
+        "list": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/address_allocators",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.namespace"
+          ],
+          "purpose": "List Address Allocator."
+        },
+        "read": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/address_allocators/{name}",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "purpose": "GET Address Allocator."
+        }
+      }
+    },
+    "advertise_policy": {
+      "resource": "advertise_policy",
+      "base_path": "/api/config/namespaces/{namespace}/advertise_policys",
+      "operations": {
+        "create": {
+          "method": "POST",
+          "path": "/api/config/namespaces/{metadata.namespace}/advertise_policys",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 1000,
+            "p95_ms": 3000,
+            "p99_ms": 8000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "metadata.name",
+            "metadata.namespace",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "creates": [
+              "advertise-policy"
+            ]
+          },
+          "purpose": "Create Advertise Policy."
+        },
+        "delete": {
+          "method": "DELETE",
+          "path": "/api/config/namespaces/{namespace}/advertise_policys/{name}",
+          "danger_level": "high",
+          "discovered_response_time": {
+            "p50_ms": 500,
+            "p95_ms": 1500,
+            "p99_ms": 4000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "confirmation_required": true,
+          "side_effects": {
+            "deletes": [
+              "advertise-policy",
+              "contained_resources"
+            ]
+          },
+          "purpose": "DELETE Advertise Policy."
+        },
+        "list": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/advertise_policys",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.namespace"
+          ],
+          "purpose": "List Advertise Policy."
+        },
+        "read": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/advertise_policys/{name}",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "purpose": "GET Advertise Policy."
+        },
+        "update": {
+          "method": "PUT",
+          "path": "/api/config/namespaces/{metadata.namespace}/advertise_policys/{metadata.name}",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 800,
+            "p95_ms": 2500,
+            "p99_ms": 6000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.metadata.name",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "modifies": [
+              "advertise-policy"
+            ]
+          },
+          "purpose": "Replace Advertise Policy."
+        }
+      }
+    },
+    "alert_policy": {
+      "resource": "alert_policy",
+      "base_path": "/api/config/namespaces/{namespace}/alert_policys",
+      "operations": {
+        "create": {
+          "method": "POST",
+          "path": "/api/config/namespaces/{metadata.namespace}/alert_policys",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 1000,
+            "p95_ms": 3000,
+            "p99_ms": 8000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "metadata.name",
+            "metadata.namespace",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "creates": [
+              "alert-policy"
+            ]
+          },
+          "purpose": "Create Alert Policy."
+        },
+        "delete": {
+          "method": "DELETE",
+          "path": "/api/config/namespaces/{namespace}/alert_policys/{name}",
+          "danger_level": "high",
+          "discovered_response_time": {
+            "p50_ms": 500,
+            "p95_ms": 1500,
+            "p99_ms": 4000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "confirmation_required": true,
+          "side_effects": {
+            "deletes": [
+              "alert-policy",
+              "contained_resources"
+            ]
+          },
+          "purpose": "DELETE Alert Policy."
+        },
+        "list": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/alert_policys",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.namespace"
+          ],
+          "purpose": "List Alert Policy."
+        },
+        "read": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/alert_policys/{name}",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "purpose": "GET Alert Policy."
+        },
+        "update": {
+          "method": "PUT",
+          "path": "/api/config/namespaces/{metadata.namespace}/alert_policys/{metadata.name}",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 800,
+            "p95_ms": 2500,
+            "p99_ms": 6000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.metadata.name",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "modifies": [
+              "alert-policy"
+            ]
+          },
+          "purpose": "Replace Alert Policy."
+        }
+      }
+    },
+    "alert_receiver": {
+      "resource": "alert_receiver",
+      "base_path": "/api/config/namespaces/{namespace}/alert_receivers/{name}",
+      "operations": {
+        "create": {
+          "method": "POST",
+          "path": "/api/alert/namespaces/{namespace}/alert_receivers/{name}/confirm",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 1000,
+            "p95_ms": 3000,
+            "p99_ms": 8000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "metadata.name",
+            "metadata.namespace",
+            "path.name",
+            "path.namespace"
+          ],
+          "side_effects": {
+            "creates": [
+              "confirm"
+            ]
+          },
+          "purpose": "Confirm Alert Receiver."
+        },
+        "delete": {
+          "method": "DELETE",
+          "path": "/api/config/namespaces/{namespace}/alert_receivers/{name}",
+          "danger_level": "high",
+          "discovered_response_time": {
+            "p50_ms": 500,
+            "p95_ms": 1500,
+            "p99_ms": 4000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "confirmation_required": true,
+          "side_effects": {
+            "deletes": [
+              "alert-receiver",
+              "contained_resources"
+            ]
+          },
+          "purpose": "DELETE Alert Receiver."
+        },
+        "list": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/alert_receivers",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.namespace"
+          ],
+          "purpose": "List Alert Receiver."
+        },
+        "read": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/alert_receivers/{name}",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "purpose": "GET Alert Receiver."
+        },
+        "update": {
+          "method": "PUT",
+          "path": "/api/config/namespaces/{metadata.namespace}/alert_receivers/{metadata.name}",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 800,
+            "p95_ms": 2500,
+            "p99_ms": 6000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.metadata.name",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "modifies": [
+              "alert-receiver"
+            ]
+          },
+          "purpose": "Replace Alert Receiver."
+        }
+      }
+    },
+    "api_crawler": {
+      "resource": "api_crawler",
+      "base_path": "/api/config/namespaces/{namespace}/api_crawlers",
+      "operations": {
+        "create": {
+          "method": "POST",
+          "path": "/api/config/namespaces/{metadata.namespace}/api_crawlers",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 1000,
+            "p95_ms": 3000,
+            "p99_ms": 8000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "metadata.name",
+            "metadata.namespace",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "creates": [
+              "api-crawler"
+            ]
+          },
+          "purpose": "Create API Crawler."
+        },
+        "delete": {
+          "method": "DELETE",
+          "path": "/api/config/namespaces/{namespace}/api_crawlers/{name}",
+          "danger_level": "high",
+          "discovered_response_time": {
+            "p50_ms": 500,
+            "p95_ms": 1500,
+            "p99_ms": 4000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "confirmation_required": true,
+          "side_effects": {
+            "deletes": [
+              "api-crawler",
+              "contained_resources"
+            ]
+          },
+          "purpose": "DELETE API Crawler."
+        },
+        "list": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/api_crawlers",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 159,
+            "p95_ms": 319,
+            "p99_ms": 479,
+            "sample_count": 1,
+            "source": "discovery"
+          },
+          "required_fields": [
+            "path.namespace"
+          ],
+          "purpose": "List API Crawler."
+        },
+        "read": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/api_crawlers/{name}",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "purpose": "GET API crawler."
+        },
+        "update": {
+          "method": "PUT",
+          "path": "/api/config/namespaces/{metadata.namespace}/api_crawlers/{metadata.name}",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 800,
+            "p95_ms": 2500,
+            "p99_ms": 6000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.metadata.name",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "modifies": [
+              "api-crawler"
+            ]
+          },
+          "purpose": "Replace API crawler."
+        }
+      }
+    },
+    "api_definition": {
+      "resource": "api_definition",
+      "base_path": "/api/config/namespaces/{namespace}/api_definitions",
+      "operations": {
+        "create": {
+          "method": "POST",
+          "path": "/api/config/namespaces/{namespace}/api_definitions/{name}/remove_from_inventory",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 1000,
+            "p95_ms": 3000,
+            "p99_ms": 8000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "metadata.name",
+            "metadata.namespace",
+            "path.name",
+            "path.namespace"
+          ],
+          "side_effects": {
+            "creates": [
+              "remove-from-inventory"
+            ]
+          },
+          "purpose": "Remove From API Inventory."
+        },
+        "delete": {
+          "method": "DELETE",
+          "path": "/api/config/namespaces/{namespace}/api_definitions/{name}",
+          "danger_level": "high",
+          "discovered_response_time": {
+            "p50_ms": 500,
+            "p95_ms": 1500,
+            "p99_ms": 4000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "confirmation_required": true,
+          "side_effects": {
+            "deletes": [
+              "api-definition",
+              "contained_resources"
+            ]
+          },
+          "purpose": "DELETE API Definition."
+        },
+        "list": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/api_definitions",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.namespace"
+          ],
+          "purpose": "List API Definition."
+        },
+        "read": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/api_definitions/{name}/loadbalancers",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "purpose": "GET Referencing Loadbalancers."
+        },
+        "update": {
+          "method": "PUT",
+          "path": "/api/config/namespaces/{metadata.namespace}/api_definitions/{metadata.name}",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 800,
+            "p95_ms": 2500,
+            "p99_ms": 6000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.metadata.name",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "modifies": [
+              "api-definition"
+            ]
+          },
+          "purpose": "Replace API Definition."
+        }
+      }
+    },
+    "api_discovery": {
+      "resource": "api_discovery",
+      "base_path": "/api/config/namespaces/{namespace}/api_discoverys",
+      "operations": {
+        "create": {
+          "method": "POST",
+          "path": "/api/config/namespaces/{metadata.namespace}/api_discoverys",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 1000,
+            "p95_ms": 3000,
+            "p99_ms": 8000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "metadata.name",
+            "metadata.namespace",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "creates": [
+              "api-discovery"
+            ]
+          },
+          "purpose": "Create API Discovery."
+        },
+        "delete": {
+          "method": "DELETE",
+          "path": "/api/config/namespaces/{namespace}/api_discoverys/{name}",
+          "danger_level": "high",
+          "discovered_response_time": {
+            "p50_ms": 500,
+            "p95_ms": 1500,
+            "p99_ms": 4000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "confirmation_required": true,
+          "side_effects": {
+            "deletes": [
+              "api-discovery",
+              "contained_resources"
+            ]
+          },
+          "purpose": "DELETE API Discovery."
+        },
+        "list": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/api_discoverys",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 160,
+            "p95_ms": 320,
+            "p99_ms": 481,
+            "sample_count": 1,
+            "source": "discovery"
+          },
+          "required_fields": [
+            "path.namespace"
+          ],
+          "purpose": "List API Discovery."
+        },
+        "read": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/api_discoverys/{name}",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "purpose": "GET API Discovery."
+        },
+        "update": {
+          "method": "PUT",
+          "path": "/api/config/namespaces/{metadata.namespace}/api_discoverys/{metadata.name}",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 800,
+            "p95_ms": 2500,
+            "p99_ms": 6000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.metadata.name",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "modifies": [
+              "api-discovery"
+            ]
+          },
+          "purpose": "Replace API Discovery."
+        }
+      }
+    },
+    "api_testing": {
+      "resource": "api_testing",
+      "base_path": "/api/config/namespaces/{namespace}/api_testings/{name}",
+      "operations": {
+        "create": {
+          "method": "POST",
+          "path": "/api/config/namespaces/{metadata.namespace}/api_testings",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 1000,
+            "p95_ms": 3000,
+            "p99_ms": 8000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "metadata.name",
+            "metadata.namespace",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "creates": [
+              "api-testing"
+            ]
+          },
+          "purpose": "Create API Testing."
+        },
+        "delete": {
+          "method": "DELETE",
+          "path": "/api/config/namespaces/{namespace}/api_testings/{name}",
+          "danger_level": "high",
+          "discovered_response_time": {
+            "p50_ms": 500,
+            "p95_ms": 1500,
+            "p99_ms": 4000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "confirmation_required": true,
+          "side_effects": {
+            "deletes": [
+              "api-testing",
+              "contained_resources"
+            ]
+          },
+          "purpose": "DELETE API Testing."
+        },
+        "list": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/api_testings",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 153,
+            "p95_ms": 307,
+            "p99_ms": 460,
+            "sample_count": 1,
+            "source": "discovery"
+          },
+          "required_fields": [
+            "path.namespace"
+          ],
+          "purpose": "List API Testing."
+        },
+        "read": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/api_testings/{name}",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "purpose": "GET API testing."
+        },
+        "update": {
+          "method": "PUT",
+          "path": "/api/config/namespaces/{metadata.namespace}/api_testings/{metadata.name}",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 800,
+            "p95_ms": 2500,
+            "p99_ms": 6000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.metadata.name",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "modifies": [
+              "api-testing"
+            ]
+          },
+          "purpose": "Replace API testing."
+        }
+      }
+    },
+    "apm": {
+      "resource": "apm",
+      "base_path": "/api/config/namespaces/{namespace}/apms",
+      "operations": {
+        "create": {
+          "method": "POST",
+          "path": "/api/data/namespaces/{namespace}/bigip/apm/metrics",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 1000,
+            "p95_ms": 3000,
+            "p99_ms": 8000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "metadata.name",
+            "metadata.namespace",
+            "path.namespace"
+          ],
+          "side_effects": {
+            "creates": [
+              "metric"
+            ]
+          },
+          "purpose": "Metrics"
+        },
+        "delete": {
+          "method": "DELETE",
+          "path": "/api/config/namespaces/{namespace}/apms/{name}",
+          "danger_level": "high",
+          "discovered_response_time": {
+            "p50_ms": 500,
+            "p95_ms": 1500,
+            "p99_ms": 4000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "confirmation_required": true,
+          "side_effects": {
+            "deletes": [
+              "apm",
+              "contained_resources"
+            ]
+          },
+          "purpose": "DELETE BIG-IP APM as a Service."
+        },
+        "list": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/apms",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.namespace"
+          ],
+          "purpose": "List BIG-IP APM as a Service."
+        },
+        "read": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/apms/{name}",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "purpose": "GET APM Service."
+        },
+        "update": {
+          "method": "PUT",
+          "path": "/api/config/namespaces/{metadata.namespace}/apms/{metadata.name}",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 800,
+            "p95_ms": 2500,
+            "p99_ms": 6000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.metadata.name",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "modifies": [
+              "apm"
+            ]
+          },
+          "purpose": "Replace APM Service."
+        }
+      }
+    },
+    "app_api_group": {
+      "resource": "app_api_group",
+      "base_path": "/api/config/namespaces/{metadata.namespace}/app_api_groups",
+      "operations": {
+        "create": {
+          "method": "POST",
+          "path": "/api/ml/data/namespaces/{namespace}/app_api_groups/stats",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 1000,
+            "p95_ms": 3000,
+            "p99_ms": 8000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "metadata.name",
+            "metadata.namespace",
+            "path.namespace"
+          ],
+          "side_effects": {
+            "creates": [
+              "stat"
+            ]
+          },
+          "purpose": "Evaluate API Group."
+        },
+        "delete": {
+          "method": "DELETE",
+          "path": "/api/config/namespaces/{namespace}/app_api_groups/{name}",
+          "danger_level": "high",
+          "discovered_response_time": {
+            "p50_ms": 500,
+            "p95_ms": 1500,
+            "p99_ms": 4000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "confirmation_required": true,
+          "side_effects": {
+            "deletes": [
+              "app-api-group",
+              "contained_resources"
+            ]
+          },
+          "purpose": "DELETE App API Group."
+        },
+        "list": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/app_api_groups",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 152,
+            "p95_ms": 304,
+            "p99_ms": 456,
+            "sample_count": 1,
+            "source": "discovery"
+          },
+          "required_fields": [
+            "path.namespace"
+          ],
+          "purpose": "List App API Group."
+        },
+        "read": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/app_api_groups/{name}",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "purpose": "GET API Group."
+        },
+        "update": {
+          "method": "PUT",
+          "path": "/api/config/namespaces/{metadata.namespace}/app_api_groups/{metadata.name}",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 800,
+            "p95_ms": 2500,
+            "p99_ms": 6000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.metadata.name",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "modifies": [
+              "app-api-group"
+            ]
+          },
+          "purpose": "Replace API Group."
+        }
+      }
+    },
+    "app_firewall": {
+      "resource": "app_firewall",
+      "base_path": "/api/config/namespaces/{metadata.namespace}/app_firewalls/{metadata.name}",
+      "operations": {
+        "create": {
+          "method": "POST",
+          "path": "/api/data/namespaces/{namespace}/app_firewall/metrics",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 1000,
+            "p95_ms": 3000,
+            "p99_ms": 8000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "metadata.name",
+            "metadata.namespace",
+            "path.namespace"
+          ],
+          "side_effects": {
+            "creates": [
+              "metric"
+            ]
+          },
+          "purpose": "Metrics"
+        },
+        "delete": {
+          "method": "DELETE",
+          "path": "/api/config/namespaces/{namespace}/app_firewalls/{name}",
+          "danger_level": "high",
+          "discovered_response_time": {
+            "p50_ms": 500,
+            "p95_ms": 1500,
+            "p99_ms": 4000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "confirmation_required": true,
+          "side_effects": {
+            "deletes": [
+              "app-firewall",
+              "contained_resources"
+            ]
+          },
+          "purpose": "DELETE Application Firewall."
+        },
+        "list": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/app_firewalls",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.namespace"
+          ],
+          "purpose": "List Application Firewall."
+        },
+        "read": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/app_firewalls/{name}",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "purpose": "GET Application Firewall."
+        },
+        "update": {
+          "method": "PUT",
+          "path": "/api/config/namespaces/{metadata.namespace}/app_firewalls/{metadata.name}",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 800,
+            "p95_ms": 2500,
+            "p99_ms": 6000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.metadata.name",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "modifies": [
+              "app-firewall"
+            ]
+          },
+          "purpose": "Replace Application Firewall."
+        }
+      }
+    },
+    "app_setting": {
+      "resource": "app_setting",
+      "base_path": "/api/config/namespaces/{metadata.namespace}/app_settings/{metadata.name}",
+      "operations": {
+        "create": {
+          "method": "POST",
+          "path": "/api/config/namespaces/{metadata.namespace}/app_settings",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 1000,
+            "p95_ms": 3000,
+            "p99_ms": 8000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "metadata.name",
+            "metadata.namespace",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "creates": [
+              "app-setting"
+            ]
+          },
+          "purpose": "Create App Setting."
+        },
+        "delete": {
+          "method": "DELETE",
+          "path": "/api/config/namespaces/{namespace}/app_settings/{name}",
+          "danger_level": "high",
+          "discovered_response_time": {
+            "p50_ms": 500,
+            "p95_ms": 1500,
+            "p99_ms": 4000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "confirmation_required": true,
+          "side_effects": {
+            "deletes": [
+              "app-setting",
+              "contained_resources"
+            ]
+          },
+          "purpose": "DELETE App Setting."
+        },
+        "list": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/app_settings",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 149,
+            "p95_ms": 299,
+            "p99_ms": 449,
+            "sample_count": 1,
+            "source": "discovery"
+          },
+          "required_fields": [
+            "path.namespace"
+          ],
+          "purpose": "List App Setting."
+        },
+        "read": {
+          "method": "GET",
+          "path": "/api/ml/data/namespaces/{namespace}/app_settings/{name}/suspicious_users",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "purpose": "GET Status of Suspicious users."
+        },
+        "update": {
+          "method": "PUT",
+          "path": "/api/config/namespaces/{metadata.namespace}/app_settings/{metadata.name}",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 800,
+            "p95_ms": 2500,
+            "p99_ms": 6000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.metadata.name",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "modifies": [
+              "app-setting"
+            ]
+          },
+          "purpose": "Replace App Setting."
+        }
+      }
+    },
+    "app_type": {
+      "resource": "app_type",
+      "base_path": "/api/config/namespaces/{namespace}/app_types/{name}",
+      "operations": {
+        "create": {
+          "method": "POST",
+          "path": "/api/ml/data/namespaces/{namespace}/app_types/{app_type_name}/api_endpoint/learnt_schema",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 1000,
+            "p95_ms": 3000,
+            "p99_ms": 8000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "metadata.name",
+            "metadata.namespace",
+            "path.app_type_name",
+            "path.namespace"
+          ],
+          "side_effects": {
+            "creates": [
+              "learnt-schema"
+            ]
+          },
+          "purpose": "GET Learnt Schema per API endpoint."
+        },
+        "delete": {
+          "method": "DELETE",
+          "path": "/api/config/namespaces/{namespace}/app_types/{name}",
+          "danger_level": "high",
+          "discovered_response_time": {
+            "p50_ms": 500,
+            "p95_ms": 1500,
+            "p99_ms": 4000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "confirmation_required": true,
+          "side_effects": {
+            "deletes": [
+              "app-type",
+              "contained_resources"
+            ]
+          },
+          "purpose": "DELETE App Type."
+        },
+        "list": {
+          "method": "GET",
+          "path": "/api/ml/data/namespaces/{namespace}/app_types/{app_type_name}/api_endpoints/swagger_spec",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 150,
+            "p95_ms": 301,
+            "p99_ms": 451,
+            "sample_count": 1,
+            "source": "discovery"
+          },
+          "required_fields": [
+            "path.app_type_name",
+            "path.namespace"
+          ],
+          "purpose": "GET Swagger Spec for App Type."
+        },
+        "read": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/app_types/{name}",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "purpose": "GET App Type."
+        },
+        "update": {
+          "method": "PUT",
+          "path": "/api/config/namespaces/{metadata.namespace}/app_types/{metadata.name}",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 800,
+            "p95_ms": 2500,
+            "p99_ms": 6000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.metadata.name",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "modifies": [
+              "app-type"
+            ]
+          },
+          "purpose": "Replace App Type."
+        }
+      }
+    },
+    "authentication": {
+      "resource": "authentication",
+      "base_path": "/api/config/namespaces/{metadata.namespace}/authentications",
+      "operations": {
+        "create": {
+          "method": "POST",
+          "path": "/api/config/namespaces/{metadata.namespace}/authentications",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 1000,
+            "p95_ms": 3000,
+            "p99_ms": 8000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "metadata.name",
+            "metadata.namespace",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "creates": [
+              "authentication"
+            ]
+          },
+          "purpose": "Create Authentication."
+        },
+        "delete": {
+          "method": "DELETE",
+          "path": "/api/config/namespaces/{namespace}/authentications/{name}",
+          "danger_level": "high",
+          "discovered_response_time": {
+            "p50_ms": 500,
+            "p95_ms": 1500,
+            "p99_ms": 4000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "confirmation_required": true,
+          "side_effects": {
+            "deletes": [
+              "authentication",
+              "contained_resources"
+            ]
+          },
+          "purpose": "DELETE Authentication."
+        },
+        "list": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/authentications",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 160,
+            "p95_ms": 321,
+            "p99_ms": 481,
+            "sample_count": 1,
+            "source": "discovery"
+          },
+          "required_fields": [
+            "path.namespace"
+          ],
+          "purpose": "List Authentication."
+        },
+        "read": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/authentications/{name}",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "purpose": "GET Authentication."
+        },
+        "update": {
+          "method": "PUT",
+          "path": "/api/config/namespaces/{metadata.namespace}/authentications/{metadata.name}",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 800,
+            "p95_ms": 2500,
+            "p99_ms": 6000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.metadata.name",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "modifies": [
+              "authentication"
+            ]
+          },
+          "purpose": "Replace Authentication."
+        }
+      }
+    },
+    "aws_tgw_site": {
+      "resource": "aws_tgw_site",
+      "base_path": "/api/config/namespaces/{namespace}/aws_tgw_sites",
+      "operations": {
+        "create": {
+          "method": "POST",
+          "path": "/api/config/namespaces/{namespace}/aws_tgw_site/{name}/set_vpc_ip_prefixes",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 1000,
+            "p95_ms": 3000,
+            "p99_ms": 8000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "metadata.name",
+            "metadata.namespace",
+            "path.name",
+            "path.namespace"
+          ],
+          "side_effects": {
+            "creates": [
+              "set-vpc-ip-prefixe"
+            ]
+          },
+          "purpose": "Configure VPC IP prefixes."
+        },
+        "delete": {
+          "method": "DELETE",
+          "path": "/api/config/namespaces/{namespace}/aws_tgw_sites/{name}",
+          "danger_level": "high",
+          "discovered_response_time": {
+            "p50_ms": 500,
+            "p95_ms": 1500,
+            "p99_ms": 4000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "confirmation_required": true,
+          "side_effects": {
+            "deletes": [
+              "aws-tgw-site",
+              "contained_resources"
+            ]
+          },
+          "purpose": "DELETE Configure AWS TGW Site."
+        },
+        "list": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/aws_tgw_sites",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 152,
+            "p95_ms": 304,
+            "p99_ms": 456,
+            "sample_count": 1,
+            "source": "discovery"
+          },
+          "required_fields": [
+            "path.namespace"
+          ],
+          "purpose": "List Configure AWS TGW Site."
+        },
+        "read": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/aws_tgw_sites/{name}",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "purpose": "GET AWS TGW site."
+        },
+        "update": {
+          "method": "PUT",
+          "path": "/api/config/namespaces/{metadata.namespace}/aws_tgw_sites/{metadata.name}",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 800,
+            "p95_ms": 2500,
+            "p99_ms": 6000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.metadata.name",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "modifies": [
+              "aws-tgw-site"
+            ]
+          },
+          "purpose": "Replace AWS TGW site."
+        }
+      }
+    },
+    "aws_vpc_site": {
+      "resource": "aws_vpc_site",
+      "base_path": "/api/config/namespaces/{metadata.namespace}/aws_vpc_sites/{metadata.name}",
+      "operations": {
+        "create": {
+          "method": "POST",
+          "path": "/api/config/namespaces/{namespace}/aws_vpc_site/{name}/set_vip_info",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 1000,
+            "p95_ms": 3000,
+            "p99_ms": 8000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "metadata.name",
+            "metadata.namespace",
+            "path.name",
+            "path.namespace"
+          ],
+          "side_effects": {
+            "creates": [
+              "set-vip-info"
+            ]
+          },
+          "purpose": "Configure AWS VPC Site VIP Information."
+        },
+        "delete": {
+          "method": "DELETE",
+          "path": "/api/config/namespaces/{namespace}/aws_vpc_sites/{name}",
+          "danger_level": "high",
+          "discovered_response_time": {
+            "p50_ms": 500,
+            "p95_ms": 1500,
+            "p99_ms": 4000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "confirmation_required": true,
+          "side_effects": {
+            "deletes": [
+              "aws-vpc-site",
+              "contained_resources"
+            ]
+          },
+          "purpose": "DELETE Configure AWS VPC Site."
+        },
+        "list": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/aws_vpc_sites",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 149,
+            "p95_ms": 298,
+            "p99_ms": 447,
+            "sample_count": 1,
+            "source": "discovery"
+          },
+          "required_fields": [
+            "path.namespace"
+          ],
+          "purpose": "List Configure AWS VPC Site."
+        },
+        "read": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/aws_vpc_sites/{name}",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "purpose": "GET AWS VPC site."
+        },
+        "update": {
+          "method": "PUT",
+          "path": "/api/config/namespaces/{metadata.namespace}/aws_vpc_sites/{metadata.name}",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 800,
+            "p95_ms": 2500,
+            "p99_ms": 6000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.metadata.name",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "modifies": [
+              "aws-vpc-site"
+            ]
+          },
+          "purpose": "Replace AWS VPC site."
+        }
+      }
+    },
+    "azure_vnet_site": {
+      "resource": "azure_vnet_site",
+      "base_path": "/api/config/namespaces/{namespace}/azure_vnet_sites/{name}",
+      "operations": {
+        "create": {
+          "method": "POST",
+          "path": "/api/config/namespaces/{namespace}/azure_vnet_site/{name}/set_vip_info",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 1000,
+            "p95_ms": 3000,
+            "p99_ms": 8000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "metadata.name",
+            "metadata.namespace",
+            "path.name",
+            "path.namespace"
+          ],
+          "side_effects": {
+            "creates": [
+              "set-vip-info"
+            ]
+          },
+          "purpose": "Configure Azure VNet Site VIP Information."
+        },
+        "delete": {
+          "method": "DELETE",
+          "path": "/api/config/namespaces/{namespace}/azure_vnet_sites/{name}",
+          "danger_level": "high",
+          "discovered_response_time": {
+            "p50_ms": 500,
+            "p95_ms": 1500,
+            "p99_ms": 4000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "confirmation_required": true,
+          "side_effects": {
+            "deletes": [
+              "azure-vnet-site",
+              "contained_resources"
+            ]
+          },
+          "purpose": "DELETE Configure Azure VNet Site."
+        },
+        "list": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/azure_vnet_sites",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 154,
+            "p95_ms": 308,
+            "p99_ms": 462,
+            "sample_count": 1,
+            "source": "discovery"
+          },
+          "required_fields": [
+            "path.namespace"
+          ],
+          "purpose": "List Configure Azure VNet Site."
+        },
+        "read": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/azure_vnet_sites/{name}",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "purpose": "GET Azure VNet site."
+        },
+        "update": {
+          "method": "PUT",
+          "path": "/api/config/namespaces/{metadata.namespace}/azure_vnet_sites/{metadata.name}",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 800,
+            "p95_ms": 2500,
+            "p99_ms": 6000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.metadata.name",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "modifies": [
+              "azure-vnet-site"
+            ]
+          },
+          "purpose": "Replace Azure VNet site."
+        }
+      }
+    },
+    "bgp": {
+      "resource": "bgp",
+      "base_path": "/api/config/namespaces/{namespace}/bgps",
+      "operations": {
+        "create": {
+          "method": "POST",
+          "path": "/api/config/namespaces/{metadata.namespace}/bgp_asn_sets",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 1000,
+            "p95_ms": 3000,
+            "p99_ms": 8000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "metadata.name",
+            "metadata.namespace",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "creates": [
+              "bgp-asn-set"
+            ]
+          },
+          "purpose": "Create BGP ASN Set."
+        },
+        "delete": {
+          "method": "DELETE",
+          "path": "/api/config/namespaces/{namespace}/bgp_asn_sets/{name}",
+          "danger_level": "high",
+          "discovered_response_time": {
+            "p50_ms": 500,
+            "p95_ms": 1500,
+            "p99_ms": 4000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "confirmation_required": true,
+          "side_effects": {
+            "deletes": [
+              "bgp-asn-set",
+              "contained_resources"
+            ]
+          },
+          "purpose": "DELETE BGP ASN Set."
+        },
+        "list": {
+          "method": "GET",
+          "path": "/api/operate/namespaces/{namespace}/sites/{site}/ver/bgp_routes",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.namespace",
+            "path.site"
+          ],
+          "purpose": "Show BGP Routes."
+        },
+        "read": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/bgpstatus/{view_name}",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.namespace",
+            "path.view_name"
+          ],
+          "purpose": "GET BGP Status for view."
+        },
+        "update": {
+          "method": "PUT",
+          "path": "/api/config/namespaces/{metadata.namespace}/bgp_routing_policys/{metadata.name}",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 800,
+            "p95_ms": 2500,
+            "p99_ms": 6000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.metadata.name",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "modifies": [
+              "bgp-routing-policy"
+            ]
+          },
+          "purpose": "Replace BGP Routing Policy."
+        }
+      }
+    },
+    "bgp_asn_set": {
+      "resource": "bgp_asn_set",
+      "base_path": "/api/config/namespaces/{metadata.namespace}/bgp_asn_sets",
+      "operations": {
+        "create": {
+          "method": "POST",
+          "path": "/api/config/namespaces/{metadata.namespace}/bgp_asn_sets",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 1000,
+            "p95_ms": 3000,
+            "p99_ms": 8000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "metadata.name",
+            "metadata.namespace",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "creates": [
+              "bgp-asn-set"
+            ]
+          },
+          "purpose": "Create BGP ASN Set."
+        },
+        "delete": {
+          "method": "DELETE",
+          "path": "/api/config/namespaces/{namespace}/bgp_asn_sets/{name}",
+          "danger_level": "high",
+          "discovered_response_time": {
+            "p50_ms": 500,
+            "p95_ms": 1500,
+            "p99_ms": 4000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "confirmation_required": true,
+          "side_effects": {
+            "deletes": [
+              "bgp-asn-set",
+              "contained_resources"
+            ]
+          },
+          "purpose": "DELETE BGP ASN Set."
+        },
+        "list": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/bgp_asn_sets",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.namespace"
+          ],
+          "purpose": "List BGP ASN Set."
+        },
+        "read": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/bgp_asn_sets/{name}",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "purpose": "GET BGP ASN Set."
+        },
+        "update": {
+          "method": "PUT",
+          "path": "/api/config/namespaces/{metadata.namespace}/bgp_asn_sets/{metadata.name}",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 800,
+            "p95_ms": 2500,
+            "p99_ms": 6000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.metadata.name",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "modifies": [
+              "bgp-asn-set"
+            ]
+          },
+          "purpose": "Replace BGP ASN Set."
+        }
+      }
+    },
+    "bgp_routing_policy": {
+      "resource": "bgp_routing_policy",
+      "base_path": "/api/config/namespaces/{namespace}/bgp_routing_policys",
+      "operations": {
+        "create": {
+          "method": "POST",
+          "path": "/api/config/namespaces/{metadata.namespace}/bgp_routing_policys",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 1000,
+            "p95_ms": 3000,
+            "p99_ms": 8000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "metadata.name",
+            "metadata.namespace",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "creates": [
+              "bgp-routing-policy"
+            ]
+          },
+          "purpose": "Create BGP Routing Policy."
+        },
+        "delete": {
+          "method": "DELETE",
+          "path": "/api/config/namespaces/{namespace}/bgp_routing_policys/{name}",
+          "danger_level": "high",
+          "discovered_response_time": {
+            "p50_ms": 500,
+            "p95_ms": 1500,
+            "p99_ms": 4000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "confirmation_required": true,
+          "side_effects": {
+            "deletes": [
+              "bgp-routing-policy",
+              "contained_resources"
+            ]
+          },
+          "purpose": "DELETE BGP Routing Policy."
+        },
+        "list": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/bgp_routing_policys",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.namespace"
+          ],
+          "purpose": "List BGP Routing Policy."
+        },
+        "read": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/bgp_routing_policys/{name}",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "purpose": "GET BGP Routing Policy."
+        },
+        "update": {
+          "method": "PUT",
+          "path": "/api/config/namespaces/{metadata.namespace}/bgp_routing_policys/{metadata.name}",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 800,
+            "p95_ms": 2500,
+            "p99_ms": 6000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.metadata.name",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "modifies": [
+              "bgp-routing-policy"
+            ]
+          },
+          "purpose": "Replace BGP Routing Policy."
+        }
+      }
+    },
+    "bot_defense_app_infrastructure": {
+      "resource": "bot_defense_app_infrastructure",
+      "base_path": "/api/config/namespaces/{metadata.namespace}/bot_defense_app_infrastructures",
+      "operations": {
+        "create": {
+          "method": "POST",
+          "path": "/api/config/namespaces/{metadata.namespace}/bot_defense_app_infrastructures",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 1000,
+            "p95_ms": 3000,
+            "p99_ms": 8000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "metadata.name",
+            "metadata.namespace",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "creates": [
+              "bot-defense-app-infrastructure"
+            ]
+          },
+          "purpose": "Create Bot Defense App Infrastructure."
+        },
+        "delete": {
+          "method": "DELETE",
+          "path": "/api/config/namespaces/{namespace}/bot_defense_app_infrastructures/{name}",
+          "danger_level": "high",
+          "discovered_response_time": {
+            "p50_ms": 500,
+            "p95_ms": 1500,
+            "p99_ms": 4000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "confirmation_required": true,
+          "side_effects": {
+            "deletes": [
+              "bot-defense-app-infrastructure",
+              "contained_resources"
+            ]
+          },
+          "purpose": "DELETE Bot Defense App Infrastructure."
+        },
+        "list": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/bot_defense_app_infrastructures",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.namespace"
+          ],
+          "purpose": "List Bot Defense App Infrastructure."
+        },
+        "read": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/bot_defense_app_infrastructures/{name}",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "purpose": "Bot Defense App Infrastructure."
+        },
+        "update": {
+          "method": "PUT",
+          "path": "/api/config/namespaces/{metadata.namespace}/bot_defense_app_infrastructures/{metadata.name}",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 800,
+            "p95_ms": 2500,
+            "p99_ms": 6000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.metadata.name",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "modifies": [
+              "bot-defense-app-infrastructure"
+            ]
+          },
+          "purpose": "Replace Bot Defense App Infrastructure."
+        }
+      }
+    },
+    "cdn_cache_rule": {
+      "resource": "cdn_cache_rule",
+      "base_path": "/api/config/namespaces/{metadata.namespace}/cdn_cache_rules",
+      "operations": {
+        "create": {
+          "method": "POST",
+          "path": "/api/config/namespaces/{metadata.namespace}/cdn_cache_rules",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 1000,
+            "p95_ms": 3000,
+            "p99_ms": 8000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "metadata.name",
+            "metadata.namespace",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "creates": [
+              "cdn-cache-rule"
+            ]
+          },
+          "purpose": "Create CDN cache rule."
+        },
+        "delete": {
+          "method": "DELETE",
+          "path": "/api/config/namespaces/{namespace}/cdn_cache_rules/{name}",
+          "danger_level": "high",
+          "discovered_response_time": {
+            "p50_ms": 500,
+            "p95_ms": 1500,
+            "p99_ms": 4000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "confirmation_required": true,
+          "side_effects": {
+            "deletes": [
+              "cdn-cache-rule",
+              "contained_resources"
+            ]
+          },
+          "purpose": "DELETE CDN cache rule."
+        },
+        "list": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/cdn_cache_rules",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 148,
+            "p95_ms": 297,
+            "p99_ms": 446,
+            "sample_count": 1,
+            "source": "discovery"
+          },
+          "required_fields": [
+            "path.namespace"
+          ],
+          "purpose": "List CDN cache rule."
+        },
+        "read": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/cdn_cache_rules/{name}",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "purpose": "GET CDN cache rule."
+        },
+        "update": {
+          "method": "PUT",
+          "path": "/api/config/namespaces/{metadata.namespace}/cdn_cache_rules/{metadata.name}",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 800,
+            "p95_ms": 2500,
+            "p99_ms": 6000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.metadata.name",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "modifies": [
+              "cdn-cache-rule"
+            ]
+          },
+          "purpose": "Replace CDN cache rule."
+        }
+      }
+    },
+    "cdn_loadbalancer": {
+      "resource": "cdn_loadbalancer",
+      "base_path": "/api/config/namespaces/{metadata.namespace}/cdn_loadbalancers",
+      "operations": {
+        "create": {
+          "method": "POST",
+          "path": "/api/config/namespaces/{namespace}/cdn_loadbalancers/{name}/block_client/suggestion",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 1000,
+            "p95_ms": 3000,
+            "p99_ms": 8000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "metadata.name",
+            "metadata.namespace",
+            "path.name",
+            "path.namespace"
+          ],
+          "side_effects": {
+            "creates": [
+              "suggestion"
+            ]
+          },
+          "purpose": "Suggest block client rule."
+        },
+        "delete": {
+          "method": "DELETE",
+          "path": "/api/config/namespaces/{namespace}/cdn_loadbalancers/{name}",
+          "danger_level": "high",
+          "discovered_response_time": {
+            "p50_ms": 500,
+            "p95_ms": 1500,
+            "p99_ms": 4000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "confirmation_required": true,
+          "side_effects": {
+            "deletes": [
+              "cdn-loadbalancer",
+              "contained_resources"
+            ]
+          },
+          "purpose": "DELETE CDN Loadbalancer."
+        },
+        "list": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/cdn_loadbalancers",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 155,
+            "p95_ms": 310,
+            "p99_ms": 466,
+            "sample_count": 1,
+            "source": "discovery"
+          },
+          "required_fields": [
+            "path.namespace"
+          ],
+          "purpose": "List CDN Loadbalancer."
+        },
+        "read": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/cdn_loadbalancers/{name}/dos_automitigation_rules",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 164,
+            "p95_ms": 328,
+            "p99_ms": 493,
+            "sample_count": 1,
+            "source": "discovery"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "purpose": "GET DoS Auto-Mitigation Rules for CDN Load Balancer."
+        },
+        "update": {
+          "method": "PUT",
+          "path": "/api/config/namespaces/{metadata.namespace}/cdn_loadbalancers/{metadata.name}",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 800,
+            "p95_ms": 2500,
+            "p99_ms": 6000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.metadata.name",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "modifies": [
+              "cdn-loadbalancer"
+            ]
+          },
+          "purpose": "Replace CDN Loadbalancer."
+        }
+      }
+    },
+    "certificate": {
+      "resource": "certificate",
+      "base_path": "/api/config/namespaces/{namespace}/certificates",
+      "operations": {
+        "create": {
+          "method": "POST",
+          "path": "/api/config/namespaces/{metadata.namespace}/certificates",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 1000,
+            "p95_ms": 3000,
+            "p99_ms": 8000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "metadata.name",
+            "metadata.namespace",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "creates": [
+              "certificate"
+            ]
+          },
+          "purpose": "Create Certificate."
+        },
+        "delete": {
+          "method": "DELETE",
+          "path": "/api/config/namespaces/{namespace}/certificates/{name}",
+          "danger_level": "high",
+          "discovered_response_time": {
+            "p50_ms": 500,
+            "p95_ms": 1500,
+            "p99_ms": 4000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "confirmation_required": true,
+          "side_effects": {
+            "deletes": [
+              "certificate",
+              "contained_resources"
+            ]
+          },
+          "purpose": "DELETE Certificate."
+        },
+        "list": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/certificates",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 159,
+            "p95_ms": 319,
+            "p99_ms": 478,
+            "sample_count": 1,
+            "source": "discovery"
+          },
+          "required_fields": [
+            "path.namespace"
+          ],
+          "purpose": "List Certificate."
+        },
+        "read": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/certificates/{name}",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "purpose": "GET Certificate."
+        },
+        "update": {
+          "method": "PUT",
+          "path": "/api/config/namespaces/{metadata.namespace}/certificate_chains/{metadata.name}",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 800,
+            "p95_ms": 2500,
+            "p99_ms": 6000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.metadata.name",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "modifies": [
+              "certificate-chain"
+            ]
+          },
+          "purpose": "Replace Certificate Chain."
+        }
+      }
+    },
+    "certificate_chain": {
+      "resource": "certificate_chain",
+      "base_path": "/api/config/namespaces/{namespace}/certificate_chains",
+      "operations": {
+        "create": {
+          "method": "POST",
+          "path": "/api/config/namespaces/{metadata.namespace}/certificate_chains",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 1000,
+            "p95_ms": 3000,
+            "p99_ms": 8000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "metadata.name",
+            "metadata.namespace",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "creates": [
+              "certificate-chain"
+            ]
+          },
+          "purpose": "Create Certificate Chain."
+        },
+        "delete": {
+          "method": "DELETE",
+          "path": "/api/config/namespaces/{namespace}/certificate_chains/{name}",
+          "danger_level": "high",
+          "discovered_response_time": {
+            "p50_ms": 500,
+            "p95_ms": 1500,
+            "p99_ms": 4000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "confirmation_required": true,
+          "side_effects": {
+            "deletes": [
+              "certificate-chain",
+              "contained_resources"
+            ]
+          },
+          "purpose": "DELETE Certificate Chain."
+        },
+        "list": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/certificate_chains",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 152,
+            "p95_ms": 305,
+            "p99_ms": 458,
+            "sample_count": 1,
+            "source": "discovery"
+          },
+          "required_fields": [
+            "path.namespace"
+          ],
+          "purpose": "List Certificate Chain."
+        },
+        "read": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/certificate_chains/{name}",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "purpose": "GET Certificate Chain."
+        },
+        "update": {
+          "method": "PUT",
+          "path": "/api/config/namespaces/{metadata.namespace}/certificate_chains/{metadata.name}",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 800,
+            "p95_ms": 2500,
+            "p99_ms": 6000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.metadata.name",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "modifies": [
+              "certificate-chain"
+            ]
+          },
+          "purpose": "Replace Certificate Chain."
+        }
+      }
+    },
+    "cloud_connect": {
+      "resource": "cloud_connect",
+      "base_path": "/api/config/namespaces/{namespace}/cloud_connects/{name}",
+      "operations": {
+        "create": {
+          "method": "POST",
+          "path": "/api/data/namespaces/system/top/cloud_connects",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 1000,
+            "p95_ms": 3000,
+            "p99_ms": 8000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "metadata.name",
+            "metadata.namespace"
+          ],
+          "side_effects": {
+            "creates": [
+              "cloud-connect"
+            ]
+          },
+          "purpose": "Top Cloud Connnect."
+        },
+        "delete": {
+          "method": "DELETE",
+          "path": "/api/config/namespaces/{namespace}/cloud_connects/{name}",
+          "danger_level": "high",
+          "discovered_response_time": {
+            "p50_ms": 500,
+            "p95_ms": 1500,
+            "p99_ms": 4000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "confirmation_required": true,
+          "side_effects": {
+            "deletes": [
+              "cloud-connect",
+              "contained_resources"
+            ]
+          },
+          "purpose": "DELETE Cloud Connect."
+        },
+        "list": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/cloud_connects",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.namespace"
+          ],
+          "purpose": "List Cloud Connect."
+        },
+        "read": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/cloud_connects/{name}",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "purpose": "GET Cloud Connect."
+        },
+        "update": {
+          "method": "PUT",
+          "path": "/api/config/namespaces/{metadata.namespace}/cloud_connects/{metadata.name}",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 800,
+            "p95_ms": 2500,
+            "p99_ms": 6000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.metadata.name",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "modifies": [
+              "cloud-connect"
+            ]
+          },
+          "purpose": "Replace Cloud Connect."
+        }
+      }
+    },
+    "cloud_credentials": {
+      "resource": "cloud_credentials",
+      "base_path": "/api/config/namespaces/{metadata.namespace}/cloud_credentialss",
+      "operations": {
+        "create": {
+          "method": "POST",
+          "path": "/api/config/namespaces/{metadata.namespace}/cloud_credentialss",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 1000,
+            "p95_ms": 3000,
+            "p99_ms": 8000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "metadata.name",
+            "metadata.namespace",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "creates": [
+              "cloud-credentials"
+            ]
+          },
+          "purpose": "Create Cloud Credentials."
+        },
+        "delete": {
+          "method": "DELETE",
+          "path": "/api/config/namespaces/{namespace}/cloud_credentialss/{name}",
+          "danger_level": "high",
+          "discovered_response_time": {
+            "p50_ms": 500,
+            "p95_ms": 1500,
+            "p99_ms": 4000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "confirmation_required": true,
+          "side_effects": {
+            "deletes": [
+              "cloud-credentials",
+              "contained_resources"
+            ]
+          },
+          "purpose": "DELETE Cloud Credentials."
+        },
+        "list": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/cloud_credentialss",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 176,
+            "p95_ms": 352,
+            "p99_ms": 529,
+            "sample_count": 1,
+            "source": "discovery"
+          },
+          "required_fields": [
+            "path.namespace"
+          ],
+          "purpose": "List Cloud Credentials."
+        },
+        "read": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/cloud_credentialss/{name}",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "purpose": "GET Cloud Credentials."
+        },
+        "update": {
+          "method": "PUT",
+          "path": "/api/config/namespaces/{metadata.namespace}/cloud_credentialss/{metadata.name}",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 800,
+            "p95_ms": 2500,
+            "p99_ms": 6000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.metadata.name",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "modifies": [
+              "cloud-credentials"
+            ]
+          },
+          "purpose": "Replace Cloud Credentials."
+        }
+      }
+    },
+    "cloud_elastic_ip": {
+      "resource": "cloud_elastic_ip",
+      "base_path": "/api/config/namespaces/{metadata.namespace}/cloud_elastic_ips",
+      "operations": {
+        "create": {
+          "method": "POST",
+          "path": "/api/config/namespaces/system/cloud_elastic_ip/{name}/force-delete",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 1000,
+            "p95_ms": 3000,
+            "p99_ms": 8000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "metadata.name",
+            "metadata.namespace",
+            "path.name"
+          ],
+          "side_effects": {
+            "creates": [
+              "force-delete"
+            ]
+          },
+          "purpose": "Force DELETE Cloud Elastic IP."
+        },
+        "delete": {
+          "method": "DELETE",
+          "path": "/api/config/namespaces/{namespace}/cloud_elastic_ips/{name}",
+          "danger_level": "high",
+          "discovered_response_time": {
+            "p50_ms": 500,
+            "p95_ms": 1500,
+            "p99_ms": 4000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "confirmation_required": true,
+          "side_effects": {
+            "deletes": [
+              "cloud-elastic-ip",
+              "contained_resources"
+            ]
+          },
+          "purpose": "DELETE Cloud Elastic IP."
+        },
+        "list": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/cloud_elastic_ips",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.namespace"
+          ],
+          "purpose": "List Cloud Elastic IP."
+        },
+        "read": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/cloud_elastic_ips/{name}",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "purpose": "GET Cloud Elastic IP."
+        },
+        "update": {
+          "method": "PUT",
+          "path": "/api/config/namespaces/{metadata.namespace}/cloud_elastic_ips/{metadata.name}",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 800,
+            "p95_ms": 2500,
+            "p99_ms": 6000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.metadata.name",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "modifies": [
+              "cloud-elastic-ip"
+            ]
+          },
+          "purpose": "Replace Cloud Elastic IP."
+        }
+      }
+    },
+    "cloud_link": {
+      "resource": "cloud_link",
+      "base_path": "/api/config/namespaces/{metadata.namespace}/cloud_links",
+      "operations": {
+        "create": {
+          "method": "POST",
+          "path": "/api/config/namespaces/{metadata.namespace}/cloud_links",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 1000,
+            "p95_ms": 3000,
+            "p99_ms": 8000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "metadata.name",
+            "metadata.namespace",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "creates": [
+              "cloud-link"
+            ]
+          },
+          "purpose": "Create CloudLink."
+        },
+        "delete": {
+          "method": "DELETE",
+          "path": "/api/config/namespaces/{namespace}/cloud_links/{name}",
+          "danger_level": "high",
+          "discovered_response_time": {
+            "p50_ms": 500,
+            "p95_ms": 1500,
+            "p99_ms": 4000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "confirmation_required": true,
+          "side_effects": {
+            "deletes": [
+              "cloud-link",
+              "contained_resources"
+            ]
+          },
+          "purpose": "DELETE CloudLink."
+        },
+        "list": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/cloud_links",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.namespace"
+          ],
+          "purpose": "List CloudLink."
+        },
+        "read": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/cloud_links/{name}",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "purpose": "GET CloudLink."
+        },
+        "update": {
+          "method": "PUT",
+          "path": "/api/config/namespaces/{metadata.namespace}/cloud_links/{metadata.name}",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 800,
+            "p95_ms": 2500,
+            "p99_ms": 6000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.metadata.name",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "modifies": [
+              "cloud-link"
+            ]
+          },
+          "purpose": "Replace CloudLink."
+        }
+      }
+    },
+    "cluster": {
+      "resource": "cluster",
+      "base_path": "/api/config/namespaces/{namespace}/clusters",
+      "operations": {
+        "create": {
+          "method": "POST",
+          "path": "/api/config/namespaces/{metadata.namespace}/clusters",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 1000,
+            "p95_ms": 3000,
+            "p99_ms": 8000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "metadata.name",
+            "metadata.namespace",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "creates": [
+              "cluster"
+            ]
+          },
+          "purpose": "Create Cluster."
+        },
+        "delete": {
+          "method": "DELETE",
+          "path": "/api/config/namespaces/{namespace}/clusters/{name}",
+          "danger_level": "high",
+          "discovered_response_time": {
+            "p50_ms": 500,
+            "p95_ms": 1500,
+            "p99_ms": 4000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "confirmation_required": true,
+          "side_effects": {
+            "deletes": [
+              "cluster",
+              "contained_resources"
+            ]
+          },
+          "purpose": "DELETE Cluster."
+        },
+        "list": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/clusters",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.namespace"
+          ],
+          "purpose": "List Cluster."
+        },
+        "read": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/clusters/{name}",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "purpose": "GET Cluster."
+        },
+        "update": {
+          "method": "PUT",
+          "path": "/api/config/namespaces/{metadata.namespace}/clusters/{metadata.name}",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 800,
+            "p95_ms": 2500,
+            "p99_ms": 6000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.metadata.name",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "modifies": [
+              "cluster"
+            ]
+          },
+          "purpose": "Replace Cluster."
+        }
+      }
+    },
+    "cminstance": {
+      "resource": "cminstance",
+      "base_path": "/api/config/namespaces/{metadata.namespace}/cminstances/{metadata.name}",
+      "operations": {
+        "create": {
+          "method": "POST",
+          "path": "/api/config/namespaces/{metadata.namespace}/cminstances",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 1000,
+            "p95_ms": 3000,
+            "p99_ms": 8000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "metadata.name",
+            "metadata.namespace",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "creates": [
+              "cminstance"
+            ]
+          },
+          "purpose": "Create Central Manager Insatnce."
+        },
+        "delete": {
+          "method": "DELETE",
+          "path": "/api/config/namespaces/{namespace}/cminstances/{name}",
+          "danger_level": "high",
+          "discovered_response_time": {
+            "p50_ms": 500,
+            "p95_ms": 1500,
+            "p99_ms": 4000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "confirmation_required": true,
+          "side_effects": {
+            "deletes": [
+              "cminstance",
+              "contained_resources"
+            ]
+          },
+          "purpose": "DELETE Central Manager Instance."
+        },
+        "list": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/cminstances",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.namespace"
+          ],
+          "purpose": "List Central Manager Instance."
+        },
+        "read": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/cminstances/{name}",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "purpose": "GET Central Manager Instance."
+        },
+        "update": {
+          "method": "PUT",
+          "path": "/api/config/namespaces/{metadata.namespace}/cminstances/{metadata.name}",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 800,
+            "p95_ms": 2500,
+            "p99_ms": 6000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.metadata.name",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "modifies": [
+              "cminstance"
+            ]
+          },
+          "purpose": "Replace Central Manager Instance."
+        }
+      }
+    },
+    "code_base_integration": {
+      "resource": "code_base_integration",
+      "base_path": "/api/config/namespaces/{metadata.namespace}/code_base_integrations/{metadata.name}",
+      "operations": {
+        "create": {
+          "method": "POST",
+          "path": "/api/config/namespaces/{metadata.namespace}/code_base_integrations",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 1000,
+            "p95_ms": 3000,
+            "p99_ms": 8000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "metadata.name",
+            "metadata.namespace",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "creates": [
+              "code-base-integration"
+            ]
+          },
+          "purpose": "CREATE Code Base Integration."
+        },
+        "delete": {
+          "method": "DELETE",
+          "path": "/api/config/namespaces/{namespace}/code_base_integrations/{name}",
+          "danger_level": "high",
+          "discovered_response_time": {
+            "p50_ms": 500,
+            "p95_ms": 1500,
+            "p99_ms": 4000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "confirmation_required": true,
+          "side_effects": {
+            "deletes": [
+              "code-base-integration",
+              "contained_resources"
+            ]
+          },
+          "purpose": "DELETE Code Base Integration."
+        },
+        "list": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/code_base_integrations",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 154,
+            "p95_ms": 308,
+            "p99_ms": 462,
+            "sample_count": 1,
+            "source": "discovery"
+          },
+          "required_fields": [
+            "path.namespace"
+          ],
+          "purpose": "List Code Base Integration."
+        },
+        "read": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/code_base_integrations/{name}",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "purpose": "GET Code Base Integration."
+        },
+        "update": {
+          "method": "PUT",
+          "path": "/api/config/namespaces/{metadata.namespace}/code_base_integrations/{metadata.name}",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 800,
+            "p95_ms": 2500,
+            "p99_ms": 6000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.metadata.name",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "modifies": [
+              "code-base-integration"
+            ]
+          },
+          "purpose": "Replace Code Base Integration."
+        }
+      }
+    },
+    "container_registry": {
+      "resource": "container_registry",
+      "base_path": "/api/config/namespaces/{namespace}/container_registrys",
+      "operations": {
+        "create": {
+          "method": "POST",
+          "path": "/api/config/namespaces/{metadata.namespace}/container_registrys",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 1000,
+            "p95_ms": 3000,
+            "p99_ms": 8000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "metadata.name",
+            "metadata.namespace",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "creates": [
+              "container-registry"
+            ]
+          },
+          "purpose": "Create Container Registry."
+        },
+        "delete": {
+          "method": "DELETE",
+          "path": "/api/config/namespaces/{namespace}/container_registrys/{name}",
+          "danger_level": "high",
+          "discovered_response_time": {
+            "p50_ms": 500,
+            "p95_ms": 1500,
+            "p99_ms": 4000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "confirmation_required": true,
+          "side_effects": {
+            "deletes": [
+              "container-registry",
+              "contained_resources"
+            ]
+          },
+          "purpose": "DELETE Container Registry."
+        },
+        "list": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/container_registrys",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.namespace"
+          ],
+          "purpose": "List Container Registry."
+        },
+        "read": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/container_registrys/{name}",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "purpose": "GET Container Registry."
+        },
+        "update": {
+          "method": "PUT",
+          "path": "/api/config/namespaces/{metadata.namespace}/container_registrys/{metadata.name}",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 800,
+            "p95_ms": 2500,
+            "p99_ms": 6000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.metadata.name",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "modifies": [
+              "container-registry"
+            ]
+          },
+          "purpose": "Replace Container Registry."
+        }
+      }
+    },
+    "crl": {
+      "resource": "crl",
+      "base_path": "/api/config/namespaces/{namespace}/crls",
+      "operations": {
+        "create": {
+          "method": "POST",
+          "path": "/api/config/namespaces/{metadata.namespace}/crls",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 1000,
+            "p95_ms": 3000,
+            "p99_ms": 8000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "metadata.name",
+            "metadata.namespace",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "creates": [
+              "crl"
+            ]
+          },
+          "purpose": "Create CRL."
+        },
+        "delete": {
+          "method": "DELETE",
+          "path": "/api/config/namespaces/{namespace}/crls/{name}",
+          "danger_level": "high",
+          "discovered_response_time": {
+            "p50_ms": 500,
+            "p95_ms": 1500,
+            "p99_ms": 4000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "confirmation_required": true,
+          "side_effects": {
+            "deletes": [
+              "crl",
+              "contained_resources"
+            ]
+          },
+          "purpose": "DELETE CRL."
+        },
+        "list": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/crls",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.namespace"
+          ],
+          "purpose": "List CRL"
+        },
+        "read": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/crls/{name}",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "purpose": "GET CRL"
+        },
+        "update": {
+          "method": "PUT",
+          "path": "/api/config/namespaces/{metadata.namespace}/crls/{metadata.name}",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 800,
+            "p95_ms": 2500,
+            "p99_ms": 6000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.metadata.name",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "modifies": [
+              "crl"
+            ]
+          },
+          "purpose": "Replace CRL."
+        }
+      }
+    },
+    "data_group": {
+      "resource": "data_group",
+      "base_path": "/api/config/namespaces/{namespace}/data_groups",
+      "operations": {
+        "create": {
+          "method": "POST",
+          "path": "/api/config/namespaces/{metadata.namespace}/data_groups",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 1000,
+            "p95_ms": 3000,
+            "p99_ms": 8000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "metadata.name",
+            "metadata.namespace",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "creates": [
+              "data-group"
+            ]
+          },
+          "purpose": "Create Data group."
+        },
+        "delete": {
+          "method": "DELETE",
+          "path": "/api/config/namespaces/{namespace}/data_groups/{name}",
+          "danger_level": "high",
+          "discovered_response_time": {
+            "p50_ms": 500,
+            "p95_ms": 1500,
+            "p99_ms": 4000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "confirmation_required": true,
+          "side_effects": {
+            "deletes": [
+              "data-group",
+              "contained_resources"
+            ]
+          },
+          "purpose": "DELETE Data Group."
+        },
+        "list": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/data_groups",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 154,
+            "p95_ms": 308,
+            "p99_ms": 462,
+            "sample_count": 1,
+            "source": "discovery"
+          },
+          "required_fields": [
+            "path.namespace"
+          ],
+          "purpose": "List Data Group."
+        },
+        "read": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/data_groups/{name}",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "purpose": "GET Data Group."
+        },
+        "update": {
+          "method": "PUT",
+          "path": "/api/config/namespaces/{metadata.namespace}/data_groups/{metadata.name}",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 800,
+            "p95_ms": 2500,
+            "p99_ms": 6000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.metadata.name",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "modifies": [
+              "data-group"
+            ]
+          },
+          "purpose": "Replace Data Group."
+        }
+      }
+    },
+    "data_type": {
+      "resource": "data_type",
+      "base_path": "/api/config/namespaces/{metadata.namespace}/data_types/{metadata.name}",
+      "operations": {
+        "create": {
+          "method": "POST",
+          "path": "/api/config/namespaces/{metadata.namespace}/data_types",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 1000,
+            "p95_ms": 3000,
+            "p99_ms": 8000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "metadata.name",
+            "metadata.namespace",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "creates": [
+              "data-type"
+            ]
+          },
+          "purpose": "Create Data Type."
+        },
+        "delete": {
+          "method": "DELETE",
+          "path": "/api/config/namespaces/{namespace}/data_types/{name}",
+          "danger_level": "high",
+          "discovered_response_time": {
+            "p50_ms": 500,
+            "p95_ms": 1500,
+            "p99_ms": 4000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "confirmation_required": true,
+          "side_effects": {
+            "deletes": [
+              "data-type",
+              "contained_resources"
+            ]
+          },
+          "purpose": "DELETE Data Type."
+        },
+        "list": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/data_types",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.namespace"
+          ],
+          "purpose": "List Data Type."
+        },
+        "read": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/data_types/{name}",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "purpose": "GET Data Type."
+        },
+        "update": {
+          "method": "PUT",
+          "path": "/api/config/namespaces/{metadata.namespace}/data_types/{metadata.name}",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 800,
+            "p95_ms": 2500,
+            "p99_ms": 6000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.metadata.name",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "modifies": [
+              "data-type"
+            ]
+          },
+          "purpose": "Replace Data Type."
+        }
+      }
+    },
+    "dc_cluster_group": {
+      "resource": "dc_cluster_group",
+      "base_path": "/api/config/namespaces/{namespace}/dc_cluster_groups/{name}",
+      "operations": {
+        "create": {
+          "method": "POST",
+          "path": "/api/data/namespaces/{namespace}/dc_cluster_groups/metrics",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 1000,
+            "p95_ms": 3000,
+            "p99_ms": 8000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "metadata.name",
+            "metadata.namespace",
+            "path.namespace"
+          ],
+          "side_effects": {
+            "creates": [
+              "metric"
+            ]
+          },
+          "purpose": "Metrics"
+        },
+        "delete": {
+          "method": "DELETE",
+          "path": "/api/config/namespaces/{namespace}/dc_cluster_groups/{name}",
+          "danger_level": "high",
+          "discovered_response_time": {
+            "p50_ms": 500,
+            "p95_ms": 1500,
+            "p99_ms": 4000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "confirmation_required": true,
+          "side_effects": {
+            "deletes": [
+              "dc-cluster-group",
+              "contained_resources"
+            ]
+          },
+          "purpose": "DELETE DC Cluster Group."
+        },
+        "list": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/dc_cluster_groups",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.namespace"
+          ],
+          "purpose": "List DC Cluster Group."
+        },
+        "read": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/dc_cluster_groups/{name}",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "purpose": "GET DC Cluster Group."
+        },
+        "update": {
+          "method": "PUT",
+          "path": "/api/config/namespaces/{metadata.namespace}/dc_cluster_groups/{metadata.name}",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 800,
+            "p95_ms": 2500,
+            "p99_ms": 6000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.metadata.name",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "modifies": [
+              "dc-cluster-group"
+            ]
+          },
+          "purpose": "Replace DC Cluster Group."
+        }
+      }
+    },
+    "discovery": {
+      "resource": "discovery",
+      "base_path": "/api/config/namespaces/{namespace}/discoverys",
+      "operations": {
+        "create": {
+          "method": "POST",
+          "path": "/api/config/namespaces/{namespace}/discovery/{name}/download_certificates",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 1000,
+            "p95_ms": 3000,
+            "p99_ms": 8000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "metadata.name",
+            "metadata.namespace",
+            "path.name",
+            "path.namespace"
+          ],
+          "side_effects": {
+            "creates": [
+              "download-certificate"
+            ]
+          },
+          "purpose": "Download Certificates."
+        },
+        "delete": {
+          "method": "DELETE",
+          "path": "/api/config/namespaces/{namespace}/api_discoverys/{name}",
+          "danger_level": "high",
+          "discovered_response_time": {
+            "p50_ms": 500,
+            "p95_ms": 1500,
+            "p99_ms": 4000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "confirmation_required": true,
+          "side_effects": {
+            "deletes": [
+              "api-discovery",
+              "contained_resources"
+            ]
+          },
+          "purpose": "DELETE API Discovery."
+        },
+        "list": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/api_discoverys",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 160,
+            "p95_ms": 320,
+            "p99_ms": 481,
+            "sample_count": 1,
+            "source": "discovery"
+          },
+          "required_fields": [
+            "path.namespace"
+          ],
+          "purpose": "List API Discovery."
+        },
+        "read": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/api_discoverys/{name}",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "purpose": "GET API Discovery."
+        },
+        "update": {
+          "method": "PUT",
+          "path": "/api/config/namespaces/{metadata.namespace}/discoverys/{metadata.name}",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 800,
+            "p95_ms": 2500,
+            "p99_ms": 6000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.metadata.name",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "modifies": [
+              "discovery"
+            ]
+          },
+          "purpose": "Replace Discovery."
+        }
+      }
+    },
+    "dns_compliance_checks": {
+      "resource": "dns_compliance_checks",
+      "base_path": "/api/config/namespaces/{metadata.namespace}/dns_compliance_checkss",
+      "operations": {
+        "create": {
+          "method": "POST",
+          "path": "/api/config/namespaces/{metadata.namespace}/dns_compliance_checkss",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 1000,
+            "p95_ms": 3000,
+            "p99_ms": 8000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "metadata.name",
+            "metadata.namespace",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "creates": [
+              "dns-compliance-checks"
+            ]
+          },
+          "purpose": "Create DNS Compliance Checks."
+        },
+        "delete": {
+          "method": "DELETE",
+          "path": "/api/config/namespaces/{namespace}/dns_compliance_checkss/{name}",
+          "danger_level": "high",
+          "discovered_response_time": {
+            "p50_ms": 500,
+            "p95_ms": 1500,
+            "p99_ms": 4000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "confirmation_required": true,
+          "side_effects": {
+            "deletes": [
+              "dns-compliance-checks",
+              "contained_resources"
+            ]
+          },
+          "purpose": "DELETE Configure DNS Compliance Checks."
+        },
+        "list": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/dns_compliance_checkss",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.namespace"
+          ],
+          "purpose": "List Configure DNS Compliance Checks."
+        },
+        "read": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/dns_compliance_checkss/{name}",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "purpose": "GET DNS Compliance Checks."
+        },
+        "update": {
+          "method": "PUT",
+          "path": "/api/config/namespaces/{metadata.namespace}/dns_compliance_checkss/{metadata.name}",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 800,
+            "p95_ms": 2500,
+            "p99_ms": 6000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.metadata.name",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "modifies": [
+              "dns-compliance-checks"
+            ]
+          },
+          "purpose": "Replace DNS Compliance Checks."
+        }
+      }
+    },
+    "dns_domain": {
+      "resource": "dns_domain",
+      "base_path": "/api/config/namespaces/{metadata.namespace}/dns_domains",
+      "operations": {
+        "create": {
+          "method": "POST",
+          "path": "/api/config/dns/namespaces/system/dns_zone/clone_from_dns_domain",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 1000,
+            "p95_ms": 3000,
+            "p99_ms": 8000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "metadata.name",
+            "metadata.namespace"
+          ],
+          "side_effects": {
+            "creates": [
+              "clone-from-dns-domain"
+            ]
+          },
+          "purpose": "Clone from DNSDomain."
+        },
+        "delete": {
+          "method": "DELETE",
+          "path": "/api/config/namespaces/{namespace}/dns_domains/{name}",
+          "danger_level": "high",
+          "discovered_response_time": {
+            "p50_ms": 500,
+            "p95_ms": 1500,
+            "p99_ms": 4000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "confirmation_required": true,
+          "side_effects": {
+            "deletes": [
+              "dns-domain",
+              "contained_resources"
+            ]
+          },
+          "purpose": "DELETE DNS Domain."
+        },
+        "list": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/dns_domains",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.namespace"
+          ],
+          "purpose": "List DNS Domain."
+        },
+        "read": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/dns_domains/{name}",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "purpose": "GET DNS Domain."
+        },
+        "update": {
+          "method": "PUT",
+          "path": "/api/config/namespaces/{metadata.namespace}/dns_domains/{metadata.name}",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 800,
+            "p95_ms": 2500,
+            "p99_ms": 6000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.metadata.name",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "modifies": [
+              "dns-domain"
+            ]
+          },
+          "purpose": "Replace DNS Domain."
+        }
+      }
+    },
+    "endpoint": {
+      "resource": "endpoint",
+      "base_path": "/api/config/namespaces/{namespace}/endpoints",
+      "operations": {
+        "create": {
+          "method": "POST",
+          "path": "/api/ml/data/namespaces/{namespace}/app_types/{app_type_name}/api_endpoint/learnt_schema",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 1000,
+            "p95_ms": 3000,
+            "p99_ms": 8000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "metadata.name",
+            "metadata.namespace",
+            "path.app_type_name",
+            "path.namespace"
+          ],
+          "side_effects": {
+            "creates": [
+              "learnt-schema"
+            ]
+          },
+          "purpose": "GET Learnt Schema per API endpoint."
+        },
+        "delete": {
+          "method": "DELETE",
+          "path": "/api/config/namespaces/{namespace}/endpoints/{name}",
+          "danger_level": "high",
+          "discovered_response_time": {
+            "p50_ms": 500,
+            "p95_ms": 1500,
+            "p99_ms": 4000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "confirmation_required": true,
+          "side_effects": {
+            "deletes": [
+              "endpoint",
+              "contained_resources"
+            ]
+          },
+          "purpose": "DELETE Endpoint."
+        },
+        "list": {
+          "method": "GET",
+          "path": "/api/ml/data/namespaces/{namespace}/app_types/{app_type_name}/api_endpoints",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.app_type_name",
+            "path.namespace"
+          ],
+          "purpose": "GET API endpoints."
+        },
+        "read": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/endpoints/{name}",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "purpose": "GET Endpoint."
+        },
+        "update": {
+          "method": "PUT",
+          "path": "/api/config/namespaces/{metadata.namespace}/endpoints/{metadata.name}",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 800,
+            "p95_ms": 2500,
+            "p99_ms": 6000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.metadata.name",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "modifies": [
+              "endpoint"
+            ]
+          },
+          "purpose": "Replace Endpoint."
+        }
+      }
+    },
+    "enhanced_firewall_policy": {
+      "resource": "enhanced_firewall_policy",
+      "base_path": "/api/config/namespaces/{namespace}/enhanced_firewall_policys",
+      "operations": {
+        "create": {
+          "method": "POST",
+          "path": "/api/data/namespaces/{namespace}/enhanced_firewall_policy/hits",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 1000,
+            "p95_ms": 3000,
+            "p99_ms": 8000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "metadata.name",
+            "metadata.namespace",
+            "path.namespace"
+          ],
+          "side_effects": {
+            "creates": [
+              "hit"
+            ]
+          },
+          "purpose": "Enhanced Firewall Policy Hits."
+        },
+        "delete": {
+          "method": "DELETE",
+          "path": "/api/config/namespaces/{namespace}/enhanced_firewall_policys/{name}",
+          "danger_level": "high",
+          "discovered_response_time": {
+            "p50_ms": 500,
+            "p95_ms": 1500,
+            "p99_ms": 4000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "confirmation_required": true,
+          "side_effects": {
+            "deletes": [
+              "enhanced-firewall-policy",
+              "contained_resources"
+            ]
+          },
+          "purpose": "DELETE Enhanced Firewall Policy."
+        },
+        "list": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/enhanced_firewall_policys",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.namespace"
+          ],
+          "purpose": "List Enhanced Firewall Policy."
+        },
+        "read": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/enhanced_firewall_policys/{name}",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "purpose": "GET Enhanced Firewall Policy."
+        },
+        "update": {
+          "method": "PUT",
+          "path": "/api/config/namespaces/{metadata.namespace}/enhanced_firewall_policys/{metadata.name}",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 800,
+            "p95_ms": 2500,
+            "p99_ms": 6000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.metadata.name",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "modifies": [
+              "enhanced-firewall-policy"
+            ]
+          },
+          "purpose": "Replace Enhanced Firewall Policy."
+        }
+      }
+    },
+    "external_connector": {
+      "resource": "external_connector",
+      "base_path": "/api/config/namespaces/{metadata.namespace}/external_connectors",
+      "operations": {
+        "create": {
+          "method": "POST",
+          "path": "/api/config/namespaces/{metadata.namespace}/external_connectors",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 1000,
+            "p95_ms": 3000,
+            "p99_ms": 8000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "metadata.name",
+            "metadata.namespace",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "creates": [
+              "external-connector"
+            ]
+          },
+          "purpose": "Create external_connector configuration."
+        },
+        "delete": {
+          "method": "DELETE",
+          "path": "/api/config/namespaces/{namespace}/external_connectors/{name}",
+          "danger_level": "high",
+          "discovered_response_time": {
+            "p50_ms": 500,
+            "p95_ms": 1500,
+            "p99_ms": 4000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "confirmation_required": true,
+          "side_effects": {
+            "deletes": [
+              "external-connector",
+              "contained_resources"
+            ]
+          },
+          "purpose": "DELETE External Connector Configuration."
+        },
+        "list": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/external_connectors",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.namespace"
+          ],
+          "purpose": "List External Connector Configuration."
+        },
+        "read": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/external_connectors/{name}",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "purpose": "GET external_connector configuration."
+        },
+        "update": {
+          "method": "PUT",
+          "path": "/api/config/namespaces/{metadata.namespace}/external_connectors/{metadata.name}",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 800,
+            "p95_ms": 2500,
+            "p99_ms": 6000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.metadata.name",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "modifies": [
+              "external-connector"
+            ]
+          },
+          "purpose": "Replace external_connector configuration."
+        }
+      }
+    },
+    "fast_acl": {
+      "resource": "fast_acl",
+      "base_path": "/api/config/namespaces/{metadata.namespace}/fast_acls/{metadata.name}",
+      "operations": {
+        "create": {
+          "method": "POST",
+          "path": "/api/config/namespaces/{metadata.namespace}/fast_acls",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 1000,
+            "p95_ms": 3000,
+            "p99_ms": 8000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "metadata.name",
+            "metadata.namespace",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "creates": [
+              "fast-acl"
+            ]
+          },
+          "purpose": "Create Fast ACL."
+        },
+        "delete": {
+          "method": "DELETE",
+          "path": "/api/config/namespaces/{namespace}/fast_acls/{name}",
+          "danger_level": "high",
+          "discovered_response_time": {
+            "p50_ms": 500,
+            "p95_ms": 1500,
+            "p99_ms": 4000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "confirmation_required": true,
+          "side_effects": {
+            "deletes": [
+              "fast-acl",
+              "contained_resources"
+            ]
+          },
+          "purpose": "DELETE Fast ACL."
+        },
+        "list": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/fast_acls",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.namespace"
+          ],
+          "purpose": "List Fast ACL."
+        },
+        "read": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/fast_acls/{name}",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "purpose": "GET Fast ACL."
+        },
+        "update": {
+          "method": "PUT",
+          "path": "/api/config/namespaces/{metadata.namespace}/fast_acls/{metadata.name}",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 800,
+            "p95_ms": 2500,
+            "p99_ms": 6000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.metadata.name",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "modifies": [
+              "fast-acl"
+            ]
+          },
+          "purpose": "Replace Fast ACL."
+        }
+      }
+    },
+    "fast_acl_rule": {
+      "resource": "fast_acl_rule",
+      "base_path": "/api/config/namespaces/{metadata.namespace}/fast_acl_rules/{metadata.name}",
+      "operations": {
+        "create": {
+          "method": "POST",
+          "path": "/api/config/namespaces/{metadata.namespace}/fast_acl_rules",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 1000,
+            "p95_ms": 3000,
+            "p99_ms": 8000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "metadata.name",
+            "metadata.namespace",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "creates": [
+              "fast-acl-rule"
+            ]
+          },
+          "purpose": "Create Fast ACL Rule."
+        },
+        "delete": {
+          "method": "DELETE",
+          "path": "/api/config/namespaces/{namespace}/fast_acl_rules/{name}",
+          "danger_level": "high",
+          "discovered_response_time": {
+            "p50_ms": 500,
+            "p95_ms": 1500,
+            "p99_ms": 4000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "confirmation_required": true,
+          "side_effects": {
+            "deletes": [
+              "fast-acl-rule",
+              "contained_resources"
+            ]
+          },
+          "purpose": "DELETE Fast ACL Rule."
+        },
+        "list": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/fast_acl_rules",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.namespace"
+          ],
+          "purpose": "List Fast ACL Rule."
+        },
+        "read": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/fast_acl_rules/{name}",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "purpose": "GET Fast ACL Rule."
+        },
+        "update": {
+          "method": "PUT",
+          "path": "/api/config/namespaces/{metadata.namespace}/fast_acl_rules/{metadata.name}",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 800,
+            "p95_ms": 2500,
+            "p99_ms": 6000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.metadata.name",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "modifies": [
+              "fast-acl-rule"
+            ]
+          },
+          "purpose": "Replace Fast ACL Rule."
+        }
+      }
+    },
+    "filter_set": {
+      "resource": "filter_set",
+      "base_path": "/api/config/namespaces/{metadata.namespace}/filter_sets/{metadata.name}",
+      "operations": {
+        "create": {
+          "method": "POST",
+          "path": "/api/config/namespaces/{metadata.namespace}/filter_sets",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 1000,
+            "p95_ms": 3000,
+            "p99_ms": 8000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "metadata.name",
+            "metadata.namespace",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "creates": [
+              "filter-set"
+            ]
+          },
+          "purpose": "Create Specification."
+        },
+        "delete": {
+          "method": "DELETE",
+          "path": "/api/config/namespaces/{namespace}/filter_sets/{name}",
+          "danger_level": "high",
+          "discovered_response_time": {
+            "p50_ms": 500,
+            "p95_ms": 1500,
+            "p99_ms": 4000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "confirmation_required": true,
+          "side_effects": {
+            "deletes": [
+              "filter-set",
+              "contained_resources"
+            ]
+          },
+          "purpose": "DELETE Filter Set."
+        },
+        "list": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/filter_sets",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.namespace"
+          ],
+          "purpose": "List Filter Set."
+        },
+        "read": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/filter_sets/{name}",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "purpose": "GET Specification."
+        },
+        "update": {
+          "method": "PUT",
+          "path": "/api/config/namespaces/{metadata.namespace}/filter_sets/{metadata.name}",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 800,
+            "p95_ms": 2500,
+            "p99_ms": 6000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.metadata.name",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "modifies": [
+              "filter-set"
+            ]
+          },
+          "purpose": "Replace Specification."
+        }
+      }
+    },
+    "fleet": {
+      "resource": "fleet",
+      "base_path": "/api/config/namespaces/{namespace}/fleets",
+      "operations": {
+        "create": {
+          "method": "POST",
+          "path": "/api/config/namespaces/{metadata.namespace}/fleets",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 1000,
+            "p95_ms": 3000,
+            "p99_ms": 8000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "metadata.name",
+            "metadata.namespace",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "creates": [
+              "fleet"
+            ]
+          },
+          "purpose": "Create Fleet."
+        },
+        "delete": {
+          "method": "DELETE",
+          "path": "/api/config/namespaces/{namespace}/fleets/{name}",
+          "danger_level": "high",
+          "discovered_response_time": {
+            "p50_ms": 500,
+            "p95_ms": 1500,
+            "p99_ms": 4000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "confirmation_required": true,
+          "side_effects": {
+            "deletes": [
+              "fleet",
+              "contained_resources"
+            ]
+          },
+          "purpose": "DELETE Fleet."
+        },
+        "list": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/fleets",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.namespace"
+          ],
+          "purpose": "List Fleet."
+        },
+        "read": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/fleets/{name}",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "purpose": "GET Fleet"
+        },
+        "update": {
+          "method": "PUT",
+          "path": "/api/config/namespaces/{metadata.namespace}/fleets/{metadata.name}",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 800,
+            "p95_ms": 2500,
+            "p99_ms": 6000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.metadata.name",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "modifies": [
+              "fleet"
+            ]
+          },
+          "purpose": "Replace Fleet."
+        }
+      }
+    },
+    "forward_proxy_policy": {
+      "resource": "forward_proxy_policy",
+      "base_path": "/api/config/namespaces/{namespace}/forward_proxy_policys",
+      "operations": {
+        "create": {
+          "method": "POST",
+          "path": "/api/data/namespaces/{namespace}/forward_proxy_policy/hits",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 1000,
+            "p95_ms": 3000,
+            "p99_ms": 8000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "metadata.name",
+            "metadata.namespace",
+            "path.namespace"
+          ],
+          "side_effects": {
+            "creates": [
+              "hit"
+            ]
+          },
+          "purpose": "Forward Proxy Policy Hits."
+        },
+        "delete": {
+          "method": "DELETE",
+          "path": "/api/config/namespaces/{namespace}/forward_proxy_policys/{name}",
+          "danger_level": "high",
+          "discovered_response_time": {
+            "p50_ms": 500,
+            "p95_ms": 1500,
+            "p99_ms": 4000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "confirmation_required": true,
+          "side_effects": {
+            "deletes": [
+              "forward-proxy-policy",
+              "contained_resources"
+            ]
+          },
+          "purpose": "DELETE Configure Forward Proxy Policy."
+        },
+        "list": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/forward_proxy_policys",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.namespace"
+          ],
+          "purpose": "List Configure Forward Proxy Policy."
+        },
+        "read": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/forward_proxy_policys/{name}",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "purpose": "GET Forward Proxy Policy."
+        },
+        "update": {
+          "method": "PUT",
+          "path": "/api/config/namespaces/{metadata.namespace}/forward_proxy_policys/{metadata.name}",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 800,
+            "p95_ms": 2500,
+            "p99_ms": 6000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.metadata.name",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "modifies": [
+              "forward-proxy-policy"
+            ]
+          },
+          "purpose": "Replace Forward Proxy Policy."
+        }
+      }
+    },
+    "forwarding_class": {
+      "resource": "forwarding_class",
+      "base_path": "/api/config/namespaces/{namespace}/forwarding_classs/{name}",
+      "operations": {
+        "create": {
+          "method": "POST",
+          "path": "/api/config/namespaces/{metadata.namespace}/forwarding_classs",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 1000,
+            "p95_ms": 3000,
+            "p99_ms": 8000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "metadata.name",
+            "metadata.namespace",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "creates": [
+              "forwarding-class"
+            ]
+          },
+          "purpose": "Create Forwarding Class."
+        },
+        "delete": {
+          "method": "DELETE",
+          "path": "/api/config/namespaces/{namespace}/forwarding_classs/{name}",
+          "danger_level": "high",
+          "discovered_response_time": {
+            "p50_ms": 500,
+            "p95_ms": 1500,
+            "p99_ms": 4000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "confirmation_required": true,
+          "side_effects": {
+            "deletes": [
+              "forwarding-class",
+              "contained_resources"
+            ]
+          },
+          "purpose": "DELETE Forwarding Class."
+        },
+        "list": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/forwarding_classs",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.namespace"
+          ],
+          "purpose": "List Forwarding Class."
+        },
+        "read": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/forwarding_classs/{name}",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "purpose": "GET Forwarding Class."
+        },
+        "update": {
+          "method": "PUT",
+          "path": "/api/config/namespaces/{metadata.namespace}/forwarding_classs/{metadata.name}",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 800,
+            "p95_ms": 2500,
+            "p99_ms": 6000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.metadata.name",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "modifies": [
+              "forwarding-class"
+            ]
+          },
+          "purpose": "Replace Forwarding Class."
+        }
+      }
+    },
+    "gcp_vpc_site": {
+      "resource": "gcp_vpc_site",
+      "base_path": "/api/config/namespaces/{metadata.namespace}/gcp_vpc_sites/{metadata.name}",
+      "operations": {
+        "create": {
+          "method": "POST",
+          "path": "/api/config/namespaces/{namespace}/gcp_vpc_site/{name}/set_cloud_site_info",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 1000,
+            "p95_ms": 3000,
+            "p99_ms": 8000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "metadata.name",
+            "metadata.namespace",
+            "path.name",
+            "path.namespace"
+          ],
+          "side_effects": {
+            "creates": [
+              "set-cloud-site-info"
+            ]
+          },
+          "purpose": "Configure GCP VPC Site Information."
+        },
+        "delete": {
+          "method": "DELETE",
+          "path": "/api/config/namespaces/{namespace}/gcp_vpc_sites/{name}",
+          "danger_level": "high",
+          "discovered_response_time": {
+            "p50_ms": 500,
+            "p95_ms": 1500,
+            "p99_ms": 4000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "confirmation_required": true,
+          "side_effects": {
+            "deletes": [
+              "gcp-vpc-site",
+              "contained_resources"
+            ]
+          },
+          "purpose": "DELETE Configure GCP VPC Site."
+        },
+        "list": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/gcp_vpc_sites",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 158,
+            "p95_ms": 317,
+            "p99_ms": 475,
+            "sample_count": 1,
+            "source": "discovery"
+          },
+          "required_fields": [
+            "path.namespace"
+          ],
+          "purpose": "List Configure GCP VPC Site."
+        },
+        "read": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/gcp_vpc_sites/{name}",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "purpose": "GET GCP VPC site."
+        },
+        "update": {
+          "method": "PUT",
+          "path": "/api/config/namespaces/{metadata.namespace}/gcp_vpc_sites/{metadata.name}",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 800,
+            "p95_ms": 2500,
+            "p99_ms": 6000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.metadata.name",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "modifies": [
+              "gcp-vpc-site"
+            ]
+          },
+          "purpose": "Replace GCP VPC site."
+        }
+      }
+    },
+    "global_log_receiver": {
+      "resource": "global_log_receiver",
+      "base_path": "/api/config/namespaces/{namespace}/global_log_receivers/{name}",
+      "operations": {
+        "create": {
+          "method": "POST",
+          "path": "/api/data/namespaces/{namespace}/global_log_receiver/status",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 1000,
+            "p95_ms": 3000,
+            "p99_ms": 8000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "metadata.name",
+            "metadata.namespace",
+            "path.namespace"
+          ],
+          "side_effects": {
+            "creates": [
+              "statu"
+            ]
+          },
+          "purpose": "Global Log Receiver Status."
+        },
+        "delete": {
+          "method": "DELETE",
+          "path": "/api/config/namespaces/{namespace}/global_log_receivers/{name}",
+          "danger_level": "high",
+          "discovered_response_time": {
+            "p50_ms": 500,
+            "p95_ms": 1500,
+            "p99_ms": 4000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "confirmation_required": true,
+          "side_effects": {
+            "deletes": [
+              "global-log-receiver",
+              "contained_resources"
+            ]
+          },
+          "purpose": "DELETE Global Log Receiver."
+        },
+        "list": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/global_log_receivers",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.namespace"
+          ],
+          "purpose": "List Global Log Receiver."
+        },
+        "read": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/global_log_receivers/{name}",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "purpose": "GET Global Log Receiver."
+        },
+        "update": {
+          "method": "PUT",
+          "path": "/api/config/namespaces/{metadata.namespace}/global_log_receivers/{metadata.name}",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 800,
+            "p95_ms": 2500,
+            "p99_ms": 6000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.metadata.name",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "modifies": [
+              "global-log-receiver"
+            ]
+          },
+          "purpose": "Replace Global Log Receiver."
+        }
+      }
+    },
+    "healthcheck": {
+      "resource": "healthcheck",
+      "base_path": "/api/config/namespaces/{metadata.namespace}/healthchecks",
+      "operations": {
+        "create": {
+          "method": "POST",
+          "path": "/api/config/namespaces/{metadata.namespace}/healthchecks",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 1000,
+            "p95_ms": 3000,
+            "p99_ms": 8000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "metadata.name",
+            "metadata.namespace",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "creates": [
+              "healthcheck"
+            ]
+          },
+          "purpose": "Create Health Check."
+        },
+        "delete": {
+          "method": "DELETE",
+          "path": "/api/config/namespaces/{namespace}/healthchecks/{name}",
+          "danger_level": "high",
+          "discovered_response_time": {
+            "p50_ms": 500,
+            "p95_ms": 1500,
+            "p99_ms": 4000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "confirmation_required": true,
+          "side_effects": {
+            "deletes": [
+              "healthcheck",
+              "contained_resources"
+            ]
+          },
+          "purpose": "DELETE Health Check."
+        },
+        "list": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/healthchecks",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.namespace"
+          ],
+          "purpose": "List Health Check."
+        },
+        "read": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/healthchecks/{name}",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "purpose": "GET Health Check."
+        },
+        "update": {
+          "method": "PUT",
+          "path": "/api/config/namespaces/{metadata.namespace}/healthchecks/{metadata.name}",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 800,
+            "p95_ms": 2500,
+            "p99_ms": 6000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.metadata.name",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "modifies": [
+              "healthcheck"
+            ]
+          },
+          "purpose": "Replace Health Check."
+        }
+      }
+    },
+    "http_loadbalancer": {
+      "resource": "http_loadbalancer",
+      "base_path": "/api/config/namespaces/{namespace}/http_loadbalancers/{name}/api_definitions/available",
+      "operations": {
+        "create": {
+          "method": "POST",
+          "path": "/api/ml/data/namespaces/{namespace}/http_loadbalancers/{name}/api_endpoints",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 1000,
+            "p95_ms": 3000,
+            "p99_ms": 8000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "metadata.name",
+            "metadata.namespace",
+            "path.name",
+            "path.namespace"
+          ],
+          "side_effects": {
+            "creates": [
+              "api-endpoint"
+            ]
+          },
+          "purpose": "GET API Endpoints."
+        },
+        "delete": {
+          "method": "DELETE",
+          "path": "/api/config/namespaces/{namespace}/http_loadbalancers/{name}",
+          "danger_level": "high",
+          "discovered_response_time": {
+            "p50_ms": 500,
+            "p95_ms": 1500,
+            "p99_ms": 4000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "confirmation_required": true,
+          "side_effects": {
+            "deletes": [
+              "http-loadbalancer",
+              "contained_resources"
+            ]
+          },
+          "purpose": "DELETE Configure HTTP Load Balancer."
+        },
+        "list": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/http_loadbalancers",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.namespace"
+          ],
+          "purpose": "List Configure HTTP Load Balancer."
+        },
+        "read": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/http_loadbalancers/{name}/dos_automitigation_rules",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "purpose": "GET DoS Auto-Mitigation Rules for HTTP Load Balancer."
+        },
+        "update": {
+          "method": "PUT",
+          "path": "/api/config/namespaces/{metadata.namespace}/http_loadbalancers/{metadata.name}",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 800,
+            "p95_ms": 2500,
+            "p99_ms": 6000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.metadata.name",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "modifies": [
+              "http-loadbalancer"
+            ]
+          },
+          "purpose": "Replace HTTP Load Balancer."
+        }
+      }
+    },
+    "ip_prefix_set": {
+      "resource": "ip_prefix_set",
+      "base_path": "/api/config/namespaces/{namespace}/ip_prefix_sets/{name}",
+      "operations": {
+        "create": {
+          "method": "POST",
+          "path": "/api/config/namespaces/{metadata.namespace}/ip_prefix_sets",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 1000,
+            "p95_ms": 3000,
+            "p99_ms": 8000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "metadata.name",
+            "metadata.namespace",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "creates": [
+              "ip-prefix-set"
+            ]
+          },
+          "purpose": "Create IP Prefix Set."
+        },
+        "delete": {
+          "method": "DELETE",
+          "path": "/api/config/namespaces/{namespace}/ip_prefix_sets/{name}",
+          "danger_level": "high",
+          "discovered_response_time": {
+            "p50_ms": 500,
+            "p95_ms": 1500,
+            "p99_ms": 4000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "confirmation_required": true,
+          "side_effects": {
+            "deletes": [
+              "ip-prefix-set",
+              "contained_resources"
+            ]
+          },
+          "purpose": "DELETE IP Prefix Set."
+        },
+        "list": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/ip_prefix_sets",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.namespace"
+          ],
+          "purpose": "List IP Prefix Set."
+        },
+        "read": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/ip_prefix_sets/{name}",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "purpose": "GET IP Prefix Set."
+        },
+        "update": {
+          "method": "PUT",
+          "path": "/api/config/namespaces/{metadata.namespace}/ip_prefix_sets/{metadata.name}",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 800,
+            "p95_ms": 2500,
+            "p99_ms": 6000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.metadata.name",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "modifies": [
+              "ip-prefix-set"
+            ]
+          },
+          "purpose": "Replace IP Prefix Set."
+        }
+      }
+    },
+    "irule": {
+      "resource": "irule",
+      "base_path": "/api/config/namespaces/{namespace}/irules",
+      "operations": {
+        "create": {
+          "method": "POST",
+          "path": "/api/config/namespaces/{metadata.namespace}/irules",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 1000,
+            "p95_ms": 3000,
+            "p99_ms": 8000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "metadata.name",
+            "metadata.namespace",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "creates": [
+              "irule"
+            ]
+          },
+          "purpose": "Create iRule."
+        },
+        "delete": {
+          "method": "DELETE",
+          "path": "/api/config/namespaces/{namespace}/irules/{name}",
+          "danger_level": "high",
+          "discovered_response_time": {
+            "p50_ms": 500,
+            "p95_ms": 1500,
+            "p99_ms": 4000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "confirmation_required": true,
+          "side_effects": {
+            "deletes": [
+              "irule",
+              "contained_resources"
+            ]
+          },
+          "purpose": "DELETE Configure iRule."
+        },
+        "list": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/irules",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 157,
+            "p95_ms": 314,
+            "p99_ms": 471,
+            "sample_count": 1,
+            "source": "discovery"
+          },
+          "required_fields": [
+            "path.namespace"
+          ],
+          "purpose": "List Configure iRule."
+        },
+        "read": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/irules/{name}",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "purpose": "GET iRule"
+        },
+        "update": {
+          "method": "PUT",
+          "path": "/api/config/namespaces/{metadata.namespace}/irules/{metadata.name}",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 800,
+            "p95_ms": 2500,
+            "p99_ms": 6000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.metadata.name",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "modifies": [
+              "irule"
+            ]
+          },
+          "purpose": "Replace iRule."
+        }
+      }
+    },
+    "log_receiver": {
+      "resource": "log_receiver",
+      "base_path": "/api/config/namespaces/{metadata.namespace}/log_receivers",
+      "operations": {
+        "create": {
+          "method": "POST",
+          "path": "/api/config/namespaces/{metadata.namespace}/log_receivers",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 1000,
+            "p95_ms": 3000,
+            "p99_ms": 8000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "metadata.name",
+            "metadata.namespace",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "creates": [
+              "log-receiver"
+            ]
+          },
+          "purpose": "Create Log Receiver."
+        },
+        "delete": {
+          "method": "DELETE",
+          "path": "/api/config/namespaces/{namespace}/global_log_receivers/{name}",
+          "danger_level": "high",
+          "discovered_response_time": {
+            "p50_ms": 500,
+            "p95_ms": 1500,
+            "p99_ms": 4000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "confirmation_required": true,
+          "side_effects": {
+            "deletes": [
+              "global-log-receiver",
+              "contained_resources"
+            ]
+          },
+          "purpose": "DELETE Global Log Receiver."
+        },
+        "list": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/global_log_receivers",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.namespace"
+          ],
+          "purpose": "List Global Log Receiver."
+        },
+        "read": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/global_log_receivers/{name}",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "purpose": "GET Global Log Receiver."
+        },
+        "update": {
+          "method": "PUT",
+          "path": "/api/config/namespaces/{metadata.namespace}/global_log_receivers/{metadata.name}",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 800,
+            "p95_ms": 2500,
+            "p99_ms": 6000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.metadata.name",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "modifies": [
+              "global-log-receiver"
+            ]
+          },
+          "purpose": "Replace Global Log Receiver."
+        }
+      }
+    },
+    "malicious_user_mitigation": {
+      "resource": "malicious_user_mitigation",
+      "base_path": "/api/config/namespaces/{namespace}/malicious_user_mitigations",
+      "operations": {
+        "create": {
+          "method": "POST",
+          "path": "/api/config/namespaces/{metadata.namespace}/malicious_user_mitigations",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 1000,
+            "p95_ms": 3000,
+            "p99_ms": 8000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "metadata.name",
+            "metadata.namespace",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "creates": [
+              "malicious-user-mitigation"
+            ]
+          },
+          "purpose": "Create Malicious User Mitigation."
+        },
+        "delete": {
+          "method": "DELETE",
+          "path": "/api/config/namespaces/{namespace}/malicious_user_mitigations/{name}",
+          "danger_level": "high",
+          "discovered_response_time": {
+            "p50_ms": 500,
+            "p95_ms": 1500,
+            "p99_ms": 4000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "confirmation_required": true,
+          "side_effects": {
+            "deletes": [
+              "malicious-user-mitigation",
+              "contained_resources"
+            ]
+          },
+          "purpose": "DELETE Malicious User Mitigation."
+        },
+        "list": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/malicious_user_mitigations",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.namespace"
+          ],
+          "purpose": "List Malicious User Mitigation."
+        },
+        "read": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/malicious_user_mitigations/{name}",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "purpose": "GET Malicious User Mitigation."
+        },
+        "update": {
+          "method": "PUT",
+          "path": "/api/config/namespaces/{metadata.namespace}/malicious_user_mitigations/{metadata.name}",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 800,
+            "p95_ms": 2500,
+            "p99_ms": 6000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.metadata.name",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "modifies": [
+              "malicious-user-mitigation"
+            ]
+          },
+          "purpose": "Replace Malicious User Mitigation."
+        }
+      }
+    },
+    "namespace": {
+      "resource": "namespace",
+      "base_path": "/api/web/namespaces/{namespace}/contacts",
+      "operations": {
+        "create": {
+          "method": "POST",
+          "path": "/api/config/namespaces/system/validate_rules",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 1000,
+            "p95_ms": 3000,
+            "p99_ms": 8000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "metadata.name",
+            "metadata.namespace"
+          ],
+          "side_effects": {
+            "creates": [
+              "validate-rule"
+            ]
+          },
+          "purpose": "Validate Rules."
+        },
+        "delete": {
+          "method": "DELETE",
+          "path": "/api/web/namespaces/{namespace}/allowed_tenants/{name}",
+          "danger_level": "high",
+          "discovered_response_time": {
+            "p50_ms": 500,
+            "p95_ms": 1500,
+            "p99_ms": 4000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "confirmation_required": true,
+          "side_effects": {
+            "deletes": [
+              "allowed-tenant",
+              "contained_resources"
+            ]
+          },
+          "purpose": "DELETE Allowed Tenant."
+        },
+        "list": {
+          "method": "GET",
+          "path": "/api/web/namespaces/system/tenant/settings/tenant/logo",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "purpose": "Tenant logo."
+        },
+        "read": {
+          "method": "GET",
+          "path": "/api/web/namespaces/{namespace}/allowed_tenants/{name}",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "purpose": "GET Allowed Tenant."
+        },
+        "update": {
+          "method": "PUT",
+          "path": "/api/web/namespaces/system/user/settings/request_initial_access",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 800,
+            "p95_ms": 2500,
+            "p99_ms": 6000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "side_effects": {
+            "modifies": [
+              "request-initial-acces"
+            ]
+          },
+          "purpose": "Request Initial Access."
+        }
+      }
+    },
+    "nat_policy": {
+      "resource": "nat_policy",
+      "base_path": "/api/config/namespaces/{namespace}/nat_policys",
+      "operations": {
+        "create": {
+          "method": "POST",
+          "path": "/api/config/namespaces/{metadata.namespace}/nat_policys",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 1000,
+            "p95_ms": 3000,
+            "p99_ms": 8000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "metadata.name",
+            "metadata.namespace",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "creates": [
+              "nat-policy"
+            ]
+          },
+          "purpose": "Create NAT Policy."
+        },
+        "delete": {
+          "method": "DELETE",
+          "path": "/api/config/namespaces/{namespace}/nat_policys/{name}",
+          "danger_level": "high",
+          "discovered_response_time": {
+            "p50_ms": 500,
+            "p95_ms": 1500,
+            "p99_ms": 4000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "confirmation_required": true,
+          "side_effects": {
+            "deletes": [
+              "nat-policy",
+              "contained_resources"
+            ]
+          },
+          "purpose": "DELETE NAT Policy."
+        },
+        "list": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/nat_policys",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.namespace"
+          ],
+          "purpose": "List NAT Policy."
+        },
+        "read": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/nat_policys/{name}",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "purpose": "GET NAT Policy."
+        },
+        "update": {
+          "method": "PUT",
+          "path": "/api/config/namespaces/{metadata.namespace}/nat_policys/{metadata.name}",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 800,
+            "p95_ms": 2500,
+            "p99_ms": 6000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.metadata.name",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "modifies": [
+              "nat-policy"
+            ]
+          },
+          "purpose": "Replace NAT Policy."
+        }
+      }
+    },
+    "network_connector": {
+      "resource": "network_connector",
+      "base_path": "/api/config/namespaces/{metadata.namespace}/network_connectors/{metadata.name}",
+      "operations": {
+        "create": {
+          "method": "POST",
+          "path": "/api/config/namespaces/{metadata.namespace}/network_connectors",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 1000,
+            "p95_ms": 3000,
+            "p99_ms": 8000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "metadata.name",
+            "metadata.namespace",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "creates": [
+              "network-connector"
+            ]
+          },
+          "purpose": "Create Network Connector."
+        },
+        "delete": {
+          "method": "DELETE",
+          "path": "/api/config/namespaces/{namespace}/network_connectors/{name}",
+          "danger_level": "high",
+          "discovered_response_time": {
+            "p50_ms": 500,
+            "p95_ms": 1500,
+            "p99_ms": 4000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "confirmation_required": true,
+          "side_effects": {
+            "deletes": [
+              "network-connector",
+              "contained_resources"
+            ]
+          },
+          "purpose": "DELETE Network Connector."
+        },
+        "list": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/network_connectors",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.namespace"
+          ],
+          "purpose": "List Network Connector."
+        },
+        "read": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/network_connectors/{name}",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "purpose": "GET Network Connector."
+        },
+        "update": {
+          "method": "PUT",
+          "path": "/api/config/namespaces/{metadata.namespace}/network_connectors/{metadata.name}",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 800,
+            "p95_ms": 2500,
+            "p99_ms": 6000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.metadata.name",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "modifies": [
+              "network-connector"
+            ]
+          },
+          "purpose": "Replace Network Connector."
+        }
+      }
+    },
+    "network_firewall": {
+      "resource": "network_firewall",
+      "base_path": "/api/config/namespaces/{namespace}/network_firewalls/{name}",
+      "operations": {
+        "create": {
+          "method": "POST",
+          "path": "/api/config/namespaces/{metadata.namespace}/network_firewalls",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 1000,
+            "p95_ms": 3000,
+            "p99_ms": 8000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "metadata.name",
+            "metadata.namespace",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "creates": [
+              "network-firewall"
+            ]
+          },
+          "purpose": "Create Network Firewall."
+        },
+        "delete": {
+          "method": "DELETE",
+          "path": "/api/config/namespaces/{namespace}/network_firewalls/{name}",
+          "danger_level": "high",
+          "discovered_response_time": {
+            "p50_ms": 500,
+            "p95_ms": 1500,
+            "p99_ms": 4000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "confirmation_required": true,
+          "side_effects": {
+            "deletes": [
+              "network-firewall",
+              "contained_resources"
+            ]
+          },
+          "purpose": "DELETE Network Firewall."
+        },
+        "list": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/network_firewalls",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.namespace"
+          ],
+          "purpose": "List Network Firewall."
+        },
+        "read": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/network_firewalls/{name}",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "purpose": "GET Network Firewall."
+        },
+        "update": {
+          "method": "PUT",
+          "path": "/api/config/namespaces/{metadata.namespace}/network_firewalls/{metadata.name}",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 800,
+            "p95_ms": 2500,
+            "p99_ms": 6000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.metadata.name",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "modifies": [
+              "network-firewall"
+            ]
+          },
+          "purpose": "Replace Network Firewall."
+        }
+      }
+    },
+    "network_interface": {
+      "resource": "network_interface",
+      "base_path": "/api/config/namespaces/{metadata.namespace}/network_interfaces",
+      "operations": {
+        "create": {
+          "method": "POST",
+          "path": "/api/config/namespaces/{metadata.namespace}/network_interfaces",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 1000,
+            "p95_ms": 3000,
+            "p99_ms": 8000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "metadata.name",
+            "metadata.namespace",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "creates": [
+              "network-interface"
+            ]
+          },
+          "purpose": "Create Network Interface."
+        },
+        "delete": {
+          "method": "DELETE",
+          "path": "/api/config/namespaces/{namespace}/network_interfaces/{name}",
+          "danger_level": "high",
+          "discovered_response_time": {
+            "p50_ms": 500,
+            "p95_ms": 1500,
+            "p99_ms": 4000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "confirmation_required": true,
+          "side_effects": {
+            "deletes": [
+              "network-interface",
+              "contained_resources"
+            ]
+          },
+          "purpose": "DELETE Network Interface."
+        },
+        "list": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/network_interfaces",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.namespace"
+          ],
+          "purpose": "List Network Interface."
+        },
+        "read": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/network_interfaces/{name}",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "purpose": "GET Network Interface."
+        },
+        "update": {
+          "method": "PUT",
+          "path": "/api/config/namespaces/{metadata.namespace}/network_interfaces/{metadata.name}",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 800,
+            "p95_ms": 2500,
+            "p99_ms": 6000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.metadata.name",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "modifies": [
+              "network-interface"
+            ]
+          },
+          "purpose": "Replace Network Interface."
+        }
+      }
+    },
+    "network_policy": {
+      "resource": "network_policy",
+      "base_path": "/api/config/namespaces/{namespace}/network_policys",
+      "operations": {
+        "create": {
+          "method": "POST",
+          "path": "/api/data/namespaces/{namespace}/network_policy/hits",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 1000,
+            "p95_ms": 3000,
+            "p99_ms": 8000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "metadata.name",
+            "metadata.namespace",
+            "path.namespace"
+          ],
+          "side_effects": {
+            "creates": [
+              "hit"
+            ]
+          },
+          "purpose": "Network Policy Hits."
+        },
+        "delete": {
+          "method": "DELETE",
+          "path": "/api/config/namespaces/{namespace}/network_policy_rules/{name}",
+          "danger_level": "high",
+          "discovered_response_time": {
+            "p50_ms": 500,
+            "p95_ms": 1500,
+            "p99_ms": 4000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "confirmation_required": true,
+          "side_effects": {
+            "deletes": [
+              "network-policy-rule",
+              "contained_resources"
+            ]
+          },
+          "purpose": "DELETE Network Policy Rule."
+        },
+        "list": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/network_policy_views",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.namespace"
+          ],
+          "purpose": "List Configure Network policy View."
+        },
+        "read": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/network_policy_rules/{name}",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "purpose": "GET Network Policy Rule."
+        },
+        "update": {
+          "method": "PUT",
+          "path": "/api/config/namespaces/{metadata.namespace}/network_policy_views/{metadata.name}",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 800,
+            "p95_ms": 2500,
+            "p99_ms": 6000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.metadata.name",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "modifies": [
+              "network-policy-view"
+            ]
+          },
+          "purpose": "Replace Network policy View."
+        }
+      }
+    },
+    "network_policy_rule": {
+      "resource": "network_policy_rule",
+      "base_path": "/api/config/namespaces/{metadata.namespace}/network_policy_rules",
+      "operations": {
+        "create": {
+          "method": "POST",
+          "path": "/api/config/namespaces/{metadata.namespace}/network_policy_rules",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 1000,
+            "p95_ms": 3000,
+            "p99_ms": 8000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "metadata.name",
+            "metadata.namespace",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "creates": [
+              "network-policy-rule"
+            ]
+          },
+          "purpose": "Create Network Policy Rule."
+        },
+        "delete": {
+          "method": "DELETE",
+          "path": "/api/config/namespaces/{namespace}/network_policy_rules/{name}",
+          "danger_level": "high",
+          "discovered_response_time": {
+            "p50_ms": 500,
+            "p95_ms": 1500,
+            "p99_ms": 4000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "confirmation_required": true,
+          "side_effects": {
+            "deletes": [
+              "network-policy-rule",
+              "contained_resources"
+            ]
+          },
+          "purpose": "DELETE Network Policy Rule."
+        },
+        "list": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/network_policy_rules",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.namespace"
+          ],
+          "purpose": "List Network Policy Rule."
+        },
+        "read": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/network_policy_rules/{name}",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "purpose": "GET Network Policy Rule."
+        },
+        "update": {
+          "method": "PUT",
+          "path": "/api/config/namespaces/{metadata.namespace}/network_policy_rules/{metadata.name}",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 800,
+            "p95_ms": 2500,
+            "p99_ms": 6000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.metadata.name",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "modifies": [
+              "network-policy-rule"
+            ]
+          },
+          "purpose": "Replace Network Policy Rule."
+        }
+      }
+    },
+    "network_policy_view": {
+      "resource": "network_policy_view",
+      "base_path": "/api/config/namespaces/{namespace}/network_policy_views/{name}",
+      "operations": {
+        "create": {
+          "method": "POST",
+          "path": "/api/data/namespaces/{namespace}/network_policy_view/hits",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 1000,
+            "p95_ms": 3000,
+            "p99_ms": 8000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "metadata.name",
+            "metadata.namespace",
+            "path.namespace"
+          ],
+          "side_effects": {
+            "creates": [
+              "hit"
+            ]
+          },
+          "purpose": "Network Policy Hits."
+        },
+        "delete": {
+          "method": "DELETE",
+          "path": "/api/config/namespaces/{namespace}/network_policy_views/{name}",
+          "danger_level": "high",
+          "discovered_response_time": {
+            "p50_ms": 500,
+            "p95_ms": 1500,
+            "p99_ms": 4000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "confirmation_required": true,
+          "side_effects": {
+            "deletes": [
+              "network-policy-view",
+              "contained_resources"
+            ]
+          },
+          "purpose": "DELETE Configure Network policy View."
+        },
+        "list": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/network_policy_views",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.namespace"
+          ],
+          "purpose": "List Configure Network policy View."
+        },
+        "read": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/network_policy_views/{name}",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "purpose": "GET Network policy View."
+        },
+        "update": {
+          "method": "PUT",
+          "path": "/api/config/namespaces/{metadata.namespace}/network_policy_views/{metadata.name}",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 800,
+            "p95_ms": 2500,
+            "p99_ms": 6000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.metadata.name",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "modifies": [
+              "network-policy-view"
+            ]
+          },
+          "purpose": "Replace Network policy View."
+        }
+      }
+    },
+    "nfv_service": {
+      "resource": "nfv_service",
+      "base_path": "/api/config/namespaces/{namespace}/nfv_services",
+      "operations": {
+        "create": {
+          "method": "POST",
+          "path": "/api/config/namespaces/system/nfv_service/{name}/force-delete",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 1000,
+            "p95_ms": 3000,
+            "p99_ms": 8000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "metadata.name",
+            "metadata.namespace",
+            "path.name"
+          ],
+          "side_effects": {
+            "creates": [
+              "force-delete"
+            ]
+          },
+          "purpose": "Force DELETE NFV Service."
+        },
+        "delete": {
+          "method": "DELETE",
+          "path": "/api/config/namespaces/{namespace}/nfv_services/{name}",
+          "danger_level": "high",
+          "discovered_response_time": {
+            "p50_ms": 500,
+            "p95_ms": 1500,
+            "p99_ms": 4000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "confirmation_required": true,
+          "side_effects": {
+            "deletes": [
+              "nfv-service",
+              "contained_resources"
+            ]
+          },
+          "purpose": "DELETE NFV Service."
+        },
+        "list": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/nfv_services",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.namespace"
+          ],
+          "purpose": "List NFV Service."
+        },
+        "read": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/nfv_services/{name}",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "purpose": "GET NFV Service."
+        },
+        "update": {
+          "method": "PUT",
+          "path": "/api/config/namespaces/{metadata.namespace}/nfv_services/{metadata.name}",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 800,
+            "p95_ms": 2500,
+            "p99_ms": 6000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.metadata.name",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "modifies": [
+              "nfv-service"
+            ]
+          },
+          "purpose": "Replace NFV Service."
+        }
+      }
+    },
+    "nginx_service_discovery": {
+      "resource": "nginx_service_discovery",
+      "base_path": "/api/config/namespaces/{namespace}/nginx_service_discoverys",
+      "operations": {
+        "create": {
+          "method": "POST",
+          "path": "/api/config/namespaces/{metadata.namespace}/nginx_service_discoverys",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 1000,
+            "p95_ms": 3000,
+            "p99_ms": 8000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "metadata.name",
+            "metadata.namespace",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "creates": [
+              "nginx-service-discovery"
+            ]
+          },
+          "purpose": "Create NGINX Service Discovery."
+        },
+        "delete": {
+          "method": "DELETE",
+          "path": "/api/config/namespaces/{namespace}/nginx_service_discoverys/{name}",
+          "danger_level": "high",
+          "discovered_response_time": {
+            "p50_ms": 500,
+            "p95_ms": 1500,
+            "p99_ms": 4000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "confirmation_required": true,
+          "side_effects": {
+            "deletes": [
+              "nginx-service-discovery",
+              "contained_resources"
+            ]
+          },
+          "purpose": "DELETE NGINX Service Discovery."
+        },
+        "list": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/nginx_service_discoverys",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.namespace"
+          ],
+          "purpose": "List NGINX Service Discovery."
+        },
+        "read": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/nginx_service_discoverys/{name}",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "purpose": "GET NGINX Service Discovery."
+        },
+        "update": {
+          "method": "PUT",
+          "path": "/api/config/namespaces/{metadata.namespace}/nginx_service_discoverys/{metadata.name}",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 800,
+            "p95_ms": 2500,
+            "p99_ms": 6000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.metadata.name",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "modifies": [
+              "nginx-service-discovery"
+            ]
+          },
+          "purpose": "Replace NGINX Service Discovery."
+        }
+      }
+    },
+    "origin_pool": {
+      "resource": "origin_pool",
+      "base_path": "/api/config/namespaces/{metadata.namespace}/origin_pools/{metadata.name}",
+      "operations": {
+        "create": {
+          "method": "POST",
+          "path": "/api/config/namespaces/{metadata.namespace}/origin_pools",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 1000,
+            "p95_ms": 3000,
+            "p99_ms": 8000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "metadata.name",
+            "metadata.namespace",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "creates": [
+              "origin-pool"
+            ]
+          },
+          "purpose": "Create Origin Pool."
+        },
+        "delete": {
+          "method": "DELETE",
+          "path": "/api/config/namespaces/{namespace}/origin_pools/{name}",
+          "danger_level": "high",
+          "discovered_response_time": {
+            "p50_ms": 500,
+            "p95_ms": 1500,
+            "p99_ms": 4000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "confirmation_required": true,
+          "side_effects": {
+            "deletes": [
+              "origin-pool",
+              "contained_resources"
+            ]
+          },
+          "purpose": "DELETE Origin Pool."
+        },
+        "list": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/origin_pools",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.namespace"
+          ],
+          "purpose": "List Origin Pool."
+        },
+        "read": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/origin_pools/{name}",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "purpose": "GET Origin Pool."
+        },
+        "update": {
+          "method": "PUT",
+          "path": "/api/config/namespaces/{metadata.namespace}/origin_pools/{metadata.name}",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 800,
+            "p95_ms": 2500,
+            "p99_ms": 6000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.metadata.name",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "modifies": [
+              "origin-pool"
+            ]
+          },
+          "purpose": "Replace Origin Pool."
+        }
+      }
+    },
+    "policer": {
+      "resource": "policer",
+      "base_path": "/api/config/namespaces/{namespace}/policers",
+      "operations": {
+        "create": {
+          "method": "POST",
+          "path": "/api/config/namespaces/{metadata.namespace}/protocol_policers",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 1000,
+            "p95_ms": 3000,
+            "p99_ms": 8000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "metadata.name",
+            "metadata.namespace",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "creates": [
+              "protocol-policer"
+            ]
+          },
+          "purpose": "Create Protocol Policer."
+        },
+        "delete": {
+          "method": "DELETE",
+          "path": "/api/config/namespaces/{namespace}/policers/{name}",
+          "danger_level": "high",
+          "discovered_response_time": {
+            "p50_ms": 500,
+            "p95_ms": 1500,
+            "p99_ms": 4000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "confirmation_required": true,
+          "side_effects": {
+            "deletes": [
+              "policer",
+              "contained_resources"
+            ]
+          },
+          "purpose": "DELETE Policer."
+        },
+        "list": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/protocol_policers",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.namespace"
+          ],
+          "purpose": "List Protocol Policer."
+        },
+        "read": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/policers/{name}",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "purpose": "GET Policer."
+        },
+        "update": {
+          "method": "PUT",
+          "path": "/api/config/namespaces/{metadata.namespace}/policers/{metadata.name}",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 800,
+            "p95_ms": 2500,
+            "p99_ms": 6000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.metadata.name",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "modifies": [
+              "policer"
+            ]
+          },
+          "purpose": "Replace Policer."
+        }
+      }
+    },
+    "policy_based_routing": {
+      "resource": "policy_based_routing",
+      "base_path": "/api/config/namespaces/{namespace}/policy_based_routings",
+      "operations": {
+        "create": {
+          "method": "POST",
+          "path": "/api/config/namespaces/{metadata.namespace}/policy_based_routings",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 1000,
+            "p95_ms": 3000,
+            "p99_ms": 8000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "metadata.name",
+            "metadata.namespace",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "creates": [
+              "policy-based-routing"
+            ]
+          },
+          "purpose": "Create Policy based Routing."
+        },
+        "delete": {
+          "method": "DELETE",
+          "path": "/api/config/namespaces/{namespace}/policy_based_routings/{name}",
+          "danger_level": "high",
+          "discovered_response_time": {
+            "p50_ms": 500,
+            "p95_ms": 1500,
+            "p99_ms": 4000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "confirmation_required": true,
+          "side_effects": {
+            "deletes": [
+              "policy-based-routing",
+              "contained_resources"
+            ]
+          },
+          "purpose": "DELETE Policy based Routing."
+        },
+        "list": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/policy_based_routings",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.namespace"
+          ],
+          "purpose": "List Policy based Routing."
+        },
+        "read": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/policy_based_routings/{name}",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "purpose": "GET Policy based Routing."
+        },
+        "update": {
+          "method": "PUT",
+          "path": "/api/config/namespaces/{metadata.namespace}/policy_based_routings/{metadata.name}",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 800,
+            "p95_ms": 2500,
+            "p99_ms": 6000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.metadata.name",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "modifies": [
+              "policy-based-routing"
+            ]
+          },
+          "purpose": "Replace Policy based Routing."
+        }
+      }
+    },
+    "protocol_inspection": {
+      "resource": "protocol_inspection",
+      "base_path": "/api/config/namespaces/{metadata.namespace}/protocol_inspections/{metadata.name}",
+      "operations": {
+        "create": {
+          "method": "POST",
+          "path": "/api/config/namespaces/{metadata.namespace}/protocol_inspections",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 1000,
+            "p95_ms": 3000,
+            "p99_ms": 8000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "metadata.name",
+            "metadata.namespace",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "creates": [
+              "protocol-inspection"
+            ]
+          },
+          "purpose": "Create Protocol Inspection."
+        },
+        "delete": {
+          "method": "DELETE",
+          "path": "/api/config/namespaces/{namespace}/protocol_inspections/{name}",
+          "danger_level": "high",
+          "discovered_response_time": {
+            "p50_ms": 500,
+            "p95_ms": 1500,
+            "p99_ms": 4000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "confirmation_required": true,
+          "side_effects": {
+            "deletes": [
+              "protocol-inspection",
+              "contained_resources"
+            ]
+          },
+          "purpose": "DELETE Configure Protocol Inspection."
+        },
+        "list": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/protocol_inspections",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.namespace"
+          ],
+          "purpose": "List Configure Protocol Inspection."
+        },
+        "read": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/protocol_inspections/{name}",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "purpose": "GET Protocol Inspection."
+        },
+        "update": {
+          "method": "PUT",
+          "path": "/api/config/namespaces/{metadata.namespace}/protocol_inspections/{metadata.name}",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 800,
+            "p95_ms": 2500,
+            "p99_ms": 6000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.metadata.name",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "modifies": [
+              "protocol-inspection"
+            ]
+          },
+          "purpose": "Replace Protocol Inspection."
+        }
+      }
+    },
+    "protocol_policer": {
+      "resource": "protocol_policer",
+      "base_path": "/api/config/namespaces/{metadata.namespace}/protocol_policers",
+      "operations": {
+        "create": {
+          "method": "POST",
+          "path": "/api/config/namespaces/{metadata.namespace}/protocol_policers",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 1000,
+            "p95_ms": 3000,
+            "p99_ms": 8000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "metadata.name",
+            "metadata.namespace",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "creates": [
+              "protocol-policer"
+            ]
+          },
+          "purpose": "Create Protocol Policer."
+        },
+        "delete": {
+          "method": "DELETE",
+          "path": "/api/config/namespaces/{namespace}/protocol_policers/{name}",
+          "danger_level": "high",
+          "discovered_response_time": {
+            "p50_ms": 500,
+            "p95_ms": 1500,
+            "p99_ms": 4000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "confirmation_required": true,
+          "side_effects": {
+            "deletes": [
+              "protocol-policer",
+              "contained_resources"
+            ]
+          },
+          "purpose": "DELETE Protocol Policer."
+        },
+        "list": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/protocol_policers",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.namespace"
+          ],
+          "purpose": "List Protocol Policer."
+        },
+        "read": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/protocol_policers/{name}",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "purpose": "GET Protocol Policer."
+        },
+        "update": {
+          "method": "PUT",
+          "path": "/api/config/namespaces/{metadata.namespace}/protocol_policers/{metadata.name}",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 800,
+            "p95_ms": 2500,
+            "p99_ms": 6000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.metadata.name",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "modifies": [
+              "protocol-policer"
+            ]
+          },
+          "purpose": "Replace Protocol Policer."
+        }
+      }
+    },
+    "proxy": {
+      "resource": "proxy",
+      "base_path": "/api/config/namespaces/{namespace}/proxys",
+      "operations": {
+        "create": {
+          "method": "POST",
+          "path": "/api/config/namespaces/{metadata.namespace}/proxys",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 1000,
+            "p95_ms": 3000,
+            "p99_ms": 8000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "metadata.name",
+            "metadata.namespace",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "creates": [
+              "proxy"
+            ]
+          },
+          "purpose": "Create Proxy."
+        },
+        "delete": {
+          "method": "DELETE",
+          "path": "/api/config/namespaces/{namespace}/proxys/{name}",
+          "danger_level": "high",
+          "discovered_response_time": {
+            "p50_ms": 500,
+            "p95_ms": 1500,
+            "p99_ms": 4000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "confirmation_required": true,
+          "side_effects": {
+            "deletes": [
+              "proxy",
+              "contained_resources"
+            ]
+          },
+          "purpose": "DELETE Proxy."
+        },
+        "list": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/proxys",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.namespace"
+          ],
+          "purpose": "List Proxy."
+        },
+        "read": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/proxys/{name}/ca_certificate",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "purpose": "GET proxy Server CA Certificate."
+        },
+        "update": {
+          "method": "PUT",
+          "path": "/api/config/namespaces/{metadata.namespace}/proxys/{metadata.name}",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 800,
+            "p95_ms": 2500,
+            "p99_ms": 6000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.metadata.name",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "modifies": [
+              "proxy"
+            ]
+          },
+          "purpose": "Replace Proxy."
+        }
+      }
+    },
+    "rate_limiter": {
+      "resource": "rate_limiter",
+      "base_path": "/api/config/namespaces/{namespace}/rate_limiters/{name}",
+      "operations": {
+        "create": {
+          "method": "POST",
+          "path": "/api/config/namespaces/{metadata.namespace}/rate_limiters",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 1000,
+            "p95_ms": 3000,
+            "p99_ms": 8000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "metadata.name",
+            "metadata.namespace",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "creates": [
+              "rate-limiter"
+            ]
+          },
+          "purpose": "Create Rate Limiter."
+        },
+        "delete": {
+          "method": "DELETE",
+          "path": "/api/config/namespaces/{namespace}/rate_limiters/{name}",
+          "danger_level": "high",
+          "discovered_response_time": {
+            "p50_ms": 500,
+            "p95_ms": 1500,
+            "p99_ms": 4000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "confirmation_required": true,
+          "side_effects": {
+            "deletes": [
+              "rate-limiter",
+              "contained_resources"
+            ]
+          },
+          "purpose": "DELETE Rate Limiter."
+        },
+        "list": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/rate_limiters",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.namespace"
+          ],
+          "purpose": "List Rate Limiter."
+        },
+        "read": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/rate_limiters/{name}",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "purpose": "GET Rate Limiter."
+        },
+        "update": {
+          "method": "PUT",
+          "path": "/api/config/namespaces/{metadata.namespace}/rate_limiters/{metadata.name}",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 800,
+            "p95_ms": 2500,
+            "p99_ms": 6000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.metadata.name",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "modifies": [
+              "rate-limiter"
+            ]
+          },
+          "purpose": "Replace Rate Limiter."
+        }
+      }
+    },
+    "rate_limiter_policy": {
+      "resource": "rate_limiter_policy",
+      "base_path": "/api/config/namespaces/{namespace}/rate_limiter_policys",
+      "operations": {
+        "create": {
+          "method": "POST",
+          "path": "/api/config/namespaces/{metadata.namespace}/rate_limiter_policys",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 1000,
+            "p95_ms": 3000,
+            "p99_ms": 8000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "metadata.name",
+            "metadata.namespace",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "creates": [
+              "rate-limiter-policy"
+            ]
+          },
+          "purpose": "Create Specification."
+        },
+        "delete": {
+          "method": "DELETE",
+          "path": "/api/config/namespaces/{namespace}/rate_limiter_policys/{name}",
+          "danger_level": "high",
+          "discovered_response_time": {
+            "p50_ms": 500,
+            "p95_ms": 1500,
+            "p99_ms": 4000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "confirmation_required": true,
+          "side_effects": {
+            "deletes": [
+              "rate-limiter-policy",
+              "contained_resources"
+            ]
+          },
+          "purpose": "DELETE Rate Limiter Policy."
+        },
+        "list": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/rate_limiter_policys",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.namespace"
+          ],
+          "purpose": "List Rate Limiter Policy."
+        },
+        "read": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/rate_limiter_policys/{name}",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "purpose": "GET Specification."
+        },
+        "update": {
+          "method": "PUT",
+          "path": "/api/config/namespaces/{metadata.namespace}/rate_limiter_policys/{metadata.name}",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 800,
+            "p95_ms": 2500,
+            "p99_ms": 6000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.metadata.name",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "modifies": [
+              "rate-limiter-policy"
+            ]
+          },
+          "purpose": "Replace Specification."
+        }
+      }
+    },
+    "route": {
+      "resource": "route",
+      "base_path": "/api/config/namespaces/{namespace}/routes",
+      "operations": {
+        "create": {
+          "method": "POST",
+          "path": "/api/operate/namespaces/{namespace}/sites/{site}/ver/routes",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 1000,
+            "p95_ms": 3000,
+            "p99_ms": 8000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "metadata.name",
+            "metadata.namespace",
+            "path.namespace",
+            "path.site"
+          ],
+          "side_effects": {
+            "creates": [
+              "route"
+            ]
+          },
+          "purpose": "Show Routes."
+        },
+        "delete": {
+          "method": "DELETE",
+          "path": "/api/config/namespaces/{namespace}/routes/{name}",
+          "danger_level": "high",
+          "discovered_response_time": {
+            "p50_ms": 500,
+            "p95_ms": 1500,
+            "p99_ms": 4000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "confirmation_required": true,
+          "side_effects": {
+            "deletes": [
+              "route",
+              "contained_resources"
+            ]
+          },
+          "purpose": "DELETE Route."
+        },
+        "list": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/routes",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.namespace"
+          ],
+          "purpose": "List Route."
+        },
+        "read": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/routes/{name}",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "purpose": "GET Route"
+        },
+        "update": {
+          "method": "PUT",
+          "path": "/api/config/namespaces/{metadata.namespace}/routes/{metadata.name}",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 800,
+            "p95_ms": 2500,
+            "p99_ms": 6000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.metadata.name",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "modifies": [
+              "route"
+            ]
+          },
+          "purpose": "Replace Route."
+        }
+      }
+    },
+    "secret_management_access": {
+      "resource": "secret_management_access",
+      "base_path": "/api/config/namespaces/{metadata.namespace}/secret_management_accesss/{metadata.name}",
+      "operations": {
+        "create": {
+          "method": "POST",
+          "path": "/api/config/namespaces/{metadata.namespace}/secret_management_accesss",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 1000,
+            "p95_ms": 3000,
+            "p99_ms": 8000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "metadata.name",
+            "metadata.namespace",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "creates": [
+              "secret-management-access"
+            ]
+          },
+          "purpose": "Create Secret Management Access."
+        },
+        "delete": {
+          "method": "DELETE",
+          "path": "/api/config/namespaces/{namespace}/secret_management_accesss/{name}",
+          "danger_level": "high",
+          "discovered_response_time": {
+            "p50_ms": 500,
+            "p95_ms": 1500,
+            "p99_ms": 4000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "confirmation_required": true,
+          "side_effects": {
+            "deletes": [
+              "secret-management-access",
+              "contained_resources"
+            ]
+          },
+          "purpose": "DELETE Secret Management Access."
+        },
+        "list": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/secret_management_accesss",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.namespace"
+          ],
+          "purpose": "List Secret Management Access."
+        },
+        "read": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/secret_management_accesss/{name}",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "purpose": "GET Secret Management Access."
+        },
+        "update": {
+          "method": "PUT",
+          "path": "/api/config/namespaces/{metadata.namespace}/secret_management_accesss/{metadata.name}",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 800,
+            "p95_ms": 2500,
+            "p99_ms": 6000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.metadata.name",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "modifies": [
+              "secret-management-access"
+            ]
+          },
+          "purpose": "Replace Secret Management Access."
+        }
+      }
+    },
+    "securemesh_site": {
+      "resource": "securemesh_site",
+      "base_path": "/api/config/namespaces/{namespace}/securemesh_sites",
+      "operations": {
+        "create": {
+          "method": "POST",
+          "path": "/api/config/namespaces/{metadata.namespace}/securemesh_site_v2s",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 1000,
+            "p95_ms": 3000,
+            "p99_ms": 8000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "metadata.name",
+            "metadata.namespace",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "creates": [
+              "securemesh-site-v2"
+            ]
+          },
+          "purpose": "Create Secure Mesh site."
+        },
+        "delete": {
+          "method": "DELETE",
+          "path": "/api/config/namespaces/{namespace}/securemesh_site_v2s/{name}",
+          "danger_level": "high",
+          "discovered_response_time": {
+            "p50_ms": 500,
+            "p95_ms": 1500,
+            "p99_ms": 4000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "confirmation_required": true,
+          "side_effects": {
+            "deletes": [
+              "securemesh-site-v2",
+              "contained_resources"
+            ]
+          },
+          "purpose": "DELETE Configure Secure Mesh Site."
+        },
+        "list": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/securemesh_site_v2s",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 168,
+            "p95_ms": 336,
+            "p99_ms": 505,
+            "sample_count": 1,
+            "source": "discovery"
+          },
+          "required_fields": [
+            "path.namespace"
+          ],
+          "purpose": "List Configure Secure Mesh Site."
+        },
+        "read": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/securemesh_site_v2s/{name}",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "purpose": "GET Secure Mesh site."
+        },
+        "update": {
+          "method": "PUT",
+          "path": "/api/config/namespaces/{metadata.namespace}/securemesh_site_v2s/{metadata.name}",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 800,
+            "p95_ms": 2500,
+            "p99_ms": 6000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.metadata.name",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "modifies": [
+              "securemesh-site-v2"
+            ]
+          },
+          "purpose": "Replace Secure Mesh site."
+        }
+      }
+    },
+    "segment": {
+      "resource": "segment",
+      "base_path": "/api/config/namespaces/{metadata.namespace}/segments",
+      "operations": {
+        "create": {
+          "method": "POST",
+          "path": "/api/config/namespaces/{metadata.namespace}/segments",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 1000,
+            "p95_ms": 3000,
+            "p99_ms": 8000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "metadata.name",
+            "metadata.namespace",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "creates": [
+              "segment"
+            ]
+          },
+          "purpose": "Create segment."
+        },
+        "delete": {
+          "method": "DELETE",
+          "path": "/api/config/namespaces/{namespace}/segments/{name}",
+          "danger_level": "high",
+          "discovered_response_time": {
+            "p50_ms": 500,
+            "p95_ms": 1500,
+            "p99_ms": 4000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "confirmation_required": true,
+          "side_effects": {
+            "deletes": [
+              "segment",
+              "contained_resources"
+            ]
+          },
+          "purpose": "DELETE Segment."
+        },
+        "list": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/segments",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.namespace"
+          ],
+          "purpose": "List Segment."
+        },
+        "read": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/segments/{name}",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "purpose": "GET segment."
+        },
+        "update": {
+          "method": "PUT",
+          "path": "/api/config/namespaces/{metadata.namespace}/segments/{metadata.name}",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 800,
+            "p95_ms": 2500,
+            "p99_ms": 6000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.metadata.name",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "modifies": [
+              "segment"
+            ]
+          },
+          "purpose": "Replace segment."
+        }
+      }
+    },
+    "sensitive_data_policy": {
+      "resource": "sensitive_data_policy",
+      "base_path": "/api/config/namespaces/{namespace}/sensitive_data_policys",
+      "operations": {
+        "create": {
+          "method": "POST",
+          "path": "/api/config/namespaces/{metadata.namespace}/sensitive_data_policys",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 1000,
+            "p95_ms": 3000,
+            "p99_ms": 8000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "metadata.name",
+            "metadata.namespace",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "creates": [
+              "sensitive-data-policy"
+            ]
+          },
+          "purpose": "Create Sensitive Data Discovery."
+        },
+        "delete": {
+          "method": "DELETE",
+          "path": "/api/config/namespaces/{namespace}/sensitive_data_policys/{name}",
+          "danger_level": "high",
+          "discovered_response_time": {
+            "p50_ms": 500,
+            "p95_ms": 1500,
+            "p99_ms": 4000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "confirmation_required": true,
+          "side_effects": {
+            "deletes": [
+              "sensitive-data-policy",
+              "contained_resources"
+            ]
+          },
+          "purpose": "DELETE Sensitive Data Discovery."
+        },
+        "list": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/sensitive_data_policys",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 159,
+            "p95_ms": 319,
+            "p99_ms": 479,
+            "sample_count": 1,
+            "source": "discovery"
+          },
+          "required_fields": [
+            "path.namespace"
+          ],
+          "purpose": "List Sensitive Data Discovery."
+        },
+        "read": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/sensitive_data_policys/{name}",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "purpose": "GET Sensitive Data Discovery."
+        },
+        "update": {
+          "method": "PUT",
+          "path": "/api/config/namespaces/{metadata.namespace}/sensitive_data_policys/{metadata.name}",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 800,
+            "p95_ms": 2500,
+            "p99_ms": 6000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.metadata.name",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "modifies": [
+              "sensitive-data-policy"
+            ]
+          },
+          "purpose": "Replace Sensitive Data Discovery."
+        }
+      }
+    },
+    "service_policy": {
+      "resource": "service_policy",
+      "base_path": "/api/config/namespaces/{namespace}/service_policys",
+      "operations": {
+        "create": {
+          "method": "POST",
+          "path": "/api/data/namespaces/{namespace}/service_policy/latency",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 1000,
+            "p95_ms": 3000,
+            "p99_ms": 8000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "metadata.name",
+            "metadata.namespace",
+            "path.namespace"
+          ],
+          "side_effects": {
+            "creates": [
+              "latency"
+            ]
+          },
+          "purpose": "Service Policy Latency."
+        },
+        "delete": {
+          "method": "DELETE",
+          "path": "/api/config/namespaces/{namespace}/service_policys/{name}",
+          "danger_level": "high",
+          "discovered_response_time": {
+            "p50_ms": 500,
+            "p95_ms": 1500,
+            "p99_ms": 4000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "confirmation_required": true,
+          "side_effects": {
+            "deletes": [
+              "service-policy",
+              "contained_resources"
+            ]
+          },
+          "purpose": "DELETE Service Policy."
+        },
+        "list": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/service_policys",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.namespace"
+          ],
+          "purpose": "List Service Policy."
+        },
+        "read": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/service_policys/{name}",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "purpose": "GET Service Policy."
+        },
+        "update": {
+          "method": "PUT",
+          "path": "/api/config/namespaces/{metadata.namespace}/service_policys/{metadata.name}",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 800,
+            "p95_ms": 2500,
+            "p99_ms": 6000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.metadata.name",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "modifies": [
+              "service-policy"
+            ]
+          },
+          "purpose": "Replace Service Policy."
+        }
+      }
+    },
+    "service_policy_rule": {
+      "resource": "service_policy_rule",
+      "base_path": "/api/config/namespaces/{namespace}/service_policy_rules/{name}",
+      "operations": {
+        "create": {
+          "method": "POST",
+          "path": "/api/config/namespaces/{metadata.namespace}/service_policy_rules",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 1000,
+            "p95_ms": 3000,
+            "p99_ms": 8000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "metadata.name",
+            "metadata.namespace",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "creates": [
+              "service-policy-rule"
+            ]
+          },
+          "purpose": "Create Service Policy Rule."
+        },
+        "delete": {
+          "method": "DELETE",
+          "path": "/api/config/namespaces/{namespace}/service_policy_rules/{name}",
+          "danger_level": "high",
+          "discovered_response_time": {
+            "p50_ms": 500,
+            "p95_ms": 1500,
+            "p99_ms": 4000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "confirmation_required": true,
+          "side_effects": {
+            "deletes": [
+              "service-policy-rule",
+              "contained_resources"
+            ]
+          },
+          "purpose": "DELETE Service Policy Rule."
+        },
+        "list": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/service_policy_rules",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.namespace"
+          ],
+          "purpose": "List Service Policy Rule."
+        },
+        "read": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/service_policy_rules/{name}",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "purpose": "GET Service Policy Rule."
+        },
+        "update": {
+          "method": "PUT",
+          "path": "/api/config/namespaces/{metadata.namespace}/service_policy_rules/{metadata.name}",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 800,
+            "p95_ms": 2500,
+            "p99_ms": 6000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.metadata.name",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "modifies": [
+              "service-policy-rule"
+            ]
+          },
+          "purpose": "Replace Service Policy Rule."
+        }
+      }
+    },
+    "site": {
+      "resource": "site",
+      "base_path": "/api/config/namespaces/{namespace}/sites/{site}/global_networks",
+      "operations": {
+        "create": {
+          "method": "POST",
+          "path": "/api/config/namespaces/{metadata.namespace}/gcp_vpc_sites",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 1000,
+            "p95_ms": 3000,
+            "p99_ms": 8000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "metadata.name",
+            "metadata.namespace",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "creates": [
+              "gcp-vpc-site"
+            ]
+          },
+          "purpose": "Create GCP VPC site."
+        },
+        "delete": {
+          "method": "DELETE",
+          "path": "/api/config/namespaces/{namespace}/azure_vnet_sites/{name}",
+          "danger_level": "high",
+          "discovered_response_time": {
+            "p50_ms": 500,
+            "p95_ms": 1500,
+            "p99_ms": 4000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "confirmation_required": true,
+          "side_effects": {
+            "deletes": [
+              "azure-vnet-site",
+              "contained_resources"
+            ]
+          },
+          "purpose": "DELETE Configure Azure VNet Site."
+        },
+        "list": {
+          "method": "GET",
+          "path": "/api/data/namespaces/system/site/{site}/api/v1/namespaces/{namespace}/secrets",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 149,
+            "p95_ms": 299,
+            "p99_ms": 448,
+            "sample_count": 1,
+            "source": "discovery"
+          },
+          "required_fields": [
+            "path.namespace",
+            "path.site"
+          ],
+          "purpose": "Secret List."
+        },
+        "read": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/azure_vnet_sites/{name}",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "purpose": "GET Azure VNet site."
+        },
+        "update": {
+          "method": "PUT",
+          "path": "/api/config/namespaces/{metadata.namespace}/gcp_vpc_sites/{metadata.name}",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 800,
+            "p95_ms": 2500,
+            "p99_ms": 6000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.metadata.name",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "modifies": [
+              "gcp-vpc-site"
+            ]
+          },
+          "purpose": "Replace GCP VPC site."
+        }
+      }
+    },
+    "site_mesh_group": {
+      "resource": "site_mesh_group",
+      "base_path": "/api/config/namespaces/{namespace}/site_mesh_groups",
+      "operations": {
+        "create": {
+          "method": "POST",
+          "path": "/api/config/namespaces/{metadata.namespace}/site_mesh_groups",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 1000,
+            "p95_ms": 3000,
+            "p99_ms": 8000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "metadata.name",
+            "metadata.namespace",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "creates": [
+              "site-mesh-group"
+            ]
+          },
+          "purpose": "Create Site Mesh Group."
+        },
+        "delete": {
+          "method": "DELETE",
+          "path": "/api/config/namespaces/{namespace}/site_mesh_groups/{name}",
+          "danger_level": "high",
+          "discovered_response_time": {
+            "p50_ms": 500,
+            "p95_ms": 1500,
+            "p99_ms": 4000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "confirmation_required": true,
+          "side_effects": {
+            "deletes": [
+              "site-mesh-group",
+              "contained_resources"
+            ]
+          },
+          "purpose": "DELETE Site Mesh Group."
+        },
+        "list": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/site_mesh_groups",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.namespace"
+          ],
+          "purpose": "List Site Mesh Group."
+        },
+        "read": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/site_mesh_groups/{name}",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "purpose": "GET Site Mesh Group."
+        },
+        "update": {
+          "method": "PUT",
+          "path": "/api/config/namespaces/{metadata.namespace}/site_mesh_groups/{metadata.name}",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 800,
+            "p95_ms": 2500,
+            "p99_ms": 6000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.metadata.name",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "modifies": [
+              "site-mesh-group"
+            ]
+          },
+          "purpose": "Replace Site Mesh Group."
+        }
+      }
+    },
+    "subnet": {
+      "resource": "subnet",
+      "base_path": "/api/config/namespaces/{namespace}/subnets/{name}",
+      "operations": {
+        "create": {
+          "method": "POST",
+          "path": "/api/config/namespaces/{metadata.namespace}/subnets",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 1000,
+            "p95_ms": 3000,
+            "p99_ms": 8000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "metadata.name",
+            "metadata.namespace",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "creates": [
+              "subnet"
+            ]
+          },
+          "purpose": "Create Subnet."
+        },
+        "delete": {
+          "method": "DELETE",
+          "path": "/api/config/namespaces/{namespace}/subnets/{name}",
+          "danger_level": "high",
+          "discovered_response_time": {
+            "p50_ms": 500,
+            "p95_ms": 1500,
+            "p99_ms": 4000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "confirmation_required": true,
+          "side_effects": {
+            "deletes": [
+              "subnet",
+              "contained_resources"
+            ]
+          },
+          "purpose": "DELETE Subnet."
+        },
+        "list": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/subnets",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.namespace"
+          ],
+          "purpose": "List Subnet."
+        },
+        "read": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/subnets/{name}",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "purpose": "GET Subnet."
+        },
+        "update": {
+          "method": "PUT",
+          "path": "/api/config/namespaces/{metadata.namespace}/subnets/{metadata.name}",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 800,
+            "p95_ms": 2500,
+            "p99_ms": 6000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.metadata.name",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "modifies": [
+              "subnet"
+            ]
+          },
+          "purpose": "Replace Subnet."
+        }
+      }
+    },
+    "tcp_loadbalancer": {
+      "resource": "tcp_loadbalancer",
+      "base_path": "/api/config/namespaces/{metadata.namespace}/tcp_loadbalancers",
+      "operations": {
+        "create": {
+          "method": "POST",
+          "path": "/api/config/namespaces/{metadata.namespace}/tcp_loadbalancers",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 1000,
+            "p95_ms": 3000,
+            "p99_ms": 8000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "metadata.name",
+            "metadata.namespace",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "creates": [
+              "tcp-loadbalancer"
+            ]
+          },
+          "purpose": "Create TCP Load Balancer."
+        },
+        "delete": {
+          "method": "DELETE",
+          "path": "/api/config/namespaces/{namespace}/tcp_loadbalancers/{name}",
+          "danger_level": "high",
+          "discovered_response_time": {
+            "p50_ms": 500,
+            "p95_ms": 1500,
+            "p99_ms": 4000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "confirmation_required": true,
+          "side_effects": {
+            "deletes": [
+              "tcp-loadbalancer",
+              "contained_resources"
+            ]
+          },
+          "purpose": "DELETE Configure TCP Load Balancer."
+        },
+        "list": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/tcp_loadbalancers",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.namespace"
+          ],
+          "purpose": "List Configure TCP Load Balancer."
+        },
+        "read": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/tcp_loadbalancers/{name}/get-dns-info",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "purpose": "GET DNS Info."
+        },
+        "update": {
+          "method": "PUT",
+          "path": "/api/config/namespaces/{metadata.namespace}/tcp_loadbalancers/{metadata.name}",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 800,
+            "p95_ms": 2500,
+            "p99_ms": 6000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.metadata.name",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "modifies": [
+              "tcp-loadbalancer"
+            ]
+          },
+          "purpose": "Replace TCP Load Balancer."
+        }
+      }
+    },
+    "tenant_configuration": {
+      "resource": "tenant_configuration",
+      "base_path": "/api/config/namespaces/{metadata.namespace}/tenant_configurations",
+      "operations": {
+        "create": {
+          "method": "POST",
+          "path": "/api/config/namespaces/{metadata.namespace}/tenant_configurations",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 1000,
+            "p95_ms": 3000,
+            "p99_ms": 8000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "metadata.name",
+            "metadata.namespace",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "creates": [
+              "tenant-configuration"
+            ]
+          },
+          "purpose": "Create tenant configuration."
+        },
+        "delete": {
+          "method": "DELETE",
+          "path": "/api/config/namespaces/{namespace}/tenant_configurations/{name}",
+          "danger_level": "high",
+          "discovered_response_time": {
+            "p50_ms": 500,
+            "p95_ms": 1500,
+            "p99_ms": 4000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "confirmation_required": true,
+          "side_effects": {
+            "deletes": [
+              "tenant-configuration",
+              "contained_resources"
+            ]
+          },
+          "purpose": "DELETE Tenant Configuration."
+        },
+        "list": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/tenant_configurations",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.namespace"
+          ],
+          "purpose": "List Tenant Configuration."
+        },
+        "read": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/tenant_configurations/{name}",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "purpose": "GET tenant configuration."
+        },
+        "update": {
+          "method": "PUT",
+          "path": "/api/config/namespaces/{metadata.namespace}/tenant_configurations/{metadata.name}",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 800,
+            "p95_ms": 2500,
+            "p99_ms": 6000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.metadata.name",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "modifies": [
+              "tenant-configuration"
+            ]
+          },
+          "purpose": "Replace tenant configuration."
+        }
+      }
+    },
+    "trusted_ca_list": {
+      "resource": "trusted_ca_list",
+      "base_path": "/api/config/namespaces/{namespace}/trusted_ca_lists",
+      "operations": {
+        "create": {
+          "method": "POST",
+          "path": "/api/config/namespaces/{metadata.namespace}/trusted_ca_lists",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 1000,
+            "p95_ms": 3000,
+            "p99_ms": 8000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "metadata.name",
+            "metadata.namespace",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "creates": [
+              "trusted-ca-list"
+            ]
+          },
+          "purpose": "Create Root CA Certificate."
+        },
+        "delete": {
+          "method": "DELETE",
+          "path": "/api/config/namespaces/{namespace}/trusted_ca_lists/{name}",
+          "danger_level": "high",
+          "discovered_response_time": {
+            "p50_ms": 500,
+            "p95_ms": 1500,
+            "p99_ms": 4000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "confirmation_required": true,
+          "side_effects": {
+            "deletes": [
+              "trusted-ca-list",
+              "contained_resources"
+            ]
+          },
+          "purpose": "DELETE Root CA Certificate."
+        },
+        "list": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/trusted_ca_lists",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.namespace"
+          ],
+          "purpose": "List Root CA Certificate."
+        },
+        "read": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/trusted_ca_lists/{name}",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "purpose": "GET Root CA Certificate."
+        },
+        "update": {
+          "method": "PUT",
+          "path": "/api/config/namespaces/{metadata.namespace}/trusted_ca_lists/{metadata.name}",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 800,
+            "p95_ms": 2500,
+            "p99_ms": 6000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.metadata.name",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "modifies": [
+              "trusted-ca-list"
+            ]
+          },
+          "purpose": "Replace Root CA Certificate."
+        }
+      }
+    },
+    "tunnel": {
+      "resource": "tunnel",
+      "base_path": "/api/config/namespaces/{metadata.namespace}/tunnels/{metadata.name}",
+      "operations": {
+        "create": {
+          "method": "POST",
+          "path": "/api/config/namespaces/{metadata.namespace}/tunnels",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 1000,
+            "p95_ms": 3000,
+            "p99_ms": 8000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "metadata.name",
+            "metadata.namespace",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "creates": [
+              "tunnel"
+            ]
+          },
+          "purpose": "Create Tunnel."
+        },
+        "delete": {
+          "method": "DELETE",
+          "path": "/api/config/namespaces/{namespace}/tunnels/{name}",
+          "danger_level": "high",
+          "discovered_response_time": {
+            "p50_ms": 500,
+            "p95_ms": 1500,
+            "p99_ms": 4000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "confirmation_required": true,
+          "side_effects": {
+            "deletes": [
+              "tunnel",
+              "contained_resources"
+            ]
+          },
+          "purpose": "DELETE Tunnel."
+        },
+        "list": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/tunnels",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.namespace"
+          ],
+          "purpose": "List Tunnel."
+        },
+        "read": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/tunnels/{name}",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "purpose": "GET Tunnel."
+        },
+        "update": {
+          "method": "PUT",
+          "path": "/api/config/namespaces/{metadata.namespace}/tunnels/{metadata.name}",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 800,
+            "p95_ms": 2500,
+            "p99_ms": 6000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.metadata.name",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "modifies": [
+              "tunnel"
+            ]
+          },
+          "purpose": "Replace Tunnel."
+        }
+      }
+    },
+    "udp_loadbalancer": {
+      "resource": "udp_loadbalancer",
+      "base_path": "/api/config/namespaces/{metadata.namespace}/udp_loadbalancers",
+      "operations": {
+        "create": {
+          "method": "POST",
+          "path": "/api/config/namespaces/{metadata.namespace}/udp_loadbalancers",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 1000,
+            "p95_ms": 3000,
+            "p99_ms": 8000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "metadata.name",
+            "metadata.namespace",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "creates": [
+              "udp-loadbalancer"
+            ]
+          },
+          "purpose": "Create UDP Load Balancer."
+        },
+        "delete": {
+          "method": "DELETE",
+          "path": "/api/config/namespaces/{namespace}/udp_loadbalancers/{name}",
+          "danger_level": "high",
+          "discovered_response_time": {
+            "p50_ms": 500,
+            "p95_ms": 1500,
+            "p99_ms": 4000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "confirmation_required": true,
+          "side_effects": {
+            "deletes": [
+              "udp-loadbalancer",
+              "contained_resources"
+            ]
+          },
+          "purpose": "DELETE Configure UDP Load Balancer."
+        },
+        "list": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/udp_loadbalancers",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.namespace"
+          ],
+          "purpose": "List Configure UDP Load Balancer."
+        },
+        "read": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/udp_loadbalancers/{name}/get-dns-info",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "purpose": "GET DNS Info."
+        },
+        "update": {
+          "method": "PUT",
+          "path": "/api/config/namespaces/{metadata.namespace}/udp_loadbalancers/{metadata.name}",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 800,
+            "p95_ms": 2500,
+            "p99_ms": 6000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.metadata.name",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "modifies": [
+              "udp-loadbalancer"
+            ]
+          },
+          "purpose": "Replace UDP Load Balancer."
+        }
+      }
+    },
+    "usb_policy": {
+      "resource": "usb_policy",
+      "base_path": "/api/config/namespaces/{namespace}/usb_policys",
+      "operations": {
+        "create": {
+          "method": "POST",
+          "path": "/api/config/namespaces/{metadata.namespace}/usb_policys",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 1000,
+            "p95_ms": 3000,
+            "p99_ms": 8000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "metadata.name",
+            "metadata.namespace",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "creates": [
+              "usb-policy"
+            ]
+          },
+          "purpose": "Create USB policy."
+        },
+        "delete": {
+          "method": "DELETE",
+          "path": "/api/config/namespaces/{namespace}/usb_policys/{name}",
+          "danger_level": "high",
+          "discovered_response_time": {
+            "p50_ms": 500,
+            "p95_ms": 1500,
+            "p99_ms": 4000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "confirmation_required": true,
+          "side_effects": {
+            "deletes": [
+              "usb-policy",
+              "contained_resources"
+            ]
+          },
+          "purpose": "DELETE USB policy."
+        },
+        "list": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/usb_policys",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 153,
+            "p95_ms": 306,
+            "p99_ms": 459,
+            "sample_count": 1,
+            "source": "discovery"
+          },
+          "required_fields": [
+            "path.namespace"
+          ],
+          "purpose": "List USB policy."
+        },
+        "read": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/usb_policys/{name}",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "purpose": "GET USB policy."
+        },
+        "update": {
+          "method": "PUT",
+          "path": "/api/config/namespaces/{metadata.namespace}/usb_policys/{metadata.name}",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 800,
+            "p95_ms": 2500,
+            "p99_ms": 6000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.metadata.name",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "modifies": [
+              "usb-policy"
+            ]
+          },
+          "purpose": "Replace USB policy."
+        }
+      }
+    },
+    "user_identification": {
+      "resource": "user_identification",
+      "base_path": "/api/config/namespaces/{namespace}/user_identifications",
+      "operations": {
+        "create": {
+          "method": "POST",
+          "path": "/api/config/namespaces/{metadata.namespace}/user_identifications",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 1000,
+            "p95_ms": 3000,
+            "p99_ms": 8000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "metadata.name",
+            "metadata.namespace",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "creates": [
+              "user-identification"
+            ]
+          },
+          "purpose": "Create User Identification."
+        },
+        "delete": {
+          "method": "DELETE",
+          "path": "/api/config/namespaces/{namespace}/user_identifications/{name}",
+          "danger_level": "high",
+          "discovered_response_time": {
+            "p50_ms": 500,
+            "p95_ms": 1500,
+            "p99_ms": 4000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "confirmation_required": true,
+          "side_effects": {
+            "deletes": [
+              "user-identification",
+              "contained_resources"
+            ]
+          },
+          "purpose": "DELETE User Identification."
+        },
+        "list": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/user_identifications",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 152,
+            "p95_ms": 305,
+            "p99_ms": 458,
+            "sample_count": 1,
+            "source": "discovery"
+          },
+          "required_fields": [
+            "path.namespace"
+          ],
+          "purpose": "List User Identification."
+        },
+        "read": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/user_identifications/{name}",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "purpose": "GET User Identification."
+        },
+        "update": {
+          "method": "PUT",
+          "path": "/api/config/namespaces/{metadata.namespace}/user_identifications/{metadata.name}",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 800,
+            "p95_ms": 2500,
+            "p99_ms": 6000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.metadata.name",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "modifies": [
+              "user-identification"
+            ]
+          },
+          "purpose": "Replace User Identification."
+        }
+      }
+    },
+    "virtual_host": {
+      "resource": "virtual_host",
+      "base_path": "/api/ml/data/namespaces/{namespace}/virtual_hosts/{name}/api_endpoint/learnt_schema",
+      "operations": {
+        "create": {
+          "method": "POST",
+          "path": "/api/config/namespaces/{namespace}/virtual_hosts/{name}/api_definitions/assign",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 1000,
+            "p95_ms": 3000,
+            "p99_ms": 8000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "metadata.name",
+            "metadata.namespace",
+            "path.name",
+            "path.namespace"
+          ],
+          "side_effects": {
+            "creates": [
+              "assign"
+            ]
+          },
+          "purpose": "Assign API Definition."
+        },
+        "delete": {
+          "method": "DELETE",
+          "path": "/api/config/namespaces/{namespace}/virtual_hosts/{name}",
+          "danger_level": "high",
+          "discovered_response_time": {
+            "p50_ms": 500,
+            "p95_ms": 1500,
+            "p99_ms": 4000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "confirmation_required": true,
+          "side_effects": {
+            "deletes": [
+              "virtual-host",
+              "contained_resources"
+            ]
+          },
+          "purpose": "DELETE Virtual Host."
+        },
+        "list": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/virtual_hosts",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.namespace"
+          ],
+          "purpose": "List Virtual Host."
+        },
+        "read": {
+          "method": "GET",
+          "path": "/api/ml/data/namespaces/{namespace}/virtual_hosts/{name}/api_endpoints",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "purpose": "GET API Endpoints."
+        },
+        "update": {
+          "method": "PUT",
+          "path": "/api/config/namespaces/{metadata.namespace}/virtual_hosts/{metadata.name}",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 800,
+            "p95_ms": 2500,
+            "p99_ms": 6000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.metadata.name",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "modifies": [
+              "virtual-host"
+            ]
+          },
+          "purpose": "Replace Virtual Host."
+        }
+      }
+    },
+    "virtual_network": {
+      "resource": "virtual_network",
+      "base_path": "/api/config/namespaces/{namespace}/virtual_networks/{name}",
+      "operations": {
+        "create": {
+          "method": "POST",
+          "path": "/api/config/namespaces/{metadata.namespace}/virtual_networks",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 1000,
+            "p95_ms": 3000,
+            "p99_ms": 8000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "metadata.name",
+            "metadata.namespace",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "creates": [
+              "virtual-network"
+            ]
+          },
+          "purpose": "Create Virtual Network."
+        },
+        "delete": {
+          "method": "DELETE",
+          "path": "/api/config/namespaces/{namespace}/virtual_networks/{name}",
+          "danger_level": "high",
+          "discovered_response_time": {
+            "p50_ms": 500,
+            "p95_ms": 1500,
+            "p99_ms": 4000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "confirmation_required": true,
+          "side_effects": {
+            "deletes": [
+              "virtual-network",
+              "contained_resources"
+            ]
+          },
+          "purpose": "DELETE Virtual Network."
+        },
+        "list": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/virtual_networks",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.namespace"
+          ],
+          "purpose": "List Virtual Network."
+        },
+        "read": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/virtual_networks/{name}",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "purpose": "GET Virtual Network."
+        },
+        "update": {
+          "method": "PUT",
+          "path": "/api/config/namespaces/{metadata.namespace}/virtual_networks/{metadata.name}",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 800,
+            "p95_ms": 2500,
+            "p99_ms": 6000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.metadata.name",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "modifies": [
+              "virtual-network"
+            ]
+          },
+          "purpose": "Replace Virtual Network."
+        }
+      }
+    },
+    "virtual_site": {
+      "resource": "virtual_site",
+      "base_path": "/api/config/namespaces/{metadata.namespace}/virtual_sites/{metadata.name}",
+      "operations": {
+        "create": {
+          "method": "POST",
+          "path": "/api/config/namespaces/{metadata.namespace}/virtual_sites",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 1000,
+            "p95_ms": 3000,
+            "p99_ms": 8000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "metadata.name",
+            "metadata.namespace",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "creates": [
+              "virtual-site"
+            ]
+          },
+          "purpose": "Create Virtual Site."
+        },
+        "delete": {
+          "method": "DELETE",
+          "path": "/api/config/namespaces/{namespace}/virtual_sites/{name}",
+          "danger_level": "high",
+          "discovered_response_time": {
+            "p50_ms": 500,
+            "p95_ms": 1500,
+            "p99_ms": 4000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "confirmation_required": true,
+          "side_effects": {
+            "deletes": [
+              "virtual-site",
+              "contained_resources"
+            ]
+          },
+          "purpose": "DELETE Virtual Site."
+        },
+        "list": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/virtual_sites",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.namespace"
+          ],
+          "purpose": "List Virtual Site."
+        },
+        "read": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/virtual_sites/{name}/selectees",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "purpose": "GET Selectees."
+        },
+        "update": {
+          "method": "PUT",
+          "path": "/api/config/namespaces/{metadata.namespace}/virtual_sites/{metadata.name}",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 800,
+            "p95_ms": 2500,
+            "p99_ms": 6000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.metadata.name",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "modifies": [
+              "virtual-site"
+            ]
+          },
+          "purpose": "Replace Virtual Site."
+        }
+      }
+    },
+    "voltstack_site": {
+      "resource": "voltstack_site",
+      "base_path": "/api/config/namespaces/{namespace}/voltstack_sites",
+      "operations": {
+        "create": {
+          "method": "POST",
+          "path": "/api/config/namespaces/{metadata.namespace}/voltstack_sites",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 1000,
+            "p95_ms": 3000,
+            "p99_ms": 8000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "metadata.name",
+            "metadata.namespace",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "creates": [
+              "voltstack-site"
+            ]
+          },
+          "purpose": "Create App Stack site."
+        },
+        "delete": {
+          "method": "DELETE",
+          "path": "/api/config/namespaces/{namespace}/voltstack_sites/{name}",
+          "danger_level": "high",
+          "discovered_response_time": {
+            "p50_ms": 500,
+            "p95_ms": 1500,
+            "p99_ms": 4000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "confirmation_required": true,
+          "side_effects": {
+            "deletes": [
+              "voltstack-site",
+              "contained_resources"
+            ]
+          },
+          "purpose": "DELETE Configure App Stack Site."
+        },
+        "list": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/voltstack_sites",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 190,
+            "p95_ms": 380,
+            "p99_ms": 570,
+            "sample_count": 1,
+            "source": "discovery"
+          },
+          "required_fields": [
+            "path.namespace"
+          ],
+          "purpose": "List Configure App Stack Site."
+        },
+        "read": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/voltstack_sites/{name}",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "purpose": "GET App Stack site."
+        },
+        "update": {
+          "method": "PUT",
+          "path": "/api/config/namespaces/{metadata.namespace}/voltstack_sites/{metadata.name}",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 800,
+            "p95_ms": 2500,
+            "p99_ms": 6000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.metadata.name",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "modifies": [
+              "voltstack-site"
+            ]
+          },
+          "purpose": "Replace App Stack site."
+        }
+      }
+    },
+    "waf_exclusion_policy": {
+      "resource": "waf_exclusion_policy",
+      "base_path": "/api/config/namespaces/{namespace}/waf_exclusion_policys",
+      "operations": {
+        "create": {
+          "method": "POST",
+          "path": "/api/config/namespaces/{metadata.namespace}/waf_exclusion_policys",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 1000,
+            "p95_ms": 3000,
+            "p99_ms": 8000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "metadata.name",
+            "metadata.namespace",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "creates": [
+              "waf-exclusion-policy"
+            ]
+          },
+          "purpose": "Create WAF Exclusion Policy."
+        },
+        "delete": {
+          "method": "DELETE",
+          "path": "/api/config/namespaces/{namespace}/waf_exclusion_policys/{name}",
+          "danger_level": "high",
+          "discovered_response_time": {
+            "p50_ms": 500,
+            "p95_ms": 1500,
+            "p99_ms": 4000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "confirmation_required": true,
+          "side_effects": {
+            "deletes": [
+              "waf-exclusion-policy",
+              "contained_resources"
+            ]
+          },
+          "purpose": "DELETE WAF Exclusion Policy."
+        },
+        "list": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/waf_exclusion_policys",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.namespace"
+          ],
+          "purpose": "List WAF Exclusion Policy."
+        },
+        "read": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/waf_exclusion_policys/{name}",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "purpose": "GET WAF Exclusion Policy."
+        },
+        "update": {
+          "method": "PUT",
+          "path": "/api/config/namespaces/{metadata.namespace}/waf_exclusion_policys/{metadata.name}",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 800,
+            "p95_ms": 2500,
+            "p99_ms": 6000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.metadata.name",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "modifies": [
+              "waf-exclusion-policy"
+            ]
+          },
+          "purpose": "Replace WAF Exclusion Policy."
+        }
+      }
+    },
+    "workload": {
+      "resource": "workload",
+      "base_path": "/api/config/namespaces/{metadata.namespace}/workloads",
+      "operations": {
+        "create": {
+          "method": "POST",
+          "path": "/api/config/namespaces/{metadata.namespace}/workloads",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 1000,
+            "p95_ms": 3000,
+            "p99_ms": 8000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "metadata.name",
+            "metadata.namespace",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "creates": [
+              "workload"
+            ]
+          },
+          "purpose": "Create Workload."
+        },
+        "delete": {
+          "method": "DELETE",
+          "path": "/api/config/namespaces/{namespace}/workloads/{name}",
+          "danger_level": "high",
+          "discovered_response_time": {
+            "p50_ms": 500,
+            "p95_ms": 1500,
+            "p99_ms": 4000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "confirmation_required": true,
+          "side_effects": {
+            "deletes": [
+              "workload",
+              "contained_resources"
+            ]
+          },
+          "purpose": "DELETE Workload."
+        },
+        "list": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/workload_flavors",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 155,
+            "p95_ms": 311,
+            "p99_ms": 467,
+            "sample_count": 1,
+            "source": "discovery"
+          },
+          "required_fields": [
+            "path.namespace"
+          ],
+          "purpose": "List Workload Flavor."
+        },
+        "read": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/workloads/{name}",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "purpose": "GET Workload."
+        },
+        "update": {
+          "method": "PUT",
+          "path": "/api/config/namespaces/{metadata.namespace}/workload_flavors/{metadata.name}",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 800,
+            "p95_ms": 2500,
+            "p99_ms": 6000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.metadata.name",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "modifies": [
+              "workload-flavor"
+            ]
+          },
+          "purpose": "Replace Flavor."
+        }
+      }
+    },
+    "workload_flavor": {
+      "resource": "workload_flavor",
+      "base_path": "/api/config/namespaces/{namespace}/workload_flavors/{name}",
+      "operations": {
+        "create": {
+          "method": "POST",
+          "path": "/api/config/namespaces/{metadata.namespace}/workload_flavors",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 1000,
+            "p95_ms": 3000,
+            "p99_ms": 8000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "metadata.name",
+            "metadata.namespace",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "creates": [
+              "workload-flavor"
+            ]
+          },
+          "purpose": "Create Workload Flavor."
+        },
+        "delete": {
+          "method": "DELETE",
+          "path": "/api/config/namespaces/{namespace}/workload_flavors/{name}",
+          "danger_level": "high",
+          "discovered_response_time": {
+            "p50_ms": 500,
+            "p95_ms": 1500,
+            "p99_ms": 4000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "confirmation_required": true,
+          "side_effects": {
+            "deletes": [
+              "workload-flavor",
+              "contained_resources"
+            ]
+          },
+          "purpose": "DELETE Workload Flavor."
+        },
+        "list": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/workload_flavors",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 155,
+            "p95_ms": 311,
+            "p99_ms": 467,
+            "sample_count": 1,
+            "source": "discovery"
+          },
+          "required_fields": [
+            "path.namespace"
+          ],
+          "purpose": "List Workload Flavor."
+        },
+        "read": {
+          "method": "GET",
+          "path": "/api/config/namespaces/{namespace}/workload_flavors/{name}",
+          "danger_level": "low",
+          "discovered_response_time": {
+            "p50_ms": 200,
+            "p95_ms": 800,
+            "p99_ms": 2000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.name",
+            "path.namespace"
+          ],
+          "purpose": "GET Workload Flavor."
+        },
+        "update": {
+          "method": "PUT",
+          "path": "/api/config/namespaces/{metadata.namespace}/workload_flavors/{metadata.name}",
+          "danger_level": "medium",
+          "discovered_response_time": {
+            "p50_ms": 800,
+            "p95_ms": 2500,
+            "p99_ms": 6000,
+            "sample_count": 0,
+            "source": "estimate"
+          },
+          "required_fields": [
+            "path.metadata.name",
+            "path.metadata.namespace"
+          ],
+          "side_effects": {
+            "modifies": [
+              "workload-flavor"
+            ]
+          },
+          "purpose": "Replace Flavor."
+        }
+      }
+    }
+  }
+}

--- a/tools/metadata/resource-metadata.json
+++ b/tools/metadata/resource-metadata.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-01-17T01:50:31Z",
+  "generated_at": "2026-01-17T09:45:45Z",
   "version": "1.0.0",
   "resources": {
     "address_allocator": {
@@ -4475,23 +4475,8 @@
       }
     },
     "discovery": {
-      "description": "Manages a Discovery resource in F5 Distributed Cloud for api to create discovery object for a site or virtual site in system namespace. configuration.",
+      "description": "Manages API discovery creates a new object in the storage backend for metadata.namespace. in F5 Distributed Cloud.",
       "import_format": "namespace/name",
-      "oneof_groups": {
-        "cluster_identifier_choice": {
-          "fields": [
-            "cluster_id",
-            "no_cluster_id"
-          ],
-          "default": "no_cluster_id"
-        },
-        "discovery_choice": {
-          "fields": [
-            "discovery_consul",
-            "discovery_k8s"
-          ]
-        }
-      },
       "attributes": {
         "annotations": {
           "type": "map",
@@ -4499,14 +4484,12 @@
           "optional": true,
           "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata."
         },
-        "cluster_id": {
-          "type": "string",
+        "custom_auth_types": {
+          "type": "list",
           "required": false,
           "optional": true,
-          "computed": true,
-          "plan_modifier": "UseStateForUnknown",
-          "oneof_group": "cluster_identifier_choice",
-          "description": "[OneOf: cluster_id, no_cluster_id; Default: no_cluster_id] Specify identifier for discovery cluster. This identifier can be specified in endpoint object to discover only from this discovery object."
+          "is_block": true,
+          "description": "Select your custom authentication types to be detected in the API discovery."
         },
         "description": {
           "type": "string",
@@ -4519,22 +4502,6 @@
           "required": false,
           "optional": true,
           "description": "A value of true will administratively disable the object."
-        },
-        "discovery_consul": {
-          "type": "object",
-          "required": false,
-          "optional": true,
-          "is_block": true,
-          "oneof_group": "discovery_choice",
-          "description": "[OneOf: discovery_consul, discovery_k8s] Discovery configuration for Hashicorp Consul."
-        },
-        "discovery_k8s": {
-          "type": "object",
-          "required": false,
-          "optional": true,
-          "is_block": true,
-          "oneof_group": "discovery_choice",
-          "description": "K8s Discovery Configuration. Discovery configuration for K8s."
         },
         "id": {
           "type": "string",
@@ -4562,21 +4529,6 @@
           "plan_modifier": "RequiresReplace",
           "validation": "name",
           "description": "Namespace where the Discovery will be created."
-        },
-        "no_cluster_id": {
-          "type": "object",
-          "required": false,
-          "optional": true,
-          "is_block": true,
-          "oneof_group": "cluster_identifier_choice",
-          "description": "Enable this option"
-        },
-        "where": {
-          "type": "object",
-          "required": false,
-          "optional": true,
-          "is_block": true,
-          "description": "NetworkSiteRefSelector defines a union of reference to site or reference to virtual_network or reference to virtual_site It is used to determine virtual network using following rules * Direct reference to virtual_network object * Site local network when refering to site object * All site local.."
         }
       }
     },
@@ -5056,24 +5008,17 @@
       }
     },
     "fast_acl": {
-      "description": "Manages new Fast ACL rule, has specification to match source IP, source port and action to apply. in F5 Distributed Cloud.",
+      "description": "Manages object, object contains rules to protect site from denial of service It has destination{destination IP, destination port) and references to. in F5 Distributed Cloud.",
       "import_format": "namespace/name",
       "oneof_groups": {
-        "source": {
+        "site_choice": {
           "fields": [
-            "ip_prefix_set",
-            "prefix"
+            "re_acl",
+            "site_acl"
           ]
         }
       },
       "attributes": {
-        "action": {
-          "type": "object",
-          "required": false,
-          "optional": true,
-          "is_block": true,
-          "description": "FastAclRuleAction specifies possible action to be applied on traffic, possible action include dropping, forwarding or ratelimiting the traffic."
-        },
         "annotations": {
           "type": "map",
           "required": false,
@@ -5099,14 +5044,6 @@
           "plan_modifier": "UseStateForUnknown",
           "description": "Unique identifier for the resource."
         },
-        "ip_prefix_set": {
-          "type": "object",
-          "required": false,
-          "optional": true,
-          "is_block": true,
-          "oneof_group": "source",
-          "description": "[OneOf: ip_prefix_set, prefix] List of references to ip_prefix_set objects."
-        },
         "labels": {
           "type": "map",
           "required": false,
@@ -5127,21 +5064,28 @@
           "validation": "name",
           "description": "Namespace where the Fast ACL will be created."
         },
-        "port": {
-          "type": "list",
-          "required": false,
-          "optional": true,
-          "is_block": true,
-          "validation": "port",
-          "description": "Source Ports. L4 port numbers to match ."
-        },
-        "prefix": {
+        "protocol_policer": {
           "type": "object",
           "required": false,
           "optional": true,
           "is_block": true,
-          "oneof_group": "source",
-          "description": "List of IP Address prefixes. Prefix must contain both prefix and prefix-length The list can contain mix of both IPv4 and IPv6 prefixes."
+          "description": "Type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name."
+        },
+        "re_acl": {
+          "type": "object",
+          "required": false,
+          "optional": true,
+          "is_block": true,
+          "oneof_group": "site_choice",
+          "description": "[OneOf: re_acl, site_acl] Fast ACL for RE. Fast ACL definition for RE."
+        },
+        "site_acl": {
+          "type": "object",
+          "required": false,
+          "optional": true,
+          "is_block": true,
+          "oneof_group": "site_choice",
+          "description": "Fast ACL for Site. Fast ACL definition for Site."
         }
       }
     },
@@ -7600,7 +7544,7 @@
       }
     },
     "irule": {
-      "description": "Manages iRule in a given namespace. If one already exists it will give an error. in F5 Distributed Cloud.",
+      "description": "Manages a Irule resource in F5 Distributed Cloud for desired state for big-ip irule service. configuration.",
       "import_format": "namespace/name",
       "attributes": {
         "annotations": {
@@ -7609,13 +7553,19 @@
           "optional": true,
           "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata."
         },
-        "description": {
+        "code": {
           "type": "string",
           "required": false,
           "optional": true,
           "computed": true,
           "plan_modifier": "UseStateForUnknown",
-          "description": "Specify Description for iRule ."
+          "description": "IRule code content, this content will be base64 encoded for preserving formating."
+        },
+        "description": {
+          "type": "string",
+          "required": false,
+          "optional": true,
+          "description": "Human readable description for the object."
         },
         "disable": {
           "type": "bool",
@@ -7630,13 +7580,13 @@
           "plan_modifier": "UseStateForUnknown",
           "description": "Unique identifier for the resource."
         },
-        "irule": {
+        "irule_name": {
           "type": "string",
           "required": false,
           "optional": true,
           "computed": true,
           "plan_modifier": "UseStateForUnknown",
-          "description": "Www.internal.example.f5.com')} DNS::drop} irule content ."
+          "description": "IRule name. IRule name."
         },
         "labels": {
           "type": "map",
@@ -7657,23 +7607,52 @@
           "plan_modifier": "RequiresReplace",
           "validation": "name",
           "description": "Namespace where the Irule will be created."
+        },
+        "source": {
+          "type": "string",
+          "required": false,
+          "optional": true,
+          "computed": true,
+          "plan_modifier": "UseStateForUnknown",
+          "description": "IRule source. IRule generation/updation source."
         }
       }
     },
     "log_receiver": {
-      "description": "Manages new Log Receiver object. in F5 Distributed Cloud.",
+      "description": "Manages new Global Log Receiver object. in F5 Distributed Cloud.",
       "category": "Monitoring",
       "tier": "Standard",
       "import_format": "namespace/name",
       "oneof_groups": {
-        "log_receiver_choice": {
+        "filter_choice": {
           "fields": [
-            "syslog"
+            "ns_all",
+            "ns_current",
+            "ns_list"
           ]
         },
-        "where_choice": {
+        "log_type": {
           "fields": [
-            "site_local"
+            "audit_logs",
+            "dns_logs",
+            "request_logs",
+            "security_events"
+          ]
+        },
+        "receiver": {
+          "fields": [
+            "aws_cloud_watch_receiver",
+            "azure_event_hubs_receiver",
+            "azure_receiver",
+            "datadog_receiver",
+            "gcp_bucket_receiver",
+            "http_receiver",
+            "kafka_receiver",
+            "new_relic_receiver",
+            "qradar_receiver",
+            "s3_receiver",
+            "splunk_receiver",
+            "sumo_logic_receiver"
           ]
         }
       },
@@ -7683,6 +7662,46 @@
           "required": false,
           "optional": true,
           "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata."
+        },
+        "audit_logs": {
+          "type": "object",
+          "required": false,
+          "optional": true,
+          "is_block": true,
+          "oneof_group": "log_type",
+          "description": "[OneOf: audit_logs, dns_logs, request_logs, security_events] Enable this option"
+        },
+        "aws_cloud_watch_receiver": {
+          "type": "object",
+          "required": false,
+          "optional": true,
+          "is_block": true,
+          "oneof_group": "receiver",
+          "description": "[OneOf: aws_cloud_watch_receiver, azure_event_hubs_receiver, azure_receiver, datadog_receiver, gcp_bucket_receiver, http_receiver, kafka_receiver, new_relic_receiver, qradar_receiver, s3_receiver, splunk_receiver, sumo_logic_receiver] AWS Cloudwatch Logs Configuration for Global Log Receiver."
+        },
+        "azure_event_hubs_receiver": {
+          "type": "object",
+          "required": false,
+          "optional": true,
+          "is_block": true,
+          "oneof_group": "receiver",
+          "description": "Azure Event Hubs Configuration for Global Log Receiver."
+        },
+        "azure_receiver": {
+          "type": "object",
+          "required": false,
+          "optional": true,
+          "is_block": true,
+          "oneof_group": "receiver",
+          "description": "Azure Blob Configuration for Global Log Receiver."
+        },
+        "datadog_receiver": {
+          "type": "object",
+          "required": false,
+          "optional": true,
+          "is_block": true,
+          "oneof_group": "receiver",
+          "description": "Datadog Configuration. Configuration for Datadog endpoint."
         },
         "description": {
           "type": "string",
@@ -7696,12 +7715,44 @@
           "optional": true,
           "description": "A value of true will administratively disable the object."
         },
+        "dns_logs": {
+          "type": "object",
+          "required": false,
+          "optional": true,
+          "is_block": true,
+          "oneof_group": "log_type",
+          "description": "Enable this option"
+        },
+        "gcp_bucket_receiver": {
+          "type": "object",
+          "required": false,
+          "optional": true,
+          "is_block": true,
+          "oneof_group": "receiver",
+          "description": "GCP Bucket Configuration for Global Log Receiver."
+        },
+        "http_receiver": {
+          "type": "object",
+          "required": false,
+          "optional": true,
+          "is_block": true,
+          "oneof_group": "receiver",
+          "description": "HTTP Configuration. Configuration for HTTP endpoint."
+        },
         "id": {
           "type": "string",
           "required": false,
           "computed": true,
           "plan_modifier": "UseStateForUnknown",
           "description": "Unique identifier for the resource."
+        },
+        "kafka_receiver": {
+          "type": "object",
+          "required": false,
+          "optional": true,
+          "is_block": true,
+          "oneof_group": "receiver",
+          "description": "Kafka Configuration for Global Log Receiver."
         },
         "labels": {
           "type": "map",
@@ -7723,21 +7774,85 @@
           "validation": "name",
           "description": "Namespace where the Log Receiver will be created."
         },
-        "site_local": {
+        "new_relic_receiver": {
           "type": "object",
           "required": false,
           "optional": true,
           "is_block": true,
-          "oneof_group": "where_choice",
+          "oneof_group": "receiver",
+          "description": "NewRelic Configuration. Configuration for NewRelic endpoint."
+        },
+        "ns_all": {
+          "type": "object",
+          "required": false,
+          "optional": true,
+          "is_block": true,
+          "oneof_group": "filter_choice",
+          "description": "[OneOf: ns_all, ns_current, ns_list] Enable this option"
+        },
+        "ns_current": {
+          "type": "object",
+          "required": false,
+          "optional": true,
+          "is_block": true,
+          "oneof_group": "filter_choice",
           "description": "Enable this option"
         },
-        "syslog": {
+        "ns_list": {
           "type": "object",
           "required": false,
           "optional": true,
           "is_block": true,
-          "oneof_group": "log_receiver_choice",
-          "description": "Syslog Server Configuration. Configuration for syslog server."
+          "oneof_group": "filter_choice",
+          "description": "Namespace List. Namespace List."
+        },
+        "qradar_receiver": {
+          "type": "object",
+          "required": false,
+          "optional": true,
+          "is_block": true,
+          "oneof_group": "receiver",
+          "description": "IBM QRadar Configuration. Configuration for IBM QRadar endpoint."
+        },
+        "request_logs": {
+          "type": "object",
+          "required": false,
+          "optional": true,
+          "is_block": true,
+          "oneof_group": "log_type",
+          "description": "Enable this option"
+        },
+        "s3_receiver": {
+          "type": "object",
+          "required": false,
+          "optional": true,
+          "is_block": true,
+          "oneof_group": "receiver",
+          "description": "S3 Configuration for Global Log Receiver."
+        },
+        "security_events": {
+          "type": "object",
+          "required": false,
+          "optional": true,
+          "is_block": true,
+          "oneof_group": "log_type",
+          "description": "Enable this option"
+        },
+        "splunk_receiver": {
+          "type": "object",
+          "required": false,
+          "optional": true,
+          "is_block": true,
+          "oneof_group": "receiver",
+          "description": "Configuration for Splunk HEC Logs endpoint."
+        },
+        "sumo_logic_receiver": {
+          "type": "object",
+          "required": false,
+          "optional": true,
+          "is_block": true,
+          "oneof_group": "receiver",
+          "description": "SumoLogic Configuration. Configuration for SumoLogic endpoint."
         }
       }
     },
@@ -8278,11 +8393,35 @@
       }
     },
     "network_policy": {
-      "description": "Manages a Network Policy resource in F5 Distributed Cloud for network policy view specification. configuration.",
+      "description": "Manages network policy rule with configured parameters in specified namespace. in F5 Distributed Cloud.",
       "category": "Security",
       "tier": "Standard",
       "import_format": "namespace/name",
+      "oneof_groups": {
+        "remote_endpoint": {
+          "fields": [
+            "ip_prefix_set",
+            "prefix",
+            "prefix_selector"
+          ]
+        }
+      },
       "attributes": {
+        "action": {
+          "type": "string",
+          "required": false,
+          "optional": true,
+          "computed": true,
+          "plan_modifier": "UseStateForUnknown",
+          "description": "[Enum: DENY|ALLOW] Network policy rule action configures the action to be taken on rule match Apply deny action on rule match Apply allow action on rule match. Possible values are `DENY`, `ALLOW`. Defaults to `DENY`."
+        },
+        "advanced_action": {
+          "type": "object",
+          "required": false,
+          "optional": true,
+          "is_block": true,
+          "description": "Network Policy Rule Advanced Action provides additional OPTIONS along with RuleAction and PBRRuleAction."
+        },
         "annotations": {
           "type": "map",
           "required": false,
@@ -8301,20 +8440,6 @@
           "optional": true,
           "description": "A value of true will administratively disable the object."
         },
-        "egress_rules": {
-          "type": "list",
-          "required": false,
-          "optional": true,
-          "is_block": true,
-          "description": "Ordered list of rules applied to connections from policy endpoints."
-        },
-        "endpoint": {
-          "type": "object",
-          "required": false,
-          "optional": true,
-          "is_block": true,
-          "description": "Shape of the endpoint choices for a view."
-        },
         "id": {
           "type": "string",
           "required": false,
@@ -8322,12 +8447,20 @@
           "plan_modifier": "UseStateForUnknown",
           "description": "Unique identifier for the resource."
         },
-        "ingress_rules": {
-          "type": "list",
+        "ip_prefix_set": {
+          "type": "object",
           "required": false,
           "optional": true,
           "is_block": true,
-          "description": "Ordered list of rules applied to connections to policy endpoints."
+          "oneof_group": "remote_endpoint",
+          "description": "[OneOf: ip_prefix_set, prefix, prefix_selector] List of references to ip_prefix_set objects."
+        },
+        "label_matcher": {
+          "type": "object",
+          "required": false,
+          "optional": true,
+          "is_block": true,
+          "description": "Label matcher specifies a list of label keys whose values need to match for source/client and destination/server. Note that the actual label values are not specified and do not matter. This allows an ability to scope grouping by the label key name."
         },
         "labels": {
           "type": "map",
@@ -8348,6 +8481,36 @@
           "plan_modifier": "RequiresReplace",
           "validation": "name",
           "description": "Namespace where the Network Policy will be created."
+        },
+        "ports": {
+          "type": "list",
+          "required": false,
+          "optional": true,
+          "description": "List of port ranges. Each range is a single port or a pair of start and end ports e.g. 8080-8192."
+        },
+        "prefix": {
+          "type": "object",
+          "required": false,
+          "optional": true,
+          "is_block": true,
+          "oneof_group": "remote_endpoint",
+          "description": "List of IP Address prefixes. Prefix must contain both prefix and prefix-length The list can contain mix of both IPv4 and IPv6 prefixes."
+        },
+        "prefix_selector": {
+          "type": "object",
+          "required": false,
+          "optional": true,
+          "is_block": true,
+          "oneof_group": "remote_endpoint",
+          "description": "Type can be used to establish a 'selector reference' from one object(called selector) to a set of other objects(called selectees) based on the value of expresssions. A label selector is a label query over a set of resources. An empty label selector matches all objects."
+        },
+        "protocol": {
+          "type": "string",
+          "required": false,
+          "optional": true,
+          "computed": true,
+          "plan_modifier": "UseStateForUnknown",
+          "description": "Protocol in IP packet to be used as match criteria Values are TCP, UDP, and icmp."
         }
       }
     },
@@ -8918,7 +9081,7 @@
       }
     },
     "policer": {
-      "description": "Manages new policer with traffic rate limits. in F5 Distributed Cloud.",
+      "description": "Manages protocol_policer object, protocol_policer object contains list of L4 protocol match condition and corresponding traffic rate limits. in F5 Distributed Cloud.",
       "import_format": "namespace/name",
       "attributes": {
         "annotations": {
@@ -8926,22 +9089,6 @@
           "required": false,
           "optional": true,
           "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata."
-        },
-        "burst_size": {
-          "type": "int64",
-          "required": false,
-          "optional": true,
-          "computed": true,
-          "plan_modifier": "UseStateForUnknown",
-          "description": "The maximum size permitted for bursts of data. E.g. 10000 pps burst ."
-        },
-        "committed_information_rate": {
-          "type": "int64",
-          "required": false,
-          "optional": true,
-          "computed": true,
-          "plan_modifier": "UseStateForUnknown",
-          "description": "The committed information rate is the guaranteed packets rate for traffic arriving or departing under normal conditions. E.g. 10000 pps ."
         },
         "description": {
           "type": "string",
@@ -8982,21 +9129,12 @@
           "validation": "name",
           "description": "Namespace where the Policer will be created."
         },
-        "policer_mode": {
-          "type": "string",
+        "protocol_policer": {
+          "type": "list",
           "required": false,
           "optional": true,
-          "computed": true,
-          "plan_modifier": "UseStateForUnknown",
-          "description": "[Enum: POLICER_MODE_NOT_SHARED|POLICER_MODE_SHARED] - POLICER_MODE_NOT_SHARED: Not Shared A separate policer instance is created for each reference to the policer - POLICER_MODE_SHARED: Shared A common policer instance is used for for all references to the policer. Possible values are `POLICER_MODE_NOT_SHARED`, `POLICER_MODE_SHARED`. Defaults to `POLICER_MODE_NOT_SHARED`."
-        },
-        "policer_type": {
-          "type": "string",
-          "required": false,
-          "optional": true,
-          "computed": true,
-          "plan_modifier": "UseStateForUnknown",
-          "description": "[Enum: POLICER_SINGLE_RATE_TWO_COLOR] Specifies the type of Policer Basic Single-Rate Two-Color Policer. The only possible value is `POLICER_SINGLE_RATE_TWO_COLOR`. Defaults to `POLICER_SINGLE_RATE_TWO_COLOR`."
+          "is_block": true,
+          "description": "List of L4 protocol match condition and associated traffic rate limits."
         }
       }
     },
@@ -10204,8 +10342,8 @@
       },
       "dependencies": {
         "referenced_by": [
-          "app_firewall",
-          "http_loadbalancer"
+          "http_loadbalancer",
+          "app_firewall"
         ]
       }
     },
@@ -10542,33 +10680,10 @@
       }
     },
     "site": {
-      "description": "Manages a Site resource in F5 Distributed Cloud for aws tgw site specification. configuration.",
+      "description": "Manages virtual site object in given namespace. in F5 Distributed Cloud.",
       "category": "Infrastructure",
       "tier": "Standard",
       "import_format": "namespace/name",
-      "oneof_groups": {
-        "blocked_services_choice": {
-          "fields": [
-            "block_all_services",
-            "blocked_services",
-            "default_blocked_services"
-          ],
-          "default": "default_blocked_services"
-        },
-        "direct_connect_choice": {
-          "fields": [
-            "direct_connect_disabled",
-            "direct_connect_enabled",
-            "private_connectivity"
-          ]
-        },
-        "logs_receiver_choice": {
-          "fields": [
-            "log_receiver",
-            "logs_streaming_disabled"
-          ]
-        }
-      },
       "attributes": {
         "annotations": {
           "type": "map",
@@ -10576,72 +10691,11 @@
           "optional": true,
           "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata."
         },
-        "aws_parameters": {
-          "type": "object",
-          "required": false,
-          "optional": true,
-          "is_block": true,
-          "description": "Setup AWS services VPC, transit gateway and site."
-        },
-        "block_all_services": {
-          "type": "object",
-          "required": false,
-          "optional": true,
-          "is_block": true,
-          "oneof_group": "blocked_services_choice",
-          "description": "[OneOf: block_all_services, blocked_services, default_blocked_services; Default: default_blocked_services] Enable this option"
-        },
-        "blocked_services": {
-          "type": "object",
-          "required": false,
-          "optional": true,
-          "is_block": true,
-          "oneof_group": "blocked_services_choice",
-          "description": "Disable node local services on this site."
-        },
-        "coordinates": {
-          "type": "object",
-          "required": false,
-          "optional": true,
-          "is_block": true,
-          "description": "Coordinates of the site which provides the site physical location."
-        },
-        "custom_dns": {
-          "type": "object",
-          "required": false,
-          "optional": true,
-          "is_block": true,
-          "description": "Custom DNS is the configured for specify CE site."
-        },
-        "default_blocked_services": {
-          "type": "object",
-          "required": false,
-          "optional": true,
-          "is_block": true,
-          "oneof_group": "blocked_services_choice",
-          "description": "Enable this option"
-        },
         "description": {
           "type": "string",
           "required": false,
           "optional": true,
           "description": "Human readable description for the object."
-        },
-        "direct_connect_disabled": {
-          "type": "object",
-          "required": false,
-          "optional": true,
-          "is_block": true,
-          "oneof_group": "direct_connect_choice",
-          "description": "[OneOf: direct_connect_disabled, direct_connect_enabled, private_connectivity] Enable this option"
-        },
-        "direct_connect_enabled": {
-          "type": "object",
-          "required": false,
-          "optional": true,
-          "is_block": true,
-          "oneof_group": "direct_connect_choice",
-          "description": "Direct Connect Configuration. Direct Connect Configuration."
         },
         "disable": {
           "type": "bool",
@@ -10656,34 +10710,11 @@
           "plan_modifier": "UseStateForUnknown",
           "description": "Unique identifier for the resource."
         },
-        "kubernetes_upgrade_drain": {
-          "type": "object",
-          "required": false,
-          "optional": true,
-          "is_block": true,
-          "description": "Specify how worker nodes within a site will be upgraded."
-        },
         "labels": {
           "type": "map",
           "required": false,
           "optional": true,
           "description": "Labels is a user defined key value map that can be attached to resources for organization and filtering."
-        },
-        "log_receiver": {
-          "type": "object",
-          "required": false,
-          "optional": true,
-          "is_block": true,
-          "oneof_group": "logs_receiver_choice",
-          "description": "[OneOf: log_receiver, logs_streaming_disabled] Type establishes a direct reference from one object(the referrer) to another(the referred). Such a reference is in form of tenant/namespace/name."
-        },
-        "logs_streaming_disabled": {
-          "type": "object",
-          "required": false,
-          "optional": true,
-          "is_block": true,
-          "oneof_group": "logs_receiver_choice",
-          "description": "Enable this option"
         },
         "name": {
           "type": "string",
@@ -10699,69 +10730,20 @@
           "validation": "name",
           "description": "Namespace where the Site will be created."
         },
-        "offline_survivability_mode": {
+        "site_selector": {
           "type": "object",
           "required": false,
           "optional": true,
           "is_block": true,
-          "description": "Offline Survivability allows the Site to continue functioning normally without traffic loss during periods of connectivity loss to the Regional Edge (RE) or the Global Controller (GC). When this feature is enabled, a site can continue to function as is with existing configuration for upto 7.."
+          "description": "Type can be used to establish a 'selector reference' from one object(called selector) to a set of other objects(called selectees) based on the value of expresssions. A label selector is a label query over a set of resources. An empty label selector matches all objects."
         },
-        "os": {
-          "type": "object",
+        "site_type": {
+          "type": "string",
           "required": false,
           "optional": true,
-          "is_block": true,
-          "description": "Select the F5XC Operating System Version for the site. By default, latest available OS Version will be used. Refer to release notes to find required released OS versions."
-        },
-        "performance_enhancement_mode": {
-          "type": "object",
-          "required": false,
-          "optional": true,
-          "is_block": true,
-          "description": "Optimize the site for L3 or L7 traffic processing. L7 optimized is the default."
-        },
-        "private_connectivity": {
-          "type": "object",
-          "required": false,
-          "optional": true,
-          "is_block": true,
-          "oneof_group": "direct_connect_choice",
-          "description": "Private Connect Configuration. Private Connect Configuration."
-        },
-        "sw": {
-          "type": "object",
-          "required": false,
-          "optional": true,
-          "is_block": true,
-          "description": "Select the F5XC Software Version for the site. By default, latest available F5XC Software Version will be used. Refer to release notes to find required released SW versions."
-        },
-        "tags": {
-          "type": "object",
-          "required": false,
-          "optional": true,
-          "is_block": true,
-          "description": "AWS Tags is a label consisting of a user-defined key and value. It helps to manage, identify, organize, search for, and filter resources in AWS console."
-        },
-        "tgw_security": {
-          "type": "object",
-          "required": false,
-          "optional": true,
-          "is_block": true,
-          "description": "Security Configuration for transit gateway."
-        },
-        "vn_config": {
-          "type": "object",
-          "required": false,
-          "optional": true,
-          "is_block": true,
-          "description": "Virtual Network Configuration. Virtual Network Configuration."
-        },
-        "vpc_attachments": {
-          "type": "object",
-          "required": false,
-          "optional": true,
-          "is_block": true,
-          "description": "Spoke VPCs to be attached to the AWS TGW Site."
+          "computed": true,
+          "plan_modifier": "UseStateForUnknown",
+          "description": "[Enum: INVALID|REGIONAL_EDGE|CUSTOMER_EDGE|NGINX_ONE] Site Type which can either RE or CE Invalid type of site Regional Edge site Customer Edge site. Possible values are `INVALID`, `REGIONAL_EDGE`, `CUSTOMER_EDGE`, `NGINX_ONE`."
         }
       },
       "dependencies": {

--- a/tools/transform-docs.go
+++ b/tools/transform-docs.go
@@ -401,6 +401,23 @@ const serverDefaultIndicator = "⚙️ **Server Default**"
 // serverDefaultMarker is the text pattern added by generate-all-schemas.go to identify server default fields
 const serverDefaultMarker = "Server applies default when omitted."
 
+// dangerLevelIndicators maps operation danger levels to visual indicators
+// Used for marking resource operations that require extra caution
+var dangerLevelIndicators = map[string]string{
+	"low":      "",     // No indicator for low risk
+	"medium":   "⚠️",   // Warning for medium risk
+	"high":     "🔶",   // Orange diamond for high risk
+	"critical": "🔴",   // Red circle for critical risk
+}
+
+// formatDangerLevelIndicator returns the visual indicator for a danger level
+func formatDangerLevelIndicator(dangerLevel string) string {
+	if indicator, ok := dangerLevelIndicators[dangerLevel]; ok {
+		return indicator
+	}
+	return ""
+}
+
 // formatServerDefaultNote transforms the server default marker in descriptions into a visual indicator.
 // The marker "Server applies default when omitted." is replaced with a styled badge.
 func formatServerDefaultNote(description string) string {


### PR DESCRIPTION
## Summary

Add support for extracting and surfacing operation-level metadata from enriched API specs v2.0.33.

## Related Issue

Closes #899

## Changes Made

### Generator (`tools/generate-all-schemas.go`)
- Add operation metadata types: `OperationsMetadataCollection`, `ResourceOperationInfo`, `OperationMetadata`, `ResponseTimeInfo`, `SideEffectsInfo`, `BestPracticesInfo`, `GuidedWorkflowInfo`, `WorkflowStepInfo`
- Add extraction functions: `collectOperationMetadata`, `mapMethodToOperationType`, `extractOperationMetadataFromRaw`, `extractBestPracticesFromRaw`, `extractGuidedWorkflowsFromRaw`
- Output `operations-metadata.json` alongside existing metadata files

### MCP Server (`mcp-server/src/`)
- Add TypeScript types in `types.ts` for operation metadata
- Add `OperationsService` class in `services/operations.ts` with methods:
  - `getResourceOperations()` - Get all operation metadata for a resource
  - `getDangerLevel()` - Get danger level for an operation
  - `getSideEffects()` - Get side effects for an operation
  - `getResponseTime()` - Get response time metrics
  - `requiresConfirmation()` - Check if operation needs confirmation
  - `getHighDangerOperations()` - Get all high/critical danger operations
  - `getSummary()` - Get statistics about operation metadata

### Transform-docs (`tools/transform-docs.go`)
- Add `dangerLevelIndicators` map for visual indicators
- Add `formatDangerLevelIndicator()` function

## New Extensions Supported

| Extension | Purpose |
|-----------|---------|
| `x-f5xc-danger-level` | Risk classification (low/medium/high/critical) |
| `x-f5xc-discovered-response-time` | API latency metrics (p50/p95/p99) |
| `x-f5xc-required-fields` | Required field paths per operation |
| `x-f5xc-confirmation-required` | Operations needing user confirmation |
| `x-f5xc-side-effects` | Resources affected by operations |
| `x-f5xc-best-practices` | Recommended configurations |
| `x-f5xc-guided-workflows` | Step-by-step creation guidance |

## Operations Metadata Statistics

```
Total Resources: 99
Total Operations: 493
Danger Levels:
  - Low: 198 (read/list operations)
  - Medium: 197 (create/update operations)
  - High: 98 (delete operations)
Confirmation Required: 98 operations
```

## Testing

- [x] Generator compiles and runs successfully
- [x] MCP server builds successfully
- [x] Pre-commit hooks pass
- [x] Generated metadata file validates as JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)