### PR TITLE
chore(mcp): update server.json to v3.23.1

### DIFF
--- a/mcp-server/manifest.json
+++ b/mcp-server/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "@robinmordasiewicz/f5xc-terraform-mcp",
   "display_name": "F5 Distributed Cloud Terraform Provider",
-  "version": "3.23.0",
+  "version": "3.23.1",
   "description": "MCP server providing AI assistants with access to F5 Distributed Cloud Terraform provider documentation, 270+ OpenAPI specifications, subscription tier information, and addon service activation workflows.",
   "long_description": "Model Context Protocol (MCP) server for F5 Distributed Cloud (F5XC) Terraform provider. Provides AI assistants with comprehensive access to:\n\n- **Terraform Documentation**: Search, retrieve, and explore F5XC resources, data sources, functions, and guides\n- **OpenAPI Specifications**: Query 270+ F5 Distributed Cloud API specs with endpoint discovery and schema definitions\n- **Subscription Intelligence**: Check resource subscription tier requirements (STANDARD, ADVANCED, PREMIUM)\n- **Addon Service Workflows**: List, check activation status, and get activation workflows for F5XC addon services\n- **Metadata & Patterns**: Access validation patterns, oneof constraints, default values, and common configuration mistakes\n\nDesigned for infrastructure-as-code workflows, enabling intelligent Terraform configuration generation with subscription compliance and best practices built-in.",
   "author": {

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@robinmordasiewicz/f5xc-terraform-mcp",
-  "version": "3.23.0",
+  "version": "3.23.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@robinmordasiewicz/f5xc-terraform-mcp",
-      "version": "3.23.0",
+      "version": "3.23.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.25.2",

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robinmordasiewicz/f5xc-terraform-mcp",
-  "version": "3.23.0",
+  "version": "3.23.1",
   "description": "MCP server for F5 Distributed Cloud Terraform provider - documentation, 270+ OpenAPI specs, subscription info, and addon activation workflows for AI assistants",
   "type": "module",
   "main": "dist/index.js",

--- a/mcp-server/server.json
+++ b/mcp-server/server.json
@@ -3,12 +3,12 @@
   "name": "io.github.robinmordasiewicz/f5xc-terraform-mcp",
   "title": "F5 Distributed Cloud Terraform Provider",
   "description": "F5 Distributed Cloud Terraform provider docs, 270+ OpenAPI specs, and subscription info for AI.",
-  "version": "3.23.0",
+  "version": "3.23.1",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@robinmordasiewicz/f5xc-terraform-mcp",
-      "version": "3.23.0",
+      "version": "3.23.1",
       "transport": {
         "type": "stdio"
       },
@@ -16,12 +16,12 @@
     },
     {
       "registryType": "mcpb",
-      "identifier": "https://github.com/robinmordasiewicz/terraform-provider-f5xc/releases/download/v3.23.0/f5xc-terraform-mcp-3.23.0.mcpb",
-      "version": "3.23.0",
+      "identifier": "https://github.com/robinmordasiewicz/terraform-provider-f5xc/releases/download/v3.23.1/f5xc-terraform-mcp-3.23.1.mcpb",
+      "version": "3.23.1",
       "transport": {
         "type": "stdio"
       },
-      "fileSha256": "d7c1cc755b21629a4e79612f1ef739951a02f9a483600dc60d2d1ff69316edf2"
+      "fileSha256": "176cb533eacf77a9fa477f163bd632f2a24d3fecdb06e4402f9267ef3b0c1b25"
     }
   ],
   "repository": {


### PR DESCRIPTION
## Summary
Automated update of server.json for MCP Registry publication.

## Version
**Version**: 3.23.1
**SHA256**: `176cb533eacf77a9fa477f163bd632f2a24d3fecdb06e4402f9267ef3b0c1b25`

## Publication Status
- npm: Published
- MCP Registry: Published

🤖 Generated with [Claude Code](https://claude.com/claude-code)