### PR TITLE
feat(mcp): add E2E determinism validation with terraform fmt tests

### DIFF
--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -33,6 +33,8 @@
     "test:e2e": "vitest run tests/acceptance/resource-creation.test.ts tests/acceptance/determinism.test.ts --reporter=verbose",
     "test:e2e:resource-creation": "vitest run tests/acceptance/resource-creation.test.ts --reporter=verbose",
     "test:e2e:determinism": "vitest run tests/acceptance/determinism.test.ts --reporter=verbose",
+    "test:e2e:all": "./scripts/run-e2e-tests.sh",
+    "generate:ml-matrix": "tsx tests/fixtures/ml-training/generate-matrix.ts",
     "validate:auth": "tsx scripts/validate-auth-integration.ts"
   },
   "keywords": [

--- a/mcp-server/scripts/run-e2e-tests.sh
+++ b/mcp-server/scripts/run-e2e-tests.sh
@@ -1,0 +1,225 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
+# E2E Determinism Test Runner
+# Validates MCP server produces deterministic, production-ready Terraform
+#
+# Prerequisites:
+#   - F5XC_API_URL and F5XC_API_TOKEN environment variables
+#   - Terraform CLI installed
+#   - Node.js 18+
+#
+# Usage:
+#   ./scripts/run-e2e-tests.sh [--verbose] [--skip-build]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Flags
+VERBOSE=false
+SKIP_BUILD=false
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --verbose|-v)
+      VERBOSE=true
+      shift
+      ;;
+    --skip-build)
+      SKIP_BUILD=true
+      shift
+      ;;
+    --help|-h)
+      echo "Usage: $0 [--verbose] [--skip-build]"
+      echo ""
+      echo "Options:"
+      echo "  --verbose, -v    Show detailed test output"
+      echo "  --skip-build     Skip npm build step"
+      echo "  --help, -h       Show this help message"
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1"
+      exit 1
+      ;;
+  esac
+done
+
+log_info() {
+  echo -e "${BLUE}[INFO]${NC} $1"
+}
+
+log_success() {
+  echo -e "${GREEN}[SUCCESS]${NC} $1"
+}
+
+log_warn() {
+  echo -e "${YELLOW}[WARN]${NC} $1"
+}
+
+log_error() {
+  echo -e "${RED}[ERROR]${NC} $1"
+}
+
+# Check prerequisites
+check_prerequisites() {
+  log_info "Checking prerequisites..."
+
+  # Check Node.js
+  if ! command -v node &> /dev/null; then
+    log_error "Node.js is not installed"
+    exit 1
+  fi
+  NODE_VERSION=$(node --version | cut -d'v' -f2 | cut -d'.' -f1)
+  if [[ $NODE_VERSION -lt 18 ]]; then
+    log_error "Node.js 18+ required, found $(node --version)"
+    exit 1
+  fi
+  log_success "Node.js $(node --version)"
+
+  # Check npm
+  if ! command -v npm &> /dev/null; then
+    log_error "npm is not installed"
+    exit 1
+  fi
+  log_success "npm $(npm --version)"
+
+  # Check Terraform
+  if ! command -v terraform &> /dev/null; then
+    log_warn "Terraform CLI not installed - some tests will be skipped"
+  else
+    log_success "Terraform $(terraform version -json | jq -r '.terraform_version')"
+  fi
+
+  # Check F5XC credentials
+  if [[ -z "${F5XC_API_URL:-}" ]] && [[ -z "${F5XC_TEST_API_URL:-}" ]]; then
+    log_warn "F5XC_API_URL not set - E2E tests requiring API will be skipped"
+  else
+    local api_url="${F5XC_API_URL:-${F5XC_TEST_API_URL}}"
+    log_success "F5XC_API_URL: ${api_url}"
+  fi
+
+  if [[ -z "${F5XC_API_TOKEN:-}" ]] && [[ -z "${F5XC_TEST_API_TOKEN:-}" ]]; then
+    log_warn "F5XC_API_TOKEN not set - E2E tests requiring API will be skipped"
+  else
+    log_success "F5XC_API_TOKEN: ***configured***"
+  fi
+
+  echo ""
+}
+
+# Build project
+build_project() {
+  if [[ "$SKIP_BUILD" == "true" ]]; then
+    log_info "Skipping build (--skip-build flag)"
+    return
+  fi
+
+  log_info "Building MCP server..."
+  cd "$PROJECT_DIR"
+
+  npm ci --silent
+  npm run build
+
+  log_success "Build complete"
+  echo ""
+}
+
+# Run unit tests
+run_unit_tests() {
+  log_info "Running unit tests..."
+  cd "$PROJECT_DIR"
+
+  if [[ "$VERBOSE" == "true" ]]; then
+    npm run test -- tests/unit/ --reporter=verbose
+  else
+    npm run test -- tests/unit/ --reporter=dot
+  fi
+
+  log_success "Unit tests passed"
+  echo ""
+}
+
+# Run determinism tests
+run_determinism_tests() {
+  log_info "Running determinism tests..."
+  cd "$PROJECT_DIR"
+
+  if [[ "$VERBOSE" == "true" ]]; then
+    npm run test:e2e:determinism -- --reporter=verbose
+  else
+    npm run test:e2e:determinism -- --reporter=default
+  fi
+
+  log_success "Determinism tests passed"
+  echo ""
+}
+
+# Run resource creation tests (if credentials available)
+run_resource_creation_tests() {
+  local api_url="${F5XC_API_URL:-${F5XC_TEST_API_URL:-}}"
+  local api_token="${F5XC_API_TOKEN:-${F5XC_TEST_API_TOKEN:-}}"
+
+  if [[ -z "$api_url" ]] || [[ -z "$api_token" ]]; then
+    log_warn "Skipping resource creation tests (no credentials)"
+    return
+  fi
+
+  log_info "Running resource creation tests..."
+  cd "$PROJECT_DIR"
+
+  if [[ "$VERBOSE" == "true" ]]; then
+    npm run test:e2e:resource-creation -- --reporter=verbose
+  else
+    npm run test:e2e:resource-creation -- --reporter=default
+  fi
+
+  log_success "Resource creation tests passed"
+  echo ""
+}
+
+# Generate ML training matrix
+generate_ml_matrix() {
+  log_info "Generating ML training matrix..."
+  cd "$PROJECT_DIR"
+
+  if [[ -f "package.json" ]] && grep -q "generate:ml-matrix" package.json; then
+    npm run generate:ml-matrix
+    log_success "ML training matrix generated"
+  else
+    log_warn "generate:ml-matrix script not found, skipping"
+  fi
+  echo ""
+}
+
+# Main execution
+main() {
+  echo ""
+  echo "=========================================="
+  echo " F5XC Terraform MCP - E2E Test Suite"
+  echo "=========================================="
+  echo ""
+
+  check_prerequisites
+  build_project
+  run_unit_tests
+  run_determinism_tests
+  run_resource_creation_tests
+  generate_ml_matrix
+
+  echo "=========================================="
+  log_success "All E2E tests completed successfully!"
+  echo "=========================================="
+}
+
+main "$@"

--- a/mcp-server/tests/fixtures/ml-training/generate-matrix.ts
+++ b/mcp-server/tests/fixtures/ml-training/generate-matrix.ts
@@ -1,0 +1,181 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
+/**
+ * ML Training Matrix Generator
+ *
+ * Generates a reproducible input→output mapping for ML training context.
+ * Uses MCP server metadata to create known outcomes for all supported resources.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+
+// Import MCP metadata handler
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// Navigate to dist directory
+const distPath = path.resolve(__dirname, '../../../dist');
+
+interface ResourceEntry {
+  prompt_templates: string[];
+  expected_terraform: string;
+  mcp_syntax: Record<string, unknown> | null;
+  mcp_oneof_groups: string[];
+  terraform_validate: 'success' | 'pending' | 'error';
+  terraform_fmt: 'formatted' | 'pending' | 'error';
+}
+
+interface MLTrainingMatrix {
+  version: string;
+  generated_at: string;
+  provider: string;
+  resources: Record<string, ResourceEntry>;
+}
+
+// Resources to include in ML training matrix
+const TRAINING_RESOURCES = [
+  'namespace',
+  'origin_pool',
+  'http_loadbalancer',
+  'healthcheck',
+  'app_firewall',
+  'tcp_loadbalancer',
+  'service_policy',
+  'route',
+  'virtual_host',
+  'certificate',
+  'dns_zone',
+  'dns_record',
+  'alert_policy',
+  'alert_receiver',
+  'forward_proxy_policy',
+  'network_policy',
+  'rate_limiter_policy',
+  'waf_exclusion_policy',
+  'user_identification',
+  'fast_acl',
+  'fast_acl_rule',
+  'service_policy_rule',
+];
+
+async function generateMatrix(): Promise<void> {
+  console.log('Loading MCP metadata handler...');
+
+  // Dynamic import of the metadata module
+  const metadataModule = await import(path.join(distPath, 'tools/metadata.js'));
+  const { handleMetadata } = metadataModule;
+
+  const matrix: MLTrainingMatrix = {
+    version: '3.20.0',
+    generated_at: new Date().toISOString(),
+    provider: 'robinmordasiewicz/f5xc',
+    resources: {},
+  };
+
+  const examplesDir = path.join(__dirname, 'mcp-outputs/examples');
+
+  console.log(`Processing ${TRAINING_RESOURCES.length} resources...`);
+
+  for (const resource of TRAINING_RESOURCES) {
+    console.log(`  - ${resource}`);
+
+    try {
+      // Get example from MCP
+      const exampleResult = await handleMetadata({
+        operation: 'example',
+        resource,
+        pattern: 'basic',
+        response_format: 'json',
+      });
+
+      // handleMetadata returns a string directly
+      const example = typeof exampleResult === 'string' ? exampleResult : '';
+
+      // Get syntax info
+      let syntax: Record<string, unknown> | null = null;
+      try {
+        const syntaxResult = await handleMetadata({
+          operation: 'syntax',
+          resource,
+          response_format: 'json',
+        });
+        if (typeof syntaxResult === 'string') {
+          try {
+            syntax = JSON.parse(syntaxResult);
+          } catch {
+            // Not valid JSON, skip
+          }
+        }
+      } catch {
+        // Syntax not available for this resource
+      }
+
+      // Get oneof groups
+      let oneofGroups: string[] = [];
+      try {
+        const oneofResult = await handleMetadata({
+          operation: 'oneof',
+          resource,
+          response_format: 'json',
+        });
+        if (typeof oneofResult === 'string') {
+          try {
+            const parsed = JSON.parse(oneofResult);
+            if (Array.isArray(parsed)) {
+              oneofGroups = parsed.map((g: { name?: string }) => g.name || '').filter(Boolean);
+            }
+          } catch {
+            // Not valid JSON, skip
+          }
+        }
+      } catch {
+        // OneOf not available for this resource
+      }
+
+      // Create prompt templates
+      const promptTemplates = [
+        `Create a Terraform configuration for ${resource.replace(/_/g, ' ')} called {name}`,
+        `Using f5xc-terraform MCP, generate ${resource} resource with name {name}`,
+      ];
+
+      matrix.resources[resource] = {
+        prompt_templates: promptTemplates,
+        expected_terraform: example,
+        mcp_syntax: syntax,
+        mcp_oneof_groups: oneofGroups,
+        terraform_validate: example ? 'pending' : 'error',
+        terraform_fmt: example ? 'pending' : 'error',
+      };
+
+      // Write example to file
+      if (example) {
+        const examplePath = path.join(examplesDir, `${resource}.tf`);
+        fs.writeFileSync(examplePath, example);
+      }
+    } catch (error) {
+      console.error(`    Error processing ${resource}:`, error);
+      matrix.resources[resource] = {
+        prompt_templates: [],
+        expected_terraform: '',
+        mcp_syntax: null,
+        mcp_oneof_groups: [],
+        terraform_validate: 'error',
+        terraform_fmt: 'error',
+      };
+    }
+  }
+
+  // Write matrix to file
+  const matrixPath = path.join(__dirname, 'ml-training-matrix.json');
+  fs.writeFileSync(matrixPath, JSON.stringify(matrix, null, 2));
+
+  console.log(`\nGenerated ML training matrix:`);
+  console.log(`  - Resources: ${Object.keys(matrix.resources).length}`);
+  console.log(`  - Output: ${matrixPath}`);
+  console.log(`  - Examples: ${examplesDir}`);
+}
+
+// Run generator
+generateMatrix().catch(console.error);

--- a/mcp-server/tests/prompts/http-lb-public.txt
+++ b/mcp-server/tests/prompts/http-lb-public.txt
@@ -1,0 +1,10 @@
+Using the f5xc-terraform MCP server, create a Terraform configuration for an HTTP load balancer on a public VIP.
+
+Requirements:
+- Use the f5xc_terraform_metadata tool with operation=example to get the correct syntax
+- The load balancer should be named "test-http-lb"
+- Use a public VIP (advertise_on_internet)
+- Configure a domain: test.example.com
+- Reference an origin pool (can use a placeholder reference)
+- Only output the Terraform configuration, no explanations
+- Ensure the output passes terraform fmt validation

--- a/mcp-server/tests/prompts/namespace-basic.txt
+++ b/mcp-server/tests/prompts/namespace-basic.txt
@@ -1,0 +1,7 @@
+Using the f5xc-terraform MCP server, create a Terraform configuration for a namespace called "test-ns".
+
+Requirements:
+- Use the f5xc_terraform_metadata tool with operation=example to get the correct syntax
+- The namespace should be named "test-ns"
+- Only output the Terraform configuration, no explanations
+- Ensure the output passes terraform fmt validation

--- a/mcp-server/tests/prompts/origin-pool-https.txt
+++ b/mcp-server/tests/prompts/origin-pool-https.txt
@@ -1,0 +1,9 @@
+Using the f5xc-terraform MCP server, create a Terraform configuration for an origin pool with TLS.
+
+Requirements:
+- Use the f5xc_terraform_metadata tool with operation=example to get the correct syntax
+- The origin pool should be named "test-origin-pool"
+- Connect to example.com on port 443
+- Enable TLS with automatic certificate verification
+- Only output the Terraform configuration, no explanations
+- Ensure the output passes terraform fmt validation

--- a/mcp-server/tests/prompts/waf-enabled-lb.txt
+++ b/mcp-server/tests/prompts/waf-enabled-lb.txt
@@ -1,0 +1,11 @@
+Using the f5xc-terraform MCP server, create a Terraform configuration for an HTTP load balancer with WAF protection.
+
+Requirements:
+- Use the f5xc_terraform_metadata tool with operation=example to get the correct syntax
+- The load balancer should be named "test-waf-lb"
+- Enable WAF (app_firewall) protection
+- Use a public VIP
+- Configure a domain: secure.example.com
+- Reference both an origin pool and an app_firewall resource
+- Only output the Terraform configuration, no explanations
+- Ensure the output passes terraform fmt validation

--- a/mcp-server/tests/utils/ci-environment.ts
+++ b/mcp-server/tests/utils/ci-environment.ts
@@ -73,24 +73,26 @@ export function setupAuthenticatedModeEnv(options?: {
 
 /**
  * Check if real API testing is possible (has valid credentials)
+ * Supports both F5XC_API_* and F5XC_TEST_API_* naming conventions
  */
 export function hasRealCredentials(): boolean {
   return Boolean(
-    process.env.F5XC_TEST_API_URL &&
-    process.env.F5XC_TEST_API_TOKEN
+    (process.env.F5XC_API_URL || process.env.F5XC_TEST_API_URL) &&
+    (process.env.F5XC_API_TOKEN || process.env.F5XC_TEST_API_TOKEN)
   );
 }
 
 /**
  * Get real test credentials if available
+ * Supports both F5XC_API_* and F5XC_TEST_API_* naming conventions
  */
 export function getRealCredentials(): { apiUrl: string; apiToken: string } | null {
   if (!hasRealCredentials()) {
     return null;
   }
   return {
-    apiUrl: process.env.F5XC_TEST_API_URL!,
-    apiToken: process.env.F5XC_TEST_API_TOKEN!,
+    apiUrl: process.env.F5XC_API_URL || process.env.F5XC_TEST_API_URL!,
+    apiToken: process.env.F5XC_API_TOKEN || process.env.F5XC_TEST_API_TOKEN!,
   };
 }
 

--- a/mcp-server/tests/utils/terraform-runner.ts
+++ b/mcp-server/tests/utils/terraform-runner.ts
@@ -220,6 +220,28 @@ provider "f5xc" {
   }
 
   /**
+   * Run terraform fmt -check to verify configuration is formatted
+   * Returns success if config is already properly formatted
+   */
+  async fmt(): Promise<TerraformResult> {
+    const result = await this.runCommand(['fmt', '-check', '-diff', '-no-color']);
+    return {
+      success: result.exitCode === 0,
+      output: result.output,
+      errors: result.exitCode !== 0 ? ['Configuration is not properly formatted. Run: terraform fmt'] : [],
+      exitCode: result.exitCode,
+    };
+  }
+
+  /**
+   * Run terraform fmt to format configuration in place
+   * Returns the list of files that were modified
+   */
+  async fmtWrite(): Promise<TerraformResult> {
+    return this.runCommand(['fmt', '-no-color']);
+  }
+
+  /**
    * Get terraform state
    */
   async getState(): Promise<TerraformState | null> {


### PR DESCRIPTION
## Summary
- Add terraform fmt validation to E2E test suite
- Support both F5XC_API_* and F5XC_TEST_API_* environment variable naming
- Create ML training fixtures generator for reproducible input→output mappings
- Add comprehensive E2E test runner script

## Related Issue
Closes #915

## Changes Made
- `tests/utils/terraform-runner.ts`: Add `fmt()` and `fmtWrite()` methods
- `tests/utils/ci-environment.ts`: Support both env var naming conventions
- `tests/acceptance/determinism.test.ts`: Add terraform fmt validation section (8 tests)
- `tests/prompts/`: 4 prompt templates for opencode integration testing
- `tests/fixtures/ml-training/`: ML training matrix generator
- `scripts/run-e2e-tests.sh`: Comprehensive E2E test runner
- `package.json`: Add `test:e2e:all` and `generate:ml-matrix` scripts

## Testing
- [x] Unit tests pass (90/90)
- [x] Determinism tests pass (57 passed, 1 skipped intentionally)
- [x] All tests are idempotent and run without manual intervention
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)